### PR TITLE
Fix datetime to date conversion

### DIFF
--- a/src/formio/components/DateField.js
+++ b/src/formio/components/DateField.js
@@ -24,7 +24,7 @@ class DateField extends DateTimeField {
       // The field itself should prevent any invalid dates from being passed in
       // so we are not checking that here
       if (this._data[this.component.key]) {
-        // Strip time off the iso datetime
+        // Strip time off the iso datetime string
         this._data[this.component.key] = this._data[this.component.key].substring(0, 10);
       }
       super.beforeSubmit();


### PR DESCRIPTION
While testing the date rendering in the Summary page I noticed that the DateField was subtracting one day from the date entered.  I found the reason is that when only a date is entered that formio is adding the time  as midnight with the users timezone as the time.  Then when making a new date and converting to the ISO string it's subtracting two hours so the date is one day earlier.

Eg.

<img width="507" alt="Screenshot 2021-06-11 at 13 54 27" src="https://user-images.githubusercontent.com/60747362/121682595-92c55380-cabc-11eb-93b9-89e0fee78cef.png">

I think it's fine to remove the extra Date conversion because this would only break if FormIO changes the format of their date strings. This seems unlikely since they're already using ISO format and if even if they did they should note it as a breaking change so we should be aware of it if/when we update FormIO versions.