### PR TITLE
Fixed race condition in logic-induced data updates

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -41,3 +41,7 @@ export const flattenComponents = (components) => {
   // Convert an array of arrays to a single array
   return [].concat.apply([], flattenedComponents);
 };
+
+
+// usage: await sleep(3000);
+export const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
Fixes open-formulieren/open-forms#1037

---

While logic checking and processing the logic check, race conditions
caused form inputs to behave erratically, often restoring input that
was previously changed. For example, typing a string in an input field,
having the logic complete and right at that moment hitting backspace
would undo the backspace actions at times.

This is caused by a race condition of new user input, updating the form
data state, while the logic check results processing would operate on
a slighter older version of that form data state.

This is NOT related to the debouncing of the check nor the API call
duration itself - on fresh input either the logic check is unscheduled,
ensuring the API call is not made in the first place, or if the API call
was initiated but hadn't completed, the pending request would be
cancelled. Instead, it is caused by taking a snapshot of the form data
to perform the logic check, the logic check being done (in a non-zero
duration), and after that but before the form data state is updated,
new user-input arrives modifying the form data state. The old snapshot
from before the logic check would then discard the changes that arrived
just after the logic check results are received from the backend.

This can be reproduced by putting a sleep statement after the
`doLogicCheck` call without calling `getCurrentFormData` before
updating the state again, and performing fresh user input while the
sleep call is running. Using 5s sleep time is an easy way to do this.