### PR TITLE
Improve appointments information in summary page

### DIFF
--- a/src/components/FormStep.js
+++ b/src/components/FormStep.js
@@ -4,6 +4,7 @@
 
 import React, {useRef, useContext} from 'react';
 import PropTypes from 'prop-types';
+import {useIntl} from 'react-intl';
 import { useHistory, useParams } from 'react-router-dom';
 import usePrevious from 'react-use/esm/usePrevious';
 import isEqual from 'lodash/isEqual';
@@ -57,6 +58,8 @@ const FormStep = ({
   // react router hooks
   const history = useHistory();
   const { step: slug } = useParams();
+
+  const intl = useIntl();
 
   // look up the form step via slug so that we can obtain the submission step
   const formStep = form.steps.find(s => s.slug === slug);
@@ -148,7 +151,7 @@ const FormStep = ({
               submission={{data: data}}
               onChange={onFormIOChange}
               onSubmit={onFormIOSubmit}
-              options={{noAlerts: true, baseUrl: config.baseUrl}}
+              options={{noAlerts: true, baseUrl: config.baseUrl, intl}}
             />
             <Toolbar modifiers={['mobile-reverse-order', 'bottom']}>
               <ToolbarList>

--- a/src/components/FormStepSummary.js
+++ b/src/components/FormStepSummary.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
+import {useIntl} from 'react-intl';
 
 import Button from 'components/Button';
 import Caption from 'components/Caption';
@@ -12,6 +13,7 @@ import { getComponentLabel, getComponentValue } from 'utils';
 
 const FormStepSummary = ({stepData, editStepUrl, editStepText}) => {
   const history = useHistory();
+  const intl = useIntl();
   return (
     <>
       <Toolbar modifiers={['compact']}>
@@ -40,7 +42,7 @@ const FormStepSummary = ({stepData, editStepUrl, editStepText}) => {
           Object.entries(stepData.data).map(([key, value]) => (
             <TableRow key={key}>
               <TableHead>{getComponentLabel(stepData.configuration.components, key)}</TableHead>
-              <TableCell>{getComponentValue(value, stepData.configuration.components, key)}</TableCell>
+              <TableCell>{getComponentValue(value, stepData.configuration.components, key, intl)}</TableCell>
             </TableRow>
           ))
         }

--- a/src/formio/components/Select.js
+++ b/src/formio/components/Select.js
@@ -69,7 +69,7 @@ class Select extends Formio.Components.components.select {
          'location_id': data[this.component.appointmentsLocationForDates]})
         .then(results => {
             this.setItems([]);
-            results.map(result => this.addOption(result.date, getFormattedDateString(result.date)));
+            results.map(result => this.addOption(result.date, getFormattedDateString(this.options.intl, result.date)));
             this.element.lastElementChild.removeAttribute("disabled");
         })
         .catch(error => console.log(error));
@@ -88,7 +88,7 @@ class Select extends Formio.Components.components.select {
          'date': data[this.component.appointmentsDateForTimes]})
         .then(results => {
             this.setItems([]);
-            results.map(result => this.addOption(result.time, getFormattedTimeString(result.time)));
+            results.map(result => this.addOption(result.time, getFormattedTimeString(this.options.intl, result.time)));
             this.element.lastElementChild.removeAttribute("disabled");
         })
         .catch(error => console.log(error));

--- a/src/formio/components/Select.js
+++ b/src/formio/components/Select.js
@@ -2,6 +2,7 @@ import { Formio } from 'react-formio';
 
 import { applyPrefix } from '../utils';
 import { get } from '../../api';
+import {getFormattedDateString, getFormattedTimeString} from '../../utils';
 
 
 /**
@@ -68,7 +69,7 @@ class Select extends Formio.Components.components.select {
          'location_id': data[this.component.appointmentsLocationForDates]})
         .then(results => {
             this.setItems([]);
-            results.map(result => this.addOption(result.date, result.date));
+            results.map(result => this.addOption(result.date, getFormattedDateString(result.date)));
             this.element.lastElementChild.removeAttribute("disabled");
         })
         .catch(error => console.log(error));
@@ -87,7 +88,7 @@ class Select extends Formio.Components.components.select {
          'date': data[this.component.appointmentsDateForTimes]})
         .then(results => {
             this.setItems([]);
-            results.map(result => this.addOption(result.time, result.time.split("T")[1].split('+')[0]));
+            results.map(result => this.addOption(result.time, getFormattedTimeString(result.time)));
             this.element.lastElementChild.removeAttribute("disabled");
         })
         .catch(error => console.log(error));
@@ -123,6 +124,16 @@ class Select extends Formio.Components.components.select {
           this.component.appointmentsShowDates || this.component.appointmentsShowTimes)) {
       super.activate();
     }
+  }
+
+  beforeSubmit() {
+    if (this.component.appointmentsShowProducts || this.component.appointmentsShowLocations) {
+      // For these two types of components we need to send both the identifier and name to the backend
+      const value = this._data[this.component.key].toString();
+      const selectedOption = this.selectOptions.filter(option => option.value === value)[0];
+      this._data[this.component.key] = {identifier: selectedOption.value, name: selectedOption.label};
+    }
+    super.beforeSubmit();
   }
 
   checkData(data, flags, row) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,13 +8,13 @@ import Image from 'components/Image';
 import Anchor from 'components/Anchor';
 
 
-export const getFormattedDateString = (dateString) => {
-  return new Date(dateString).toLocaleDateString();
+export const getFormattedDateString = (intl, dateString) => {
+  return intl.formatDate(new Date(dateString));
 };
 
 
-export const getFormattedTimeString = (dateTimeString) => {
-  return new Date(dateTimeString).toLocaleTimeString(undefined,  {hour: '2-digit', minute:'2-digit'});
+export const getFormattedTimeString = (intl, dateTimeString) => {
+  return intl.formatTime(new Date(dateTimeString));
 };
 
 
@@ -48,7 +48,7 @@ export const getComponentLabel = (components, key) => {
 };
 
 
-export const getComponentValue = (inputValue, components, key) => {
+export const getComponentValue = (inputValue, components, key, intl) => {
     let component = components.find(component => component.key === key);
 
     if (component === undefined) {
@@ -66,9 +66,9 @@ export const getComponentValue = (inputValue, components, key) => {
       if (component.appointmentsShowProducts || component.appointmentsShowLocations) {
         return inputValue.name;
       } else if (component.appointmentsShowDates) {
-        return getFormattedDateString(inputValue);
+        return getFormattedDateString(intl, inputValue);
       } else if (component.appointmentsShowTimes) {
-        return getFormattedTimeString(inputValue);
+        return getFormattedTimeString(intl, inputValue);
       } else {
         return obj ? obj.label : '';
       }

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,6 +8,16 @@ import Image from 'components/Image';
 import Anchor from 'components/Anchor';
 
 
+export const getFormattedDateString = (dateString) => {
+  return new Date(dateString).toLocaleDateString();
+};
+
+
+export const getFormattedTimeString = (dateTimeString) => {
+  return new Date(dateTimeString).toLocaleTimeString(undefined,  {hour: '2-digit', minute:'2-digit'});
+};
+
+
 export const getBEMClassName = (base, modifiers=[]) => {
   const prefixedBase = applyPrefix(base);
   const prefixedModifiers = modifiers.map(mod => applyPrefix(`${base}--${mod}`));
@@ -53,7 +63,15 @@ export const getComponentValue = (inputValue, components, key) => {
       return inputValue ? 'Ja' : 'Nee';
     } else if (component.type === "select") {
       const obj = component.data.values.find(obj => obj.value === inputValue);
-      return obj ? obj.label : inputValue;
+      if (component.appointmentsShowProducts || component.appointmentsShowLocations) {
+        return inputValue.name;
+      } else if (component.appointmentsShowDates) {
+        return getFormattedDateString(inputValue);
+      } else if (component.appointmentsShowTimes) {
+        return getFormattedTimeString(inputValue);
+      } else {
+        return obj ? obj.label : '';
+      }
     } else if (component.type === "file") {
       /*
        NOTE the structure of the data set by FormIO's file component


### PR DESCRIPTION
Changes needed for points
- Should have human readable values in summary page. Will need a way to save these human readable values after they have been selected.
- On the overview page, the appointment details are rendered weirdly

of https://github.com/open-formulieren/open-forms/issues/597

Related Backend Pull Request: https://github.com/open-formulieren/open-forms/pull/645

By saving both the id and name we can then access the name in the summary page and display it rather than the id.

This also formats the dates and times, both in the summary page and when choosing a date or time.

**Screenshots**

![Screenshot 2021-09-09 at 15 21 27](https://user-images.githubusercontent.com/60747362/132694822-a235c9de-b49d-4492-bb1e-ade873a53a20.png)

![Screenshot 2021-09-09 at 15 21 38](https://user-images.githubusercontent.com/60747362/132694836-9d027713-e545-4289-86b7-02bd096d41b5.png)

![Screenshot 2021-09-09 at 15 22 08](https://user-images.githubusercontent.com/60747362/132694852-1d292109-502d-4a7c-b695-007e89e44c59.png)
