### PR TITLE
Apply form logic while the user is filling out the form.

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -9,7 +9,7 @@ import {
 
 import { ConfigContext } from 'Context';
 
-import {destroy, get, post} from 'api';
+import {destroy, post} from 'api';
 import usePageViews from 'hooks/usePageViews';
 import ErrorBoundary from 'components/ErrorBoundary';
 import FormStart from 'components/FormStart';
@@ -121,19 +121,11 @@ const reducer = (draft, action) => {
     history.push(firstStepRoute);
   };
 
-
   const onStepSubmitted = async (formStep) => {
     const stepIndex = form.steps.indexOf(formStep);
     // TODO: there *may* be optional steps, so completion/summary can already get
     // triggered earlier, potentially. This will need to be incorporated later.
     const nextStep = form.steps[stepIndex + 1]; // will be undefined if it's the last step
-
-    // refresh the submission from the backend
-    const submission = await get(state.submission.url);
-    dispatch({
-      type: 'SUBMISSION_LOADED',
-      payload: submission,
-    });
 
     const nextUrl = nextStep ? `/stap/${nextStep.slug}` : '/overzicht';
     history.push(nextUrl);
@@ -166,6 +158,13 @@ const reducer = (draft, action) => {
     history.push('/');
     // TODO: replace with a proper reset of the state instead of a page reload.
     window.location.reload();
+  };
+
+  const onReloadSubmission = (submission) => {
+    dispatch({
+      type: 'SUBMISSION_LOADED',
+      payload: submission,
+    });
   };
 
   // render the form step if there's an active submission (and no summary)
@@ -206,6 +205,7 @@ const reducer = (draft, action) => {
                 form={form}
                 onStepSubmitted={onStepSubmitted}
                 onLogout={onLogout}
+                onReloadSubmission={onReloadSubmission}
                 component={FormStep}
               />
             )} />

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -9,11 +9,11 @@ import {
 
 import { ConfigContext } from 'Context';
 
-import {destroy, post} from 'api';
+import {destroy, post, get} from 'api';
 import usePageViews from 'hooks/usePageViews';
 import ErrorBoundary from 'components/ErrorBoundary';
 import FormStart from 'components/FormStart';
-import FormStep from 'components/FormStep';
+import {FormStep, doLogicCheck} from 'components/FormStep';
 import ProgressIndicator from 'components/ProgressIndicator';
 import { Layout, LayoutRow, LayoutColumn } from 'components/Layout';
 import RequireSubmission from 'components/RequireSubmission';
@@ -42,6 +42,11 @@ const initialState = {
     statusUrl: '',
   },
   confirmationPageContent: 'Your submission was received.',
+  submissionStep: {
+    configuration: null,
+    data: null,
+    canSubmit: true,
+  },
 };
 
 
@@ -64,6 +69,29 @@ const reducer = (draft, action) => {
         },
         confirmationPageContent: action.payload.confirmationPageContent,
       };
+    }
+    case 'SUBMISSION_STEP_LOADED': {
+      const {data, formStep: {configuration}, canSubmit} = action.payload;
+      // This is the context aware configuration
+      draft.submissionStep.configuration = configuration;
+      draft.submissionStep.data = data;
+      draft.submissionStep.canSubmit = canSubmit;
+      break;
+    }
+    case 'UPDATE_SUBMISSION_STEP': {
+      const {formStep: {configuration}, canSubmit} = action.payload;
+      // This is the context aware configuration
+      draft.submissionStep.configuration = configuration;
+      draft.submissionStep.canSubmit = canSubmit;
+      break;
+    }
+    case 'BLOCK_CURRENT_STEP_SUBMIT': {
+      draft.submissionStep.canSubmit = false;
+      break;
+    }
+    case 'SUBMISSION_DATA_CHANGED': {
+      draft.submissionStep.data = action.payload;
+      break;
     }
     default: {
       throw new Error(`Unknown action ${action.type}`);
@@ -160,11 +188,46 @@ const reducer = (draft, action) => {
     window.location.reload();
   };
 
-  const onReloadSubmission = (submission) => {
+  const onLoadFormStep = async (submissionStepUrl) => {
+    const stepDetail = await get(submissionStepUrl);
     dispatch({
-      type: 'SUBMISSION_LOADED',
-      payload: submission,
+      type: 'SUBMISSION_STEP_LOADED',
+      payload: stepDetail,
     });
+  };
+
+  const onLogicCheck = async (formRef, submissionStepUrl, submissionData) => {
+    if (!submissionData) return;
+
+      dispatch({type: 'BLOCK_CURRENT_STEP_SUBMIT'});
+      const checkedSubmission = await doLogicCheck(submissionStepUrl, submissionData);
+
+      // TODO: check custom attributes for submission button control
+      const formInstance = formRef.current.instance.instance;
+
+      // we can't just dispatch this, because Formio keeps references to DOM nodes
+      // which expire when the component re-renders, and that gives React
+      // unstable_flushDiscreteUpdates warnings. However, we can update the form
+      // definition by using the ref to the underlying Formio instance.
+      formInstance.setForm(checkedSubmission.step.formStep.configuration);
+
+      // Reload the submission. This should update other steps (for example if they
+      // are not applicable.
+      dispatch({
+        type: 'SUBMISSION_LOADED',
+        payload: checkedSubmission.submission,
+      });
+
+      // Update the current submission step. This updates things like 'canSubmit'.
+      // Note: the step data returned from the logic check is empty.
+      dispatch({
+        type: 'UPDATE_SUBMISSION_STEP',
+        payload: checkedSubmission.step,
+      });
+  };
+
+  const onSubmissionDataChanged = (data) => {
+    dispatch({type: 'SUBMISSION_DATA_CHANGED', payload: data});
   };
 
   // render the form step if there's an active submission (and no summary)
@@ -203,9 +266,12 @@ const reducer = (draft, action) => {
               <RequireSubmission
                 submission={state.submission}
                 form={form}
+                submissionStepData={state.submissionStep}
                 onStepSubmitted={onStepSubmitted}
                 onLogout={onLogout}
-                onReloadSubmission={onReloadSubmission}
+                onLoadFormStep={onLoadFormStep}
+                onLogicCheck={onLogicCheck}
+                onSubmissionDataChanged={onSubmissionDataChanged}
                 component={FormStep}
               />
             )} />

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -78,13 +78,6 @@ const reducer = (draft, action) => {
       draft.submissionStep.canSubmit = canSubmit;
       break;
     }
-    case 'UPDATE_SUBMISSION_STEP': {
-      const {formStep: {configuration}, canSubmit} = action.payload;
-      // This is the context aware configuration
-      draft.submissionStep.configuration = configuration;
-      draft.submissionStep.canSubmit = canSubmit;
-      break;
-    }
     case 'BLOCK_CURRENT_STEP_SUBMIT': {
       draft.submissionStep.canSubmit = false;
       break;
@@ -219,9 +212,8 @@ const reducer = (draft, action) => {
       });
 
       // Update the current submission step. This updates things like 'canSubmit'.
-      // Note: the step data returned from the logic check is empty.
       dispatch({
-        type: 'UPDATE_SUBMISSION_STEP',
+        type: 'SUBMISSION_STEP_LOADED',
         payload: checkedSubmission.step,
       });
   };

--- a/src/components/FormStep.js
+++ b/src/components/FormStep.js
@@ -5,6 +5,8 @@
 import React, {useRef, useContext} from 'react';
 import PropTypes from 'prop-types';
 import { useHistory, useParams } from 'react-router-dom';
+import usePrevious from 'react-use/esm/usePrevious';
+import isEqual from 'lodash/isEqual';
 
 import useAsync from 'react-use/esm/useAsync';
 import useDebounce from 'react-use/esm/useDebounce';
@@ -19,6 +21,7 @@ import Loader from 'components/Loader';
 import { ConfigContext } from 'Context';
 import Types from 'types';
 import LogoutButton from 'components/LogoutButton';
+
 
 const STEP_LOGIC_DEBOUNCE_MS = 300;
 
@@ -62,8 +65,16 @@ const FormStep = ({
   // fetch the form step configuration
   const {loading} = useAsync(() => onLoadFormStep(submissionStep.url), [submissionStep.url]);
 
+  const checkLogic = async (previousData) => {
+    if (previousData && isEqual(previousData, submissionStepData.data)) return;
+
+    await onLogicCheck(formRef, submissionStep.url, submissionStepData.data);
+  }
+
+  const previousData = usePrevious(submissionStepData.data);
+
   useDebounce(
-    async () => onLogicCheck(formRef, submissionStep.url, submissionStepData.data),
+    () => checkLogic(previousData),
     STEP_LOGIC_DEBOUNCE_MS,
     [submissionStepData.data]
   );

--- a/src/components/ProgressIndicator.js
+++ b/src/components/ProgressIndicator.js
@@ -10,12 +10,12 @@ import FAIcon from 'components/FAIcon';
 import { getBEMClassName } from 'utils';
 
 
-const getLinkModifiers = (active, available, completed) => {
+const getLinkModifiers = (active, isApplicable, completed) => {
   return [
     'inherit',
     'hover',
     active ? 'active' : undefined,
-    available ? undefined : 'muted',
+    isApplicable ? undefined : 'muted',
     completed ? undefined : 'indent',
   ].filter( mod => mod !== undefined );
 };
@@ -34,12 +34,12 @@ LinkOrDisabledAnchor.propTypes = {
 };
 
 
-const SidebarStepStatus = ({isCurrent, step, available=false, completed=false}) => {
+const SidebarStepStatus = ({isCurrent, step, isApplicable=false, completed=false}) => {
   const icon = completed ? <FAIcon icon="check" modifiers={['small']} aria-hidden="true" /> : null;
-  const linkText = ` ${step.formDefinition}`; // space required between icon and text
-  const modifiers = getLinkModifiers(isCurrent, available, completed);
+  const modifiers = getLinkModifiers(isCurrent, isApplicable, completed);
+  const linkText = ` ${step.formDefinition} ${!isApplicable ? ' (n.v.t)' : ''}`; // space required between icon and text
   return (
-    <LinkOrDisabledAnchor to={`/stap/${step.slug}`} useLink={available} modifiers={modifiers}>
+    <LinkOrDisabledAnchor to={`/stap/${step.slug}`} useLink={isApplicable} modifiers={modifiers}>
       {icon}
       {linkText}
     </LinkOrDisabledAnchor>
@@ -50,7 +50,7 @@ const SidebarStepStatus = ({isCurrent, step, available=false, completed=false}) 
 SidebarStepStatus.propTypes = {
   isCurrent: PropTypes.bool.isRequired,
   completed: PropTypes.bool,
-  available: PropTypes.bool,
+  isApplicable: PropTypes.bool,
   step: PropTypes.shape({
     url: PropTypes.string.isRequired,
     uuid: PropTypes.string.isRequired,
@@ -122,7 +122,7 @@ const ProgressIndicator = ({ title, submission, steps }) => {
               key={step.uuid}
               step={step}
               completed={submission ? submission.steps[index].completed : false}
-              available={submission ? submission.steps[index].available : false}
+              isApplicable={submission ? submission.steps[index].isApplicable : true}
               isCurrent={step.slug === stepSlug}
               slug={step.slug}
             />
@@ -148,7 +148,7 @@ ProgressIndicator.propTypes = {
   submission: PropTypes.shape({
     steps: PropTypes.arrayOf(PropTypes.shape({
       completed: PropTypes.bool.isRequired,
-      available: PropTypes.bool.isRequired,
+      isApplicable: PropTypes.bool.isRequired,
       // and more...
     })),
   }),


### PR DESCRIPTION
Depends on the backend PRs that provide the API endpoint & form logic implementation.

The idea is that on every change that may affect the state/definition of the form, a check is done towards the backend with the latest form step data (debounced to allow for active typing by the user). The backend can then reply with modified form definition within the context of the existing submission data AND the currently filled out fields, even if these are not persisted yet to the backend.