### PR TITLE
Save submission ID in localStorage

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -2,10 +2,10 @@ const fetchDefaults = {
   credentials: 'include', // required for Firefox 60, which is used in werkplekken
 };
 
-const apiCall = async (url, opts) => {
+const apiCall = async (url, opts, alertOnPermissionDenied=true) => {
   const options = { ...fetchDefaults, ...opts };
   const response = await window.fetch(url, options);
-  if (response.status === 403) {
+  if (response.status === 403 && alertOnPermissionDenied) {
     const data = await response.json();
     alert(data.detail);
   }

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -36,11 +36,11 @@ const createSubmission = async (config, form) => {
 
 const retrieveExistingSubmission = async (config, form, submissionId, setSubmissionId, removeSubmissionId) => {
   let submission;
-  const response = await apiCall(`${config.baseUrl}submissions/${submissionId}`);
+  const response = await apiCall(`${config.baseUrl}submissions/${submissionId}`, {},false);
   if (!response.ok) {
-    if (response.status === 404) {
-      // If the session has expired, the user won't be able to retrieve their submission and the API will return 404.
-      // So remove the submissionId from the localStorage and start a new one.
+    if (response.status === 403) {
+      // If the session has expired, the user won't have the permission to retrieve their submission.
+      // So remove the submissionId from the localStorage and start a new session.
       removeSubmissionId();
       submission = await createSubmission(config, form);
       setSubmissionId(submission.id);

--- a/src/components/FormStart/index.js
+++ b/src/components/FormStart/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 
 import AuthenticationOutage, { useDetectAuthenticationOutage } from 'components/auth/AuthenticationOutage';
@@ -71,7 +71,7 @@ LoginButtonIcons.propTypes = {
 };
 
 
-const useStartSubmission = (onFormStart) => {
+const useStartSubmission = () => {
   const query = useQuery();
   return !!query.get(START_FORM_QUERY_PARAM);
 };
@@ -85,7 +85,7 @@ const useStartSubmission = (onFormStart) => {
  * eHerkenning...)
  */
 const FormStart = ({ form, onFormStart }) => {
-  const doStart = useStartSubmission(onFormStart);
+  const doStart = useStartSubmission();
   const outagePluginId = useDetectAuthenticationOutage();
   const authErrors = useDetectAuthErrorMessages();
   const hasAuthErrors = !!outagePluginId || !!authErrors;

--- a/src/formio/components/Select.js
+++ b/src/formio/components/Select.js
@@ -32,10 +32,12 @@ class Select extends Formio.Components.components.select {
     if (this.component?.appointments?.showProducts || this.component?.appointments?.showLocations) {
       // For these two types of components we need to send both the identifier and name to the backend
       const value = this.getValue();
-      const selectedOption = this.selectOptions.filter(option => option.value === value)[0];
-      const formattedValue = {identifier: selectedOption.value, name: selectedOption.label};
-      // bypass events etc. (which this.setValue(...) calls!)
-      this.dataValue = formattedValue;
+      const selectedOption = this.selectOptions.find(option => option.value === value);
+      if (selectedOption) {
+        const formattedValue = {identifier: selectedOption.value, name: selectedOption.label};
+        // bypass events etc. (which this.setValue(...) calls!)
+        this.dataValue = formattedValue;
+      }
     }
     super.beforeSubmit();
   }

--- a/src/hooks/useRecycleSubmission.js
+++ b/src/hooks/useRecycleSubmission.js
@@ -1,0 +1,51 @@
+import {useContext} from 'react';
+
+import {useLocation} from 'react-router-dom';
+import useLocalStorage from 'react-use/esm/useLocalStorage';
+import useAsync from 'react-use/esm/useAsync';
+
+import {apiCall} from 'api';
+import {ConfigContext} from 'Context';
+
+const useRecycleSubmission = (form, currentSubmission, onSubmissionLoaded) => {
+  const location = useLocation();
+  const config = useContext(ConfigContext);
+  const [submissionId, setSubmissionId, removeSubmissionId] = useLocalStorage(form.uuid, '');
+
+  const url = submissionId ? `${config.baseUrl}submissions/${submissionId}` : null;
+
+  // try to load the submission from the detail endpoint
+  const {loading} = useAsync(
+    async () => {
+      // no URL to load -> abort
+      if (!url) return;
+      // the submission from the state is the same as the submission ID in local storage -> abort
+      if (currentSubmission?.id === submissionId) return;
+
+      // fetch the submission from the API
+      const response = await apiCall(url, {}, false);
+      if (response.ok) {
+        const submission = await response.json();
+        onSubmissionLoaded(submission, location.pathname);
+        setSubmissionId(submission.id);
+        return;
+      }
+
+      // error handling
+      if (response.status === 403 || response.status === 404) {
+        removeSubmissionId();
+      }
+      return;
+    },
+    [url, submissionId, currentSubmission?.id],
+  );
+
+  return [
+    loading,
+    setSubmissionId,
+    removeSubmissionId
+  ];
+};
+
+
+export default useRecycleSubmission;

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,11 +9,13 @@ import Anchor from 'components/Anchor';
 
 
 export const getFormattedDateString = (intl, dateString) => {
+  if (!dateString) return '';
   return intl.formatDate(new Date(dateString));
 };
 
 
 export const getFormattedTimeString = (intl, dateTimeString) => {
+  if (!dateTimeString) return '';
   return intl.formatTime(new Date(dateTimeString));
 };
 


### PR DESCRIPTION
Fixes open-formulieren/open-forms#447

Right now after a page refresh the user will be redirected to the Form start page. The user needs to click on 'Start form' again to continue filling in the form. This means that if a user was logged in with DigiD, they will have to log in again (although if there is `?_start=1` in the URL the form will start anyway). 

Note: I couldn't manage to write a test for this :cry: 