### PR TITLE
Improvements/appointments selecting

### DIFF
--- a/src/formio/components/Select.js
+++ b/src/formio/components/Select.js
@@ -61,7 +61,7 @@ class Select extends Formio.Components.components.select {
   handleSettingAppointmentDates(data) {
     if (this.component.appointmentsShowDates &&
         this.selectOptions.length === 0 &&
-        [this.component.appointmentsProductForDates] &&
+        data[this.component.appointmentsProductForDates] &&
         data[this.component.appointmentsLocationForDates]) {
       get(`${this.options.baseUrl}appointments/dates`,
         {'product_id': data[this.component.appointmentsProductForDates],

--- a/src/formio/components/Select.js
+++ b/src/formio/components/Select.js
@@ -90,24 +90,22 @@ class Select extends Formio.Components.components.select {
     }
   }
 
-  handleClearingAppointmentData(data) {
-    // Product is empty so clear locations
+  handleClearingAppointmentData(data, changedKey) {
+
+    // Product is changed so clear locations
     const shouldClearLocations = this.component.appointmentsShowLocations &&
-                                 !data[this.component.appointmentsProductForLocations] &&
-                                 data[this.component.key];
+                                 this.component.appointmentsProductForLocations === changedKey;
 
-    // Product or location is empty so clear dates
+    // Product or location is changed so clear dates
     const shouldClearDates = this.component.appointmentsShowDates &&
-                             (!data[this.component.appointmentsProductForDates]||
-                              !data[this.component.appointmentsLocationForDates]) &&
-                             data[this.component.key];
+                             (this.component.appointmentsProductForDates === changedKey||
+                              this.component.appointmentsLocationForDates === changedKey);
 
-    // Product or location or date is empty so clear times
+    // Product or location or date is changed so clear times
     const shouldClearTimes = this.component.appointmentsShowTimes &&
-                             (!data[this.component.appointmentsProductForTimes] ||
-                              !data[this.component.appointmentsLocationForTimes] ||
-                              !data[this.component.appointmentsDateForTimes]) &&
-                             data[this.component.key];
+                             (this.component.appointmentsProductForTimes === changedKey ||
+                              this.component.appointmentsLocationForTimes === changedKey ||
+                              this.component.appointmentsDateForTimes === changedKey);
 
     if (shouldClearLocations || shouldClearDates || shouldClearTimes) {
       this.setValue(this.emptyValue);
@@ -123,13 +121,14 @@ class Select extends Formio.Components.components.select {
     }
   }
 
-  fieldLogic(data, row) {
-    const changed = super.fieldLogic(data, row);
-    this.handleClearingAppointmentData(data);
+  checkData(data, flags, row) {
+    if (flags.changed) {
+      this.handleClearingAppointmentData(data, flags.changed.instance.key);
+    }
     this.handleSettingAppointmentLocations(data);
     this.handleSettingAppointmentDates(data);
     this.handleSettingAppointmentTimes(data);
-    return changed;
+    return super.checkData(data, flags, row);
   }
 }
 

--- a/src/formio/components/Select.js
+++ b/src/formio/components/Select.js
@@ -92,28 +92,24 @@ class Select extends Formio.Components.components.select {
 
   handleClearingAppointmentData(data) {
     // Product is empty so clear locations
-    if (this.component.appointmentsShowLocations &&
-        !data[this.component.appointmentsProductForLocations] &&
-        data[this.component.key]) {
-      this.setValue(this.emptyValue);
-      this.setItems([]);
-      this.element.lastElementChild.setAttribute('disabled', 'disabled');
-    }
+    const shouldClearLocations = this.component.appointmentsShowLocations &&
+                                 !data[this.component.appointmentsProductForLocations] &&
+                                 data[this.component.key];
+
     // Product or location is empty so clear dates
-    if (this.component.appointmentsShowDates &&
-        (!data[this.component.appointmentsProductForDates]||
-         !data[this.component.appointmentsLocationForDates]) &&
-        data[this.component.key]) {
-      this.setValue(this.emptyValue);
-      this.setItems([]);
-      this.element.lastElementChild.setAttribute('disabled', 'disabled');
-    }
+    const shouldClearDates = this.component.appointmentsShowDates &&
+                             (!data[this.component.appointmentsProductForDates]||
+                              !data[this.component.appointmentsLocationForDates]) &&
+                             data[this.component.key];
+
     // Product or location or date is empty so clear times
-    if (this.component.appointmentsShowTimes &&
-        (!data[this.component.appointmentsProductForTimes] ||
-         !data[this.component.appointmentsLocationForTimes] ||
-         !data[this.component.appointmentsDateForTimes]) &&
-        data[this.component.key]) {
+    const shouldClearTimes = this.component.appointmentsShowTimes &&
+                             (!data[this.component.appointmentsProductForTimes] ||
+                              !data[this.component.appointmentsLocationForTimes] ||
+                              !data[this.component.appointmentsDateForTimes]) &&
+                             data[this.component.key];
+
+    if (shouldClearLocations || shouldClearDates || shouldClearTimes) {
       this.setValue(this.emptyValue);
       this.setItems([]);
       this.element.lastElementChild.setAttribute('disabled', 'disabled');

--- a/src/formio/components/Select.js
+++ b/src/formio/components/Select.js
@@ -90,7 +90,7 @@ class Select extends Formio.Components.components.select {
     }
   }
 
-  handleClearingAppointmentData(data, changedKey) {
+  handleClearingAppointmentData(changedKey) {
 
     // Product is changed so clear locations
     const shouldClearLocations = this.component.appointmentsShowLocations &&
@@ -123,7 +123,7 @@ class Select extends Formio.Components.components.select {
 
   checkData(data, flags, row) {
     if (flags.changed) {
-      this.handleClearingAppointmentData(data, flags.changed.instance.key);
+      this.handleClearingAppointmentData(flags.changed.instance.key);
     }
     this.handleSettingAppointmentLocations(data);
     this.handleSettingAppointmentDates(data);

--- a/src/formio/components/Select.js
+++ b/src/formio/components/Select.js
@@ -15,6 +15,10 @@ class Select extends Formio.Components.components.select {
     // instead of the whole wrapper that replaces the <select> element (and messes with styling).
     // We're deliberately forcing this, as we have dysfunctional styles for anything else.
     this.component.widget = 'html5';
+    if (this.component.appointmentsShowProducts || this.component.appointmentsShowLocations ||
+        this.component.appointmentsShowDates || this.component.appointmentsShowTimes) {
+      this.component.disabled = true;
+    }
     if (this.component.appointmentsShowProducts) {
       this.handleSettingAppointmentProducts();
     }
@@ -33,6 +37,7 @@ class Select extends Formio.Components.components.select {
           .then(results => {
             this.setItems([]);
             results.map(result => this.addOption(result.identifier, result.name));
+            this.element.lastElementChild.removeAttribute("disabled");
           })
           .catch(error => console.log(error));
     }
@@ -47,6 +52,7 @@ class Select extends Formio.Components.components.select {
         .then(results => {
             this.setItems([]);
             results.map(result => this.addOption(result.identifier, result.name));
+            this.element.lastElementChild.removeAttribute("disabled");
         })
         .catch(error => console.log(error));
     }
@@ -61,6 +67,7 @@ class Select extends Formio.Components.components.select {
         .then(results => {
             this.setItems([]);
             results.map(result => this.addOption(result.date, result.date));
+            this.element.lastElementChild.removeAttribute("disabled");
         })
         .catch(error => console.log(error));
     }
@@ -77,6 +84,7 @@ class Select extends Formio.Components.components.select {
         .then(results => {
             this.setItems([]);
             results.map(result => this.addOption(result.time, result.time.split("T")[1].split('+')[0]));
+            this.element.lastElementChild.removeAttribute("disabled");
         })
         .catch(error => console.log(error));
     }

--- a/src/formio/components/Select.js
+++ b/src/formio/components/Select.js
@@ -105,10 +105,9 @@ class Select extends Formio.Components.components.select {
   }
 
   activate() {
-    super.activate();
-    if (this.component.appointmentsShowProducts || this.component.appointmentsShowLocations ||
-        this.component.appointmentsShowDates || this.component.appointmentsShowTimes) {
-      this.setValue(this.emptyValue);
+    if (!(this.component.appointmentsShowProducts || this.component.appointmentsShowLocations ||
+        this.component.appointmentsShowDates || this.component.appointmentsShowTimes)) {
+      super.activate();
     }
     if (this.component.appointmentsShowProducts) {
       this.handleSettingAppointmentProducts();

--- a/src/formio/components/Select.js
+++ b/src/formio/components/Select.js
@@ -45,8 +45,8 @@ class Select extends Formio.Components.components.select {
 
   handleSettingAppointmentLocations(data) {
     if (this.component.appointmentsShowLocations &&
-        data[this.component.appointmentsProductForLocations] &&
-        !data[this.component.key]) {
+        this.selectOptions.length === 0 &&
+        data[this.component.appointmentsProductForLocations]) {
       get(`${this.options.baseUrl}appointments/locations`,
         {'product_id': data[this.component.appointmentsProductForLocations]})
         .then(results => {
@@ -59,8 +59,10 @@ class Select extends Formio.Components.components.select {
   }
 
   handleSettingAppointmentDates(data) {
-    if (this.component.appointmentsShowDates && data[this.component.appointmentsProductForDates]
-        && data[this.component.appointmentsLocationForDates] && !data[this.component.key]) {
+    if (this.component.appointmentsShowDates &&
+        this.selectOptions.length === 0 &&
+        [this.component.appointmentsProductForDates] &&
+        data[this.component.appointmentsLocationForDates]) {
       get(`${this.options.baseUrl}appointments/dates`,
         {'product_id': data[this.component.appointmentsProductForDates],
          'location_id': data[this.component.appointmentsLocationForDates]})
@@ -74,9 +76,11 @@ class Select extends Formio.Components.components.select {
   }
 
   handleSettingAppointmentTimes(data) {
-    if (this.component.appointmentsShowTimes && data[this.component.appointmentsProductForTimes] &&
-        data[this.component.appointmentsLocationForTimes] && data[this.component.appointmentsDateForTimes] &&
-        !data[this.component.key]) {
+    if (this.component.appointmentsShowTimes &&
+        this.selectOptions.length === 0 &&
+        data[this.component.appointmentsProductForTimes] &&
+        data[this.component.appointmentsLocationForTimes] &&
+        data[this.component.appointmentsDateForTimes]) {
       get(`${this.options.baseUrl}appointments/times`,
         {'product_id': data[this.component.appointmentsProductForTimes],
          'location_id': data[this.component.appointmentsLocationForTimes],

--- a/src/formio/components/Select.js
+++ b/src/formio/components/Select.js
@@ -96,6 +96,8 @@ class Select extends Formio.Components.components.select {
         !data[this.component.appointmentsProductForLocations] &&
         data[this.component.key]) {
       this.setValue(this.emptyValue);
+      this.setItems([]);
+      this.element.lastElementChild.setAttribute('disabled', 'disabled');
     }
     // Product or location is empty so clear dates
     if (this.component.appointmentsShowDates &&
@@ -103,6 +105,8 @@ class Select extends Formio.Components.components.select {
          !data[this.component.appointmentsLocationForDates]) &&
         data[this.component.key]) {
       this.setValue(this.emptyValue);
+      this.setItems([]);
+      this.element.lastElementChild.setAttribute('disabled', 'disabled');
     }
     // Product or location or date is empty so clear times
     if (this.component.appointmentsShowTimes &&
@@ -111,6 +115,8 @@ class Select extends Formio.Components.components.select {
          !data[this.component.appointmentsDateForTimes]) &&
         data[this.component.key]) {
       this.setValue(this.emptyValue);
+      this.setItems([]);
+      this.element.lastElementChild.setAttribute('disabled', 'disabled');
     }
   }
 

--- a/src/formio/components/Select.js
+++ b/src/formio/components/Select.js
@@ -15,6 +15,9 @@ class Select extends Formio.Components.components.select {
     // instead of the whole wrapper that replaces the <select> element (and messes with styling).
     // We're deliberately forcing this, as we have dysfunctional styles for anything else.
     this.component.widget = 'html5';
+    if (this.component.appointmentsShowProducts) {
+      this.handleSettingAppointmentProducts();
+    }
   }
 
   get inputInfo() {
@@ -64,7 +67,6 @@ class Select extends Formio.Components.components.select {
   }
 
   handleSettingAppointmentTimes(data) {
-
     if (this.component.appointmentsShowTimes && data[this.component.appointmentsProductForTimes] &&
         data[this.component.appointmentsLocationForTimes] && data[this.component.appointmentsDateForTimes] &&
         !data[this.component.key]) {
@@ -106,11 +108,8 @@ class Select extends Formio.Components.components.select {
 
   activate() {
     if (!(this.component.appointmentsShowProducts || this.component.appointmentsShowLocations ||
-        this.component.appointmentsShowDates || this.component.appointmentsShowTimes)) {
+          this.component.appointmentsShowDates || this.component.appointmentsShowTimes)) {
       super.activate();
-    }
-    if (this.component.appointmentsShowProducts) {
-      this.handleSettingAppointmentProducts();
     }
   }
 


### PR DESCRIPTION
Fixes some points of https://github.com/open-formulieren/open-forms/issues/597.  Specifically:
- Load products upon form step loading, instead of when clicking the pulldown.
- Load locations in the dropdown upon selecting a product.
- Load dates upon selecting a location.
- Load times when a date is selected.
- Whenever nothing is loaded, make the form elements disabled. Also make them disabled when the load is in progress.
- The initial load of products was slow (3.3s, I presume because of WSDL loading/fetching). Subsequent loads were reasonably fast (250ms) [Note: Sort of, now that the initial loading of the products is done when the step is loaded the end user hopefully won't notice this slowness]
- When clicking a dropdown, it looks like the options are refreshed and it closes/re-opens or re-renders. It's not a pleasant user experience

The other points in the ticket should not be affected by these changes and vice versa so I think it makes sense to make this pull request to keep the pull requests small and specific.