### PR TITLE
Feature - Logout button

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -9,7 +9,7 @@ import {
 
 import { ConfigContext } from 'Context';
 
-import { get, post } from 'api';
+import {destroy, get, post} from 'api';
 import usePageViews from 'hooks/usePageViews';
 import ErrorBoundary from 'components/ErrorBoundary';
 import FormStart from 'components/FormStart';
@@ -20,6 +20,7 @@ import RequireSubmission from 'components/RequireSubmission';
 import SubmissionConfirmation from 'components/SubmissionConfirmation';
 import Summary from 'components/Summary';
 import Types from 'types';
+import {useIntl} from 'react-intl';
 
 /**
  * Create a submission instance from a given form instance
@@ -81,6 +82,7 @@ const reducer = (draft, action) => {
  const Form = ({ form }) => {
   const history = useHistory();
   usePageViews();
+  const intl = useIntl();
 
   // extract the declared properties and configuration
   const {steps} = form;
@@ -147,7 +149,21 @@ const reducer = (draft, action) => {
       }
     });
     history.push('/bevestiging');
-  }
+  };
+
+  const onLogout = async (event) => {
+    event.preventDefault();
+
+    const confirmationQuestion = intl.formatMessage(
+      {id: 'confirmLogout', defaultMessage: 'Are you sure that you want to logout?'}
+    );
+    if (!window.confirm(confirmationQuestion)) {
+      return;
+    }
+    await destroy(`${config.baseUrl}authentication/session`);
+    history.push('/');
+    window.location.reload();
+  };
 
   // render the form step if there's an active submission (and no summary)
   return (
@@ -169,6 +185,7 @@ const reducer = (draft, action) => {
                 submission={state.submission}
                 form={form}
                 onConfirm={onSubmitForm}
+                onLogout={onLogout}
                 component={Summary} />
             </Route>
 
@@ -185,6 +202,7 @@ const reducer = (draft, action) => {
                 submission={state.submission}
                 form={form}
                 onStepSubmitted={onStepSubmitted}
+                onLogout={onLogout}
                 component={FormStep}
               />
             )} />

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -155,6 +155,8 @@ const reducer = (draft, action) => {
     event.preventDefault();
 
     const confirmationQuestion = intl.formatMessage(
+      // TODO using id in the formatMessage is discouraged. However, since the translation pipeline
+      // is not fully setup yet, using the description instead of the ids causes errors.
       {id: 'confirmLogout', defaultMessage: 'Are you sure that you want to logout?'}
     );
     if (!window.confirm(confirmationQuestion)) {
@@ -162,6 +164,7 @@ const reducer = (draft, action) => {
     }
     await destroy(`${config.baseUrl}authentication/session`);
     history.push('/');
+    // TODO: replace with a proper reset of the state instead of a page reload.
     window.location.reload();
   };
 

--- a/src/components/FormStep.js
+++ b/src/components/FormStep.js
@@ -18,6 +18,7 @@ import { Toolbar, ToolbarList } from 'components/Toolbar';
 import Loader from 'components/Loader';
 import { ConfigContext } from 'Context';
 import Types from 'types';
+import LogoutButton from 'components/LogoutButton';
 
 const initialState = {
   configuration: null,
@@ -43,7 +44,7 @@ const submitStepData = async (stepUrl, data) => {
   return stepDataResponse.data;
 };
 
-const FormStep = ({ form, submission, onStepSubmitted }) => {
+const FormStep = ({ form, submission, onStepSubmitted, onLogout }) => {
   const config = useContext(ConfigContext);
   // component state
   const formRef = useRef(null);
@@ -143,6 +144,7 @@ const FormStep = ({ form, submission, onStepSubmitted }) => {
                 <Button type="submit" variant="primary" name="next">{formStep.literals.nextText.resolved}</Button>
               </ToolbarList>
             </Toolbar>
+            {form.loginRequired ? <LogoutButton onLogout={onLogout}/> : null}
           </form>
         ) : null
       }
@@ -154,6 +156,7 @@ FormStep.propTypes = {
   form: Types.Form,
   submission: PropTypes.object.isRequired,
   onStepSubmitted: PropTypes.func.isRequired,
+  onLogout: PropTypes.func.isRequired,
 };
 
 

--- a/src/components/LogoutButton.js
+++ b/src/components/LogoutButton.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+import PropTypes from 'prop-types';
+
+import {Toolbar, ToolbarList} from 'components/Toolbar';
+import Button from 'components/Button';
+
+const LogoutButton = ({onLogout}) => {
+  return (
+    <Toolbar modifiers={['bottom','reverse']}>
+      <ToolbarList>
+        <Button variant="danger" onClick={onLogout}>
+          <FormattedMessage id="logOut" defaultMessage="Log out" />
+        </Button>
+      </ToolbarList>
+    </Toolbar>
+  )
+};
+
+LogoutButton.propTypes = {
+  onLogout: PropTypes.func.isRequired,
+};
+
+
+export default LogoutButton;

--- a/src/components/LogoutButton.js
+++ b/src/components/LogoutButton.js
@@ -10,6 +10,8 @@ const LogoutButton = ({onLogout}) => {
     <Toolbar modifiers={['bottom','reverse']}>
       <ToolbarList>
         <Button variant="danger" onClick={onLogout}>
+          {/*TODO using id in the formatMessage is discouraged. However, since the translation pipeline */}
+          {/*is not fully setup yet, using the description instead of the ids causes errors.*/}
           <FormattedMessage id="logOut" defaultMessage="Log out" />
         </Button>
       </ToolbarList>

--- a/src/components/Summary.js
+++ b/src/components/Summary.js
@@ -11,6 +11,7 @@ import FormStepSummary from 'components/FormStepSummary';
 import { Toolbar, ToolbarList } from 'components/Toolbar';
 import Types from 'types';
 import { flattenComponents } from 'utils';
+import LogoutButton from 'components/LogoutButton';
 
 
 const loadStepsData = async (submission) => {
@@ -40,7 +41,7 @@ const completeSubmission = async (submission) => {
 };
 
 
-const Summary = ({ form, submission, onConfirm }) => {
+const Summary = ({ form, submission, onConfirm, onLogout }) => {
   const history = useHistory();
   const {loading, value: submissionSteps, error} = useAsync(
     async () => loadStepsData(submission),
@@ -90,6 +91,7 @@ const Summary = ({ form, submission, onConfirm }) => {
             </Button>
           </ToolbarList>
         </Toolbar>
+        {form.loginRequired ? <LogoutButton onLogout={onLogout}/> : null}
       </form>
     </Card>
   );
@@ -99,6 +101,7 @@ Summary.propTypes = {
   form: Types.Form.isRequired,
   submission: PropTypes.object.isRequired,
   onConfirm: PropTypes.func.isRequired,
+  onLogout: PropTypes.func.isRequired,
 };
 
 

--- a/src/components/Summary/index.js
+++ b/src/components/Summary/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import useAsync from 'react-use/esm/useAsync';
+import {useAsync} from 'react-use';
 import { useHistory } from 'react-router-dom';
 
 import { get, post } from 'api';

--- a/src/components/Summary/test.spec.js
+++ b/src/components/Summary/test.spec.js
@@ -57,7 +57,7 @@ it('Summary displays logout button if loginRequired is true', () => {
   expect(container.textContent).toContain('Uitloggen');
 });
 
-it('Summary displays logout button if loginRequired is false', () => {
+it('Summary does not display logout button if loginRequired is false', () => {
   const formLoginRequired = {
     ...testForm,
     loginRequired: false,

--- a/src/components/Summary/test.spec.js
+++ b/src/components/Summary/test.spec.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, unmountComponentAtNode } from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { IntlProvider } from 'react-intl';
+import {useAsync} from 'react-use';
+
+import Summary from 'components/Summary';
+import messagesNL from 'i18n';
+import {testForm} from 'components/FormStart/fixtures';
+
+
+jest.mock('react-use');
+
+let container = null;
+
+beforeEach(() => {
+  // setup a DOM element as a render target
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  // cleanup on exiting
+  unmountComponentAtNode(container);
+  container.remove();
+  container = null;
+});
+
+
+it('Summary displays logout button if loginRequired is true', () => {
+  const formLoginRequired = {
+    ...testForm,
+    loginRequired: true,
+  };
+  const onLogout = jest.fn();
+  const onConfirm = jest.fn();
+
+  useAsync.mockReturnValue({loading: false});
+
+  act(() => {
+    render(
+      <IntlProvider
+        locale="nl"
+        messages={messagesNL}
+      >
+        <Summary
+          form={formLoginRequired}
+          submission={{steps: [{formStep: 'http://testserver/api/v1/forms/33af5a1c-552e-4e8f-8b19-287cf35b9edd/steps/0c2a1816-a7d7-4193-b431-918956744038'}]}}
+          onConfirm={onConfirm}
+          onLogout={onLogout}
+        />
+      </IntlProvider>,
+      container
+    );
+  });
+
+  expect(container.textContent).toContain('Uitloggen');
+});
+
+it('Summary displays logout button if loginRequired is false', () => {
+  const formLoginRequired = {
+    ...testForm,
+    loginRequired: false,
+  };
+  const onLogout = jest.fn();
+  const onConfirm = jest.fn();
+
+  useAsync.mockReturnValue({loading: false});
+
+  act(() => {
+    render(
+      <IntlProvider
+        locale="nl"
+        messages={messagesNL}
+      >
+        <Summary
+          form={formLoginRequired}
+          submission={{steps: [{formStep: 'http://testserver/api/v1/forms/33af5a1c-552e-4e8f-8b19-287cf35b9edd/steps/0c2a1816-a7d7-4193-b431-918956744038'}]}}
+          onConfirm={onConfirm}
+          onLogout={onLogout}
+        />
+      </IntlProvider>,
+      container
+    );
+  });
+
+  expect(container.textContent).not.toContain('Uitloggen');
+});

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,4 +1,7 @@
 // TODO: set up translations
-const messagesNL = {};
+const messagesNL = {
+  logOut: 'Uitloggen',
+  confirmLogout: 'Weet je zeker dat je wilt uitloggen?',
+};
 
 export default messagesNL;

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -52,6 +52,7 @@ $button-padding-h: $grid-margin-2;
   @include button-theme('primary', $color-background, scale_color($color-primary, $lightness: 10%, $saturation: 0%), $color-primary);
   @include button-theme('', $typography-color-text, $color-background, $color-border);
   @include button-theme('anchor', $typography-color-link, transparent, transparent, true);
+  @include button-theme('danger', scale_color($color-danger, $lightness: 90%), $color-danger, scale_color($color-danger, $lightness: -20%));
   appearance: none;
   border-radius: 0;
   display: flex;

--- a/src/scss/components/_toolbar.scss
+++ b/src/scss/components/_toolbar.scss
@@ -22,6 +22,10 @@
     @include margin(true, $properties: margin-top);
   }
 
+  @include modifier('reverse') {
+    justify-content: flex-end;
+  }
+
   @include mobile-only {
     display: block;
 


### PR DESCRIPTION
Related to https://github.com/open-formulieren/open-forms/issues/532

Currently this works as follows: if a form has a `loginRequired: true`, a logout button appears. It came to mind though that it is possible to have `loginRequired: false` but still specify an auth backend. In that case, it is still possible to login with DigiD/eHerkenning, but there will be no logout button.

Note: I didn't manage to add a test for `FormStep` to make sure the logout button is displayed :cry: The current problem is how to find a way around mocking `useImmerReducer`. 

Note 2: The difference in size build caused by replacing `import useAsync from 'react-use/esm/useAsync';` with `import {useAsync} from 'react-use';` is from 472.06 KB to 472.15 KB 