### PR TITLE
Skip steps that are not applicable

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -22,6 +22,7 @@ import SubmissionConfirmation from 'components/SubmissionConfirmation';
 import Summary from 'components/Summary';
 import Types from 'types';
 import {useIntl} from 'react-intl';
+import {findNextApplicableStep} from 'components/utils';
 
 /**
  * Create a submission instance from a given form instance
@@ -137,10 +138,10 @@ const reducer = (draft, action) => {
   };
 
   const onStepSubmitted = async (formStep) => {
-    const stepIndex = form.steps.indexOf(formStep);
-    // TODO: there *may* be optional steps, so completion/summary can already get
-    // triggered earlier, potentially. This will need to be incorporated later.
-    const nextStep = form.steps[stepIndex + 1]; // will be undefined if it's the last step
+    const currentStepIndex = form.steps.indexOf(formStep);
+
+    const nextStepIndex = findNextApplicableStep(currentStepIndex, state.submission);
+    const nextStep = form.steps[nextStepIndex]; // will be undefined if it's the last step
 
     const nextUrl = nextStep ? `/stap/${nextStep.slug}` : '/overzicht';
     history.push(nextUrl);

--- a/src/components/FormStep.js
+++ b/src/components/FormStep.js
@@ -23,6 +23,7 @@ import { ConfigContext } from 'Context';
 import Types from 'types';
 import LogoutButton from 'components/LogoutButton';
 import hooks from '../formio/hooks';
+import {findPreviousApplicableStep} from 'components/utils';
 
 
 const STEP_LOGIC_DEBOUNCE_MS = 300;
@@ -196,8 +197,10 @@ const FormStep = ({
 
   const onPrevPage = (event) => {
     event.preventDefault();
-    const indexPreviousStep = form.steps.indexOf(formStep) - 1;
-    const prevStepSlug = form.steps[indexPreviousStep]?.slug;
+    const currentStepIndex = form.steps.indexOf(formStep);
+    const previousStepIndex = findPreviousApplicableStep(currentStepIndex, submission);
+
+    const prevStepSlug = form.steps[previousStepIndex]?.slug;
     const navigateTo = prevStepSlug ? `/stap/${prevStepSlug}` : '/';
     history.push(navigateTo);
   };

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -1,0 +1,22 @@
+const findPreviousApplicableStep = (currentStepIndex, submission) => {
+  let candidateStepIndex = currentStepIndex - 1;
+  while (candidateStepIndex >= 0 && !submission.steps[candidateStepIndex].isApplicable) {
+    candidateStepIndex = candidateStepIndex - 1;
+    if (candidateStepIndex < 0) break;
+  }
+  return candidateStepIndex;
+};
+
+
+const findNextApplicableStep = (currentStepIndex, submission) => {
+  let candidateStepIndex = currentStepIndex + 1;
+  if (candidateStepIndex >= submission.steps.length) return candidateStepIndex;
+
+  while (!submission.steps[candidateStepIndex].isApplicable) {
+    candidateStepIndex = candidateStepIndex + 1;
+    if (!submission.steps[candidateStepIndex]) break;
+  }
+  return candidateStepIndex;
+};
+
+export {findNextApplicableStep, findPreviousApplicableStep};


### PR DESCRIPTION
Fixes open-formulieren/open-forms#225

TODO:

- [x] Deal with the problem that if a user makes a hard refresh, the steps are no longer marked as not applicable and the user can then navigate to them by going backwards/forwards.

Backend PR: https://github.com/open-formulieren/open-forms/pull/706