### PR TITLE
Autofill street name and city

### DIFF
--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -1,7 +1,7 @@
 import { Formio } from 'react-formio';
 
 import { applyPrefix } from '../utils';
-import {get} from "../../api";
+import { get } from '../../api';
 import enableValidationPlugins from "../validators/plugins";
 
 

--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -9,7 +9,7 @@ import {get} from "../../api";
 
 const {REACT_APP_BASE_API_URL} = process.env;
 
-const POSTCODE_REGEX = /^[0-9]{4} [a-zA-Z]{2}$/;
+const POSTCODE_REGEX = /^[0-9]{4}\s?[a-zA-Z]{2}$/;
 const HOUSE_NUMBER_REGEX = /^\d+$/;
 
 /**

--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -32,9 +32,8 @@ class TextField extends Formio.Components.components.textfield {
 
   setLocationData(postcode, house_number, key) {
     get(`${this.options.baseUrl}location/get-street-name-and-city`, {postcode, house_number})
-      .then(result => this.setValue(result[key] || ''))
+      .then(result => this.setValue(result[key]))
       .catch(error => console.log(error));
-
   }
 
   handleSettingLocationData(data) {

--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -34,11 +34,8 @@ class TextField extends Formio.Components.components.textfield {
   }
 
   setLocationData(postcode, house_number, key) {
-    get(`${REACT_APP_BASE_API_URL}location/get-street-name-and-city`,
-      {postcode, house_number})
-      .then(result => {
-        this.setValue(result[key] || '');
-      })
+    get(`${REACT_APP_BASE_API_URL}location/get-street-name-and-city`, {postcode, house_number})
+      .then(result => this.setValue(result[key] || ''))
       .catch(error => console.log(error));
 
   }

--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -42,7 +42,10 @@ class TextField extends Formio.Components.components.textfield {
   }
 
   handleSettingLocationData(data) {
-    if (data[this.component.derivePostcode] && data[this.component.deriveHouseNumber]) {
+    if (data[this.component.deriveHouseNumber] &&
+        !isNaN(data[this.component.deriveHouseNumber]) &&
+        data[this.component.derivePostcode] &&
+        data[this.component.derivePostcode].replaceAll('_', '').replaceAll(' ', '').length === 6) {
       if (this.component.deriveStreetName) {
         this.setLocationData(
           data[this.component.derivePostcode],

--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -32,7 +32,8 @@ class TextField extends Formio.Components.components.textfield {
   }
 
   setLocationData(postcode, house_number, key) {
-    get(`${REACT_APP_BASE_API_URL}location/get-street-name-and-city`, {postcode, house_number})
+    get(`${REACT_APP_BASE_API_URL}location/get-street-name-and-city`,
+      {postcode, house_number})
       .then(result => {
         this.setValue(result[key] || '');
       })
@@ -40,15 +41,29 @@ class TextField extends Formio.Components.components.textfield {
 
   }
 
-  fieldLogic(data, row) {
+  handleSettingLocationData(data) {
     if (data[this.component.derivePostcode] && data[this.component.deriveHouseNumber]) {
       if (this.component.deriveStreetName) {
-        this.setLocationData(data[this.component.derivePostcode], data[this.component.deriveHouseNumber], 'streetName');
+        this.setLocationData(
+          data[this.component.derivePostcode],
+          data[this.component.deriveHouseNumber],
+          'streetName'
+        );
       }
       if (this.component.deriveCity) {
-        this.setLocationData(data[this.component.derivePostcode], data[this.component.deriveHouseNumber], 'city');
+        this.setLocationData(
+          data[this.component.derivePostcode],
+          data[this.component.deriveHouseNumber],
+          'city'
+        );
       }
     }
+  }
+
+  fieldLogic(data, row) {
+    const changed = super.fieldLogic(data, row);
+    this.handleSettingLocationData(data);
+    return changed;
   }
 }
 

--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -9,6 +9,8 @@ import {get} from "../../api";
 
 const {REACT_APP_BASE_API_URL} = process.env;
 
+const POSTCODE_REGEX = /^[0-9]{4} [a-zA-Z]{2}$/;
+const HOUSE_NUMBER_REGEX = /^\d+$/;
 
 /**
  * Extend the default text field to modify it to our needs.
@@ -42,10 +44,8 @@ class TextField extends Formio.Components.components.textfield {
   }
 
   handleSettingLocationData(data) {
-    const isValidHouseNumber = data[this.component.deriveHouseNumber] &&
-      !isNaN(data[this.component.deriveHouseNumber]);
-    const isValidPostcode = data[this.component.derivePostcode] &&
-      data[this.component.derivePostcode].replaceAll('_', '').replaceAll(' ', '').length === 6;
+    const isValidHouseNumber = HOUSE_NUMBER_REGEX.test(data[this.component.deriveHouseNumber]);
+    const isValidPostcode = POSTCODE_REGEX.test(data[this.component.derivePostcode]);
 
     if (isValidHouseNumber && isValidPostcode) {
       if (this.component.deriveStreetName) {

--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -42,10 +42,12 @@ class TextField extends Formio.Components.components.textfield {
   }
 
   handleSettingLocationData(data) {
-    if (data[this.component.deriveHouseNumber] &&
-        !isNaN(data[this.component.deriveHouseNumber]) &&
-        data[this.component.derivePostcode] &&
-        data[this.component.derivePostcode].replaceAll('_', '').replaceAll(' ', '').length === 6) {
+    const isValidHouseNumber = data[this.component.deriveHouseNumber] &&
+      !isNaN(data[this.component.deriveHouseNumber]);
+    const isValidPostcode = data[this.component.derivePostcode] &&
+      data[this.component.derivePostcode].replaceAll('_', '').replaceAll(' ', '').length === 6;
+
+    if (isValidHouseNumber && isValidPostcode) {
       if (this.component.deriveStreetName) {
         this.setLocationData(
           data[this.component.derivePostcode],

--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -41,9 +41,12 @@ class TextField extends Formio.Components.components.textfield {
   }
 
   fieldLogic(data, row) {
-    if (data.postcode && data.houseNumber) {
-      if (this.component.key === 'streetName' || this.component.key === 'city') {
-        this.setLocationData(data.postcode, data.houseNumber, this.component.key);
+    if (data[this.component.derivePostcode] && data[this.component.deriveHouseNumber]) {
+      if (this.component.deriveStreetName) {
+        this.setLocationData(data[this.component.derivePostcode], data[this.component.deriveHouseNumber], 'streetName');
+      }
+      if (this.component.deriveCity) {
+        this.setLocationData(data[this.component.derivePostcode], data[this.component.deriveHouseNumber], 'city');
       }
     }
   }

--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -5,6 +5,11 @@ import { applyPrefix } from '../utils';
 import enableValidationPlugins from "../validators/plugins";
 
 
+import {get} from "../../api";
+
+const {REACT_APP_BASE_API_URL} = process.env;
+
+
 /**
  * Extend the default text field to modify it to our needs.
  */
@@ -24,6 +29,23 @@ class TextField extends Formio.Components.components.textfield {
 
   checkComponentValidity(data, dirty, row, options = {}){
     return super.checkComponentValidity(data, dirty, row, {...options, async: true});
+  }
+
+  setLocationData(postcode, house_number, key) {
+    get(`${REACT_APP_BASE_API_URL}location/get-street-name-and-city`, {postcode, house_number})
+      .then(result => {
+        this.setValue(result[key] || '');
+      })
+      .catch(error => console.log(error));
+
+  }
+
+  fieldLogic(data, row) {
+    if (data.postcode && data.houseNumber) {
+      if (this.component.key === 'streetName' || this.component.key === 'city') {
+        this.setLocationData(data.postcode, data.houseNumber, this.component.key);
+      }
+    }
   }
 }
 

--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -1,16 +1,13 @@
 import { Formio } from 'react-formio';
 
 import { applyPrefix } from '../utils';
-
+import {get} from "../../api";
 import enableValidationPlugins from "../validators/plugins";
 
 
-import {get} from "../../api";
-
-const {REACT_APP_BASE_API_URL} = process.env;
-
 const POSTCODE_REGEX = /^[0-9]{4}\s?[a-zA-Z]{2}$/;
 const HOUSE_NUMBER_REGEX = /^\d+$/;
+
 
 /**
  * Extend the default text field to modify it to our needs.
@@ -34,7 +31,7 @@ class TextField extends Formio.Components.components.textfield {
   }
 
   setLocationData(postcode, house_number, key) {
-    get(`${REACT_APP_BASE_API_URL}location/get-street-name-and-city`, {postcode, house_number})
+    get(`${this.options.baseUrl}location/get-street-name-and-city`, {postcode, house_number})
       .then(result => this.setValue(result[key] || ''))
       .catch(error => console.log(error));
 


### PR DESCRIPTION
SDK PR for https://github.com/open-formulieren/open-forms/pull/499

Tested using both the Postcode component and a Textfield component for the postcode and the Textfield Component and Number component for the house number and both worked.  I tested with various formats of postcode (1015 CJ, 1015CJ, 1015cj, 1015 cj) and these all worked.  If an address is not found then the fields are just left blank.

Note: This does **not** work if the house number has a house letter appended (eg. 117a) since the BAG api returns a 400 if this is entered as a house number.  When 117 is filled in a request would be made to the backend and the fields would be autofilled but one would not be made after the 'a' was entered so if the user types 117a it's autofilled but not if they copy-and-pasted, for example. We _could_ strip off any letters when making a request but I'm not sure if we want to do this, if we do let me know and I'll add this. :) 

**Screenshot**

![Screenshot 2021-07-22 at 14 30 54](https://user-images.githubusercontent.com/60747362/126639403-13c6d50c-8bb2-4442-80ea-36fc2f43a9e5.png)
