### PR TITLE
Display payment status

### DIFF
--- a/src/components/PaymentOverview/__snapshots__/test.spec.js.snap
+++ b/src/components/PaymentOverview/__snapshots__/test.spec.js.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`navigation without context displays a generic error message 1`] = `
+<div
+  className="openforms-card"
+>
+  <header
+    className="openforms-card__header"
+  >
+    <h2
+      className="openforms-title"
+    >
+      Payment overview
+    </h2>
+  </header>
+  <div
+    className="openforms-card__body"
+  >
+     
+    <div
+      className="openforms-alert openforms-alert--error"
+    >
+      <span
+        className="openforms-alert__icon openforms-alert__icon--wide"
+      >
+        <span
+          className="fa fas fa-icon fa-exclamation-circle"
+        />
+      </span>
+      <div
+        className="openforms-body"
+      >
+        We can't display any payment information - did you maybe get here by accident?
+      </div>
+    </div>
+     
+  </div>
+</div>
+`;
+
+exports[`on valid redirect renders an error message on failure 1`] = `
+<div
+  className="openforms-card"
+>
+  <header
+    className="openforms-card__header"
+  >
+    <h2
+      className="openforms-title"
+    >
+      Payment overview
+    </h2>
+  </header>
+  <div
+    className="openforms-card__body"
+  >
+     
+    <div
+      className="openforms-body"
+    >
+      <div
+        className="openforms-alert openforms-alert--error"
+      >
+        <span
+          className="openforms-alert__icon openforms-alert__icon--wide"
+        >
+          <span
+            className="fa fas fa-icon fa-exclamation-circle"
+          />
+        </span>
+        <div
+          className="openforms-body"
+        >
+          The payment has failed. If you aborted the payment, please complete payment from the confirmation email.
+        </div>
+      </div>
+    </div>
+    <a>
+      some link
+    </a>
+     
+  </div>
+</div>
+`;
+
+exports[`on valid redirect renders the status information 1`] = `
+<div
+  className="openforms-card"
+>
+  <header
+    className="openforms-card__header"
+  >
+    <h2
+      className="openforms-title"
+    >
+      Payment overview
+    </h2>
+  </header>
+  <div
+    className="openforms-card__body"
+  >
+     
+    <div
+      className="openforms-body"
+    >
+      Your payment has been received.
+    </div>
+    <a>
+      some link
+    </a>
+     
+  </div>
+</div>
+`;

--- a/src/components/PaymentOverview/index.js
+++ b/src/components/PaymentOverview/index.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link, useLocation } from 'react-router-dom';
+import { FormattedMessage, defineMessage, useIntl } from 'react-intl';
+
+import Body from 'components/Body';
+import Anchor from 'components/Anchor';
+import Card from 'components/Card';
+import ErrorMessage from 'components/ErrorMessage';
+
+// see openforms.payments.constants.UserAction in the backend
+const USER_ACTIONS = [
+  'accept',
+  'exception',
+  'cancel',
+  'unknown',
+];
+
+// see openforms.payments.constants.PaymentStatus in the backend
+const STATUS_MESSAGES = {
+  started: defineMessage({
+    description: 'payment started status',
+    defaultMessage: 'You\'ve started the payment process.',
+  }),
+  processing: defineMessage({
+    description: 'payment processing status',
+    defaultMessage: 'Your payment is currently processing.',
+  }),
+  failed: defineMessage({
+    description: 'payment failed status',
+    defaultMessage: 'The payment has failed. If you aborted the payment, please complete payment from the confirmation email.',
+  }),
+  completed: defineMessage({
+    description: 'payment completed status',
+    defaultMessage: 'Your payment has been received.',
+  }),
+  registered: defineMessage({
+    description: 'payment registered status',
+    defaultMessage: 'Your payment is received and processed.',
+  }),
+};
+
+
+const Container = ({ children }) => (
+  <Card title={<FormattedMessage
+                  description="Payment overview title"
+                  defaultMessage="Payment overview" /> }>
+    {children}
+  </Card>
+);
+
+Container.propTypes = {
+  children: PropTypes.node,
+};
+
+
+const PaymentOverview = () => {
+  const intl = useIntl();
+  const {state: {status, userAction} = {}} = useLocation();
+
+  // display a warning if someone navigates directly to this URL.
+  if (!status || !userAction) {
+    return (
+      <Container>
+        <ErrorMessage>
+          <FormattedMessage
+            description="Payment overview missing state error message"
+            defaultMessage="We can't display any payment information - did you maybe get here by accident?"
+          />
+        </ErrorMessage>
+      </Container>
+    );
+  }
+
+  if (!USER_ACTIONS.includes(userAction)) {
+    throw new Error('Unknown payment user action');
+  }
+
+  const statusMsg = STATUS_MESSAGES[status];
+  if (!statusMsg) {
+    throw new Error('Unknown payment status');
+  }
+
+  let Wrapper = React.Fragment;
+  if (status === 'failed') {
+    Wrapper = ErrorMessage;
+  }
+
+  return (
+    <Container>
+      <Body component="div">
+        <Wrapper>
+          {intl.formatMessage(statusMsg)}
+        </Wrapper>
+      </Body>
+
+      <Link to="/" component={Anchor}>
+        <FormattedMessage description="return to form start button" defaultMessage="Back to form start" />
+      </Link>
+    </Container>
+  );
+};
+
+PaymentOverview.propTypes = {
+};
+
+
+export default PaymentOverview;

--- a/src/components/PaymentOverview/test.spec.js
+++ b/src/components/PaymentOverview/test.spec.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { IntlProvider } from 'react-intl';
+import {useLocation} from 'react-router-dom';
+import {render} from '@testing-library/react';
+
+import PaymentOverview from 'components/PaymentOverview';
+import messagesEN from 'i18n/compiled/en.json';
+
+/**
+ * Set up mocks
+ */
+jest.mock("../../map/rd", () => jest.fn());
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn(),
+  Link: () => (<a>some link</a>),
+}));
+
+
+describe('navigation without context', () => {
+  it('displays a generic error message', () => {
+    useLocation.mockImplementation(() => ({
+      pathname: 'localhost:3000/betaaloverzicht',
+    }));
+    const tree = renderer
+      .create((
+        <IntlProvider locale="en" messages={messagesEN}>
+          <PaymentOverview />
+        </IntlProvider>
+      ))
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('throws on unexpected values (status)', () => {
+    useLocation.mockImplementation(() => ({
+      pathname: 'localhost:3000/betaaloverzicht',
+      state: {
+        status: 'nope',
+        userAction: 'accept',
+      }
+    }));
+
+    expect(() => render(
+      <IntlProvider locale="en" messages={messagesEN}>
+        <PaymentOverview />
+      </IntlProvider>
+    )).toThrow();
+
+  });
+
+  it('throws on unexpected values (userAction)', () => {
+    useLocation.mockImplementation(() => ({
+      pathname: 'localhost:3000/betaaloverzicht',
+      state: {
+        status: 'completed',
+        userAction: 'nope',
+      }
+    }));
+
+    expect(() => render(
+      <IntlProvider locale="en" messages={messagesEN}>
+        <PaymentOverview />
+      </IntlProvider>
+    )).toThrow();
+
+  });
+});
+
+
+describe('on valid redirect', () => {
+  it('renders the status information', () => {
+    useLocation.mockImplementation(() => ({
+      pathname: 'localhost:3000/betaaloverzicht',
+      state: {
+        status: 'completed',
+        userAction: 'accept',
+      }
+    }));
+
+    const tree = renderer
+      .create((
+        <IntlProvider locale="en" messages={messagesEN}>
+          <PaymentOverview />
+        </IntlProvider>
+      ))
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders an error message on failure', () => {
+    useLocation.mockImplementation(() => ({
+      pathname: 'localhost:3000/betaaloverzicht',
+      state: {
+        status: 'failed',
+        userAction: 'accept',
+      }
+    }));
+
+    const tree = renderer
+      .create((
+        <IntlProvider locale="en" messages={messagesEN}>
+          <PaymentOverview />
+        </IntlProvider>
+      ))
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -83,6 +83,12 @@
       "value": "Cancel appointment"
     }
   ],
+  "JB/IBw": [
+    {
+      "type": 0,
+      "value": "The payment has failed. If you aborted the payment, please complete payment from the confirmation email."
+    }
+  ],
   "LEeGSv": [
     {
       "options": {
@@ -153,6 +159,24 @@
       "value": "Cancel appointment"
     }
   ],
+  "VrbdRk": [
+    {
+      "type": 0,
+      "value": "Your payment has been received."
+    }
+  ],
+  "WVmmME": [
+    {
+      "type": 0,
+      "value": "Payment overview"
+    }
+  ],
+  "YdeY1f": [
+    {
+      "type": 0,
+      "value": "Back to form start"
+    }
+  ],
   "ZehFnX": [
     {
       "type": 0,
@@ -187,6 +211,24 @@
     {
       "type": 1,
       "value": "reference"
+    }
+  ],
+  "bgfiRG": [
+    {
+      "type": 0,
+      "value": "You've started the payment process."
+    }
+  ],
+  "bu0CcW": [
+    {
+      "type": 0,
+      "value": "Your payment is received and processed."
+    }
+  ],
+  "eO6Ysb": [
+    {
+      "type": 0,
+      "value": "Your payment is currently processing."
     }
   ],
   "ertoXR": [
@@ -245,6 +287,12 @@
     {
       "type": 0,
       "value": ". Please fill out your email address for verification purposes."
+    }
+  ],
+  "tIN0Is": [
+    {
+      "type": 0,
+      "value": "We can't display any payment information - did you maybe get here by accident?"
     }
   ],
   "tohkCS": [

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -83,6 +83,12 @@
       "value": "Afspraak annuleren"
     }
   ],
+  "JB/IBw": [
+    {
+      "type": 0,
+      "value": "The payment has failed. If you aborted the payment, please complete payment from the confirmation email."
+    }
+  ],
   "LEeGSv": [
     {
       "options": {
@@ -153,6 +159,24 @@
       "value": "Afspraak annuleren"
     }
   ],
+  "VrbdRk": [
+    {
+      "type": 0,
+      "value": "Your payment has been received."
+    }
+  ],
+  "WVmmME": [
+    {
+      "type": 0,
+      "value": "Payment overview"
+    }
+  ],
+  "YdeY1f": [
+    {
+      "type": 0,
+      "value": "Back to form start"
+    }
+  ],
   "ZehFnX": [
     {
       "type": 0,
@@ -187,6 +211,24 @@
     {
       "type": 1,
       "value": "reference"
+    }
+  ],
+  "bgfiRG": [
+    {
+      "type": 0,
+      "value": "You've started the payment process."
+    }
+  ],
+  "bu0CcW": [
+    {
+      "type": 0,
+      "value": "Your payment is received and processed."
+    }
+  ],
+  "eO6Ysb": [
+    {
+      "type": 0,
+      "value": "Your payment is currently processing."
     }
   ],
   "ertoXR": [
@@ -245,6 +287,12 @@
     {
       "type": 0,
       "value": " te annuleren. Vul uw e-mailadres in voor verificatiedoeleinden."
+    }
+  ],
+  "tIN0Is": [
+    {
+      "type": 0,
+      "value": "We can't display any payment information - did you maybe get here by accident?"
     }
   ],
   "tohkCS": [

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -59,6 +59,11 @@
     "description": "Cancel appointment title",
     "originalDefault": "Cancel appointment"
   },
+  "JB/IBw": {
+    "defaultMessage": "The payment has failed. If you aborted the payment, please complete payment from the confirmation email.",
+    "description": "payment failed status",
+    "originalDefault": "The payment has failed. If you aborted the payment, please complete payment from the confirmation email."
+  },
   "LEeGSv": {
     "defaultMessage": "{isApplicable, select, false {{label} (n/a)} other {{label}} }",
     "description": "Step label in progress indicator",
@@ -89,6 +94,21 @@
     "description": "Cancel appointment submit button",
     "originalDefault": "Cancel appointment"
   },
+  "VrbdRk": {
+    "defaultMessage": "Your payment has been received.",
+    "description": "payment completed status",
+    "originalDefault": "Your payment has been received."
+  },
+  "WVmmME": {
+    "defaultMessage": "Payment overview",
+    "description": "Payment overview title",
+    "originalDefault": "Payment overview"
+  },
+  "YdeY1f": {
+    "defaultMessage": "Back to form start",
+    "description": "return to form start button",
+    "originalDefault": "Back to form start"
+  },
   "ZehFnX": {
     "defaultMessage": "Je hebt het inloggen met {service} geannuleerd.",
     "description": "DigiD/EHerkenning cancellation message. MUST BE THIS EXACT STRING!",
@@ -108,6 +128,21 @@
     "defaultMessage": "Confirmation: {reference}",
     "description": "On succesful completion title",
     "originalDefault": "Confirmation: {reference}"
+  },
+  "bgfiRG": {
+    "defaultMessage": "You've started the payment process.",
+    "description": "payment started status",
+    "originalDefault": "You've started the payment process."
+  },
+  "bu0CcW": {
+    "defaultMessage": "Your payment is received and processed.",
+    "description": "payment registered status",
+    "originalDefault": "Your payment is received and processed."
+  },
+  "eO6Ysb": {
+    "defaultMessage": "Your payment is currently processing.",
+    "description": "payment processing status",
+    "originalDefault": "Your payment is currently processing."
   },
   "ertoXR": {
     "defaultMessage": "Processing...",
@@ -133,6 +168,11 @@
     "defaultMessage": "You're about to cancel your appointment on <b>{date}</b> at <b>{time}</b>. Please fill out your email address for verification purposes.",
     "description": "Appointment cancellation body text",
     "originalDefault": "You're about to cancel your appointment on <b>{date}</b> at <b>{time}</b>. Please fill out your email address for verification purposes."
+  },
+  "tIN0Is": {
+    "defaultMessage": "We can't display any payment information - did you maybe get here by accident?",
+    "description": "Payment overview missing state error message",
+    "originalDefault": "We can't display any payment information - did you maybe get here by accident?"
   },
   "tohkCS": {
     "defaultMessage": "The email address where you received the appointment confirmation email.",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -59,6 +59,11 @@
     "description": "Cancel appointment title",
     "originalDefault": "Cancel appointment"
   },
+  "JB/IBw": {
+    "defaultMessage": "The payment has failed. If you aborted the payment, please complete payment from the confirmation email.",
+    "description": "payment failed status",
+    "originalDefault": "The payment has failed. If you aborted the payment, please complete payment from the confirmation email."
+  },
   "LEeGSv": {
     "defaultMessage": "{isApplicable, select, false {{label} (n.v.t.)} other {{label}} }",
     "description": "Step label in progress indicator",
@@ -89,6 +94,21 @@
     "description": "Cancel appointment submit button",
     "originalDefault": "Cancel appointment"
   },
+  "VrbdRk": {
+    "defaultMessage": "Your payment has been received.",
+    "description": "payment completed status",
+    "originalDefault": "Your payment has been received."
+  },
+  "WVmmME": {
+    "defaultMessage": "Payment overview",
+    "description": "Payment overview title",
+    "originalDefault": "Payment overview"
+  },
+  "YdeY1f": {
+    "defaultMessage": "Back to form start",
+    "description": "return to form start button",
+    "originalDefault": "Back to form start"
+  },
   "ZehFnX": {
     "defaultMessage": "Je hebt het inloggen met {service} geannuleerd.",
     "description": "DigiD/EHerkenning cancellation message. MUST BE THIS EXACT STRING!",
@@ -108,6 +128,21 @@
     "defaultMessage": "Bevestiging: {reference}",
     "description": "On succesful completion title",
     "originalDefault": "Confirmation: {reference}"
+  },
+  "bgfiRG": {
+    "defaultMessage": "You've started the payment process.",
+    "description": "payment started status",
+    "originalDefault": "You've started the payment process."
+  },
+  "bu0CcW": {
+    "defaultMessage": "Your payment is received and processed.",
+    "description": "payment registered status",
+    "originalDefault": "Your payment is received and processed."
+  },
+  "eO6Ysb": {
+    "defaultMessage": "Your payment is currently processing.",
+    "description": "payment processing status",
+    "originalDefault": "Your payment is currently processing."
   },
   "ertoXR": {
     "defaultMessage": "Bezig...",
@@ -133,6 +168,11 @@
     "defaultMessage": "U staat op het punt uw afspraak op <b>{date}</b> om <b>{time}</b> te annuleren. Vul uw e-mailadres in voor verificatiedoeleinden.",
     "description": "Appointment cancellation body text",
     "originalDefault": "You're about to cancel your appointment on <b>{date}</b> at <b>{time}</b>. Please fill out your email address for verification purposes."
+  },
+  "tIN0Is": {
+    "defaultMessage": "We can't display any payment information - did you maybe get here by accident?",
+    "description": "Payment overview missing state error message",
+    "originalDefault": "We can't display any payment information - did you maybe get here by accident?"
   },
   "tohkCS": {
     "defaultMessage": "Het e-mailadres waarop u de bevestigingsmail van de afspraak heeft ontvangen.",


### PR DESCRIPTION
Fixes open-formulieren/open-forms#724

I've decided to keep it simple and possibly we can expand and include the payment button again if payment is not succesful. Given that we wipe all the session/state after completion, it'd be quite a bit of work to fetch that information again, and maybe we can leverage the `status` api endpoint to also display pricing information, but that's all extra complexity.

Screenshots:

Payment cancelled

![image](https://user-images.githubusercontent.com/5518550/140058719-4ee4e5e8-4748-4f99-bfc7-fe74dbca243a.png)

Payment succeeded

![image](https://user-images.githubusercontent.com/5518550/140067095-77b7b126-3cda-4e31-8723-2fca046bf484.png)

Banktransfer leads to "processing" status

![image](https://user-images.githubusercontent.com/5518550/140067493-44e6a377-f967-492d-be19-11d9f1598225.png)

