### PR TITLE
Do not try to read the CSRFToken cookie

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -25,13 +25,18 @@ const get = async (url, params = {}, multiParams = []) => {
 };
 
 const _unsafe = async (method = 'POST', url, data) => {
-  const csrfTokenCookie = await window.cookieStore.get('csrftoken');
-  const csrftoken = csrfTokenCookie.value;
+  // we do not include the X-Csrftoken header, since the SDK is primarily meant to run
+  // in both cross-domain and same-site origins. In cross-domain contexts, the CSRF
+  // cookie is not available to be read (or sent).
+  //
+  // This isn't really relevant anyway, since we have explicit CORS settings in the
+  // backend on which origins to trust (protecting against CSRF attacks) and the
+  // endpoints don't have actual authenticated user sessions - only "generic" sessions
+  // that do not map to an (admin) user.
   const opts = {
       method,
       headers: {
           'Content-Type': 'application/json',
-          'X-CSRFToken': csrftoken,
       },
   };
   if (data) {


### PR DESCRIPTION
The SDK is meant to be used in cross-origin contexts, and the Open
Forms endpoints rely on session cookies without actually being
authenticated, thus, CSRF tokens should not be provided in the API
calls.

sister PR in the backend: https://github.com/open-formulieren/open-forms/pull/413