### PR TITLE
Remove submission ID before calling dispatch

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -163,6 +163,7 @@ const reducer = (draft, action) => {
   };
 
   const onSubmitForm = (processingStatusUrl) => {
+    removeSubmissionId();
     dispatch({
       type: 'SUBMITTED',
       payload: {
@@ -170,7 +171,6 @@ const reducer = (draft, action) => {
         processingStatusUrl,
       }
     });
-    removeSubmissionId();
     history.push('/bevestiging');
   };
 


### PR DESCRIPTION
Partially fixes open-formulieren/open-forms#974

Fixes point `Investigate unexpected HTTP 403's while filling out the form - happens even when going from step to next step` 

The reason for at least one of the API call failures is that when we call dispatch then the component would re-render and so `useRecycleSubmission` was being called before we actually removed the submission id.  This would mean `useRecycleSubmission` would make an api call with a submission id that it should not since the submission was completed.