### PR TITLE
Include current browser location as form URL

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -31,7 +31,11 @@ import {findNextApplicableStep} from 'components/utils';
  * @return {Object}        The Submission instance.
  */
 const createSubmission = async (config, form) => {
-  const submissionResponse = await post(`${config.baseUrl}submissions`, {form: form.url});
+  const createData = {
+    form: form.url,
+    formUrl: window.location.toString(),
+  };
+  const submissionResponse = await post(`${config.baseUrl}submissions`, createData);
   return submissionResponse.data;
 };
 


### PR DESCRIPTION
Fixes open-formulieren/open-forms#709

The backend needs to know where the form originated for possible
future redirects (outside of the usual fill-out-form flow, such as
payment redirect, resuming the form or cancelling an appointment).

We include the formUrl parameter in the create data for this.