### PR TITLE
Handle all mime types

### DIFF
--- a/src/formio/components/FileField.js
+++ b/src/formio/components/FileField.js
@@ -1,0 +1,37 @@
+import { Formio } from 'react-formio';
+
+/**
+ * Extend the default file field to modify it to our needs.
+ */
+class FileField extends Formio.Components.components.file {
+
+  get browseOptions() {
+    // This code is copied from https://github.com/formio/formio.js/blob/v4.13.0/src/components/file/File.js#L281-L304
+    // Since we are using FormIO v4.12.7 only image based files are supported
+    // If are are using v4.13.x or higher this can probably be deleted
+
+    const options = {};
+
+    if (this.component.multiple) {
+      options.multiple = true;
+    }
+    //use "accept" attribute only for desktop devices because of its limited support by mobile browsers
+    if (!this.isMobile.any) {
+      const filePattern = this.component.filePattern.trim() || '';
+      const imagesPattern = 'image/*';
+
+      if (this.imageUpload && (!filePattern || filePattern === '*')) {
+        options.accept = imagesPattern;
+      } else if (this.imageUpload && !filePattern.includes(imagesPattern)) {
+        options.accept = `${imagesPattern},${filePattern}`;
+      } else {
+        options.accept = filePattern;
+      }
+    }
+
+    return options;
+  }
+}
+
+
+export default FileField;

--- a/src/formio/module.js
+++ b/src/formio/module.js
@@ -15,6 +15,7 @@ import TimeField from "./components/TimeField";
 import PostcodeField from "./components/PostcodeField";
 import PhoneNumberField from "./components/PhoneNumberField";
 import BsnField from "./components/BsnField";
+import FileField from "./components/FileField";
 
 const FormIOModule = {
   components: {
@@ -35,6 +36,7 @@ const FormIOModule = {
     postcode: PostcodeField,
     phoneNumber: PhoneNumberField,
     bsn: BsnField,
+    file: FileField,
   },
 };
 


### PR DESCRIPTION
Fixes https://github.com/open-formulieren/open-forms/issues/524

The cause of the bug is that this functionality is not supported in FormIO v4.12.7 though it is supported in version 4.13.x so I copied the code from v4.13.0 into our code base.

Ref:
v4.13.0: https://github.com/formio/formio.js/blob/v4.13.0/src/components/file/File.js#L281-L304
v4.12.7: https://github.com/formio/formio.js/blob/v4.12.7/src/components/file/File.js#L271-L283

We could also bump the version up to v4.13.4 though this would require more testing to make sure the whole project still functions.

**Screenshots**

PDF

![Screenshot 2021-08-05 at 14 32 16](https://user-images.githubusercontent.com/60747362/128351158-2d082107-0da6-4f6e-b06b-fc9522c01543.png)

Image

![Screenshot 2021-08-05 at 14 33 47](https://user-images.githubusercontent.com/60747362/128351189-12baa68a-c544-464e-9ca5-975a468b30c1.png)
