### PR TITLE
[#79] Do nothing in restoreCaretPosition for email components

### DIFF
--- a/src/formio/components/Email.js
+++ b/src/formio/components/Email.js
@@ -13,6 +13,10 @@ class Email extends Formio.Components.components.email {
     info.attr.class = applyPrefix('email');
     return info;
   }
+
+  // TODO: Temporary fix for issue #79. setSelectionRange() can only be used on input fields of type text, search, URL,
+  // tel and password. This is fixed in FormIO 4.13, but upgrading currently causes other issues.
+  restoreCaretPosition() {}
 }
 
 


### PR DESCRIPTION
Temporary fix for issue #79. 

This error happens because `setSelectionRange()` (used inside `restoreCaretPosition()`) can only be used on input fields of type text, search, URL, tel and password. 
Chrome throws errors if it is used on inputs of different types. https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange

This is fixed in FormIO 4.13, but upgrading currently causes other issues.

The problem with both this solution and the one from FormIO in 4.13, is that after entering your email in the form and waiting for the logic check to happen, the cursor goes back to the beginning of the email. This might make it frustrating to fill in a form. 