### PR TITLE
Don't call alert by default

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -2,7 +2,7 @@ const fetchDefaults = {
   credentials: 'include', // required for Firefox 60, which is used in werkplekken
 };
 
-const apiCall = async (url, opts, alertOnPermissionDenied=true) => {
+const apiCall = async (url, opts, alertOnPermissionDenied=false) => {
   const options = { ...fetchDefaults, ...opts };
   const response = await window.fetch(url, options);
   if (response.status === 403 && alertOnPermissionDenied) {

--- a/src/hooks/useRecycleSubmission.js
+++ b/src/hooks/useRecycleSubmission.js
@@ -30,7 +30,7 @@ const useRecycleSubmission = (form, currentSubmission, onSubmissionLoaded) => {
       if (currentSubmission?.id === submissionId) return;
 
       // fetch the submission from the API
-      const response = await apiCall(url, {}, false);
+      const response = await apiCall(url, {});
       if (response.ok) {
         const submission = await response.json();
         onSubmissionLoaded(submission, location);


### PR DESCRIPTION
Mentioned on Slack that we don't want to display this alert.  While nothing will currently use the alert I thought we should keep the code there in case we want it in the future, though we can also just remove it if that's preferred. 