### PR TITLE
More fixes w/r to Formio data immutability

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -151,6 +151,8 @@ const reducer = (draft, action) => {
   const onFormStart = async (event) => {
     event && event.preventDefault();
 
+    // required to get rid of the error message saying the session is expired - once
+    // you start a new submission, any previous call history should be discarded.
     resetSession();
 
     if (state.submission != null) {

--- a/src/components/FormStart/index.js
+++ b/src/components/FormStart/index.js
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React, {useEffect, useRef} from 'react';
 import PropTypes from 'prop-types';
 import {FormattedMessage, useIntl} from 'react-intl';
 
@@ -64,8 +64,21 @@ const FormStart = ({ form, onFormStart }) => {
   const authErrors = useDetectAuthErrorMessages();
   const hasAuthErrors = !!outagePluginId || !!authErrors;
 
+  const onFormStartCalledRef = useRef(false);
+
   useEffect(() => {
-    if (doStart && !hasAuthErrors) onFormStart();
+    // if it's already called, do not call it again as this creates 'infite' cycles.
+    // This component is re-mounted/re-rendered because of parent component state changes,
+    // while the start marker is still in the querystring. Therefore, once we have called
+    // the callback, we keep track of this call being done so that it's invoked only once.
+    // See https://github.com/open-formulieren/open-forms/issues/1174
+    if (onFormStartCalledRef.current) {
+      return;
+    }
+    if (doStart && !hasAuthErrors) {
+      onFormStart();
+      onFormStartCalledRef.current = true;
+    }
   }, [doStart, hasAuthErrors, onFormStart]);
 
   // do not re-render the login options while we're redirecting

--- a/src/components/FormStart/index.js
+++ b/src/components/FormStart/index.js
@@ -8,6 +8,7 @@ import Body from 'components/Body';
 import Button from 'components/Button';
 import Card from 'components/Card';
 import {Literal, LiteralsProvider} from 'components/Literal';
+import Loader from 'components/Loader';
 import MaintenanceMode from 'components/MaintenanceMode';
 import { Toolbar, ToolbarList } from 'components/Toolbar';
 import useQuery from 'hooks/useQuery';
@@ -65,7 +66,16 @@ const FormStart = ({ form, onFormStart }) => {
 
   useEffect(() => {
     if (doStart && !hasAuthErrors) onFormStart();
-  }, [doStart, outagePluginId, hasAuthErrors, onFormStart]);
+  }, [doStart, hasAuthErrors, onFormStart]);
+
+  // do not re-render the login options while we're redirecting
+  if (doStart && !hasAuthErrors) {
+    return (
+      <Card>
+        <Loader modifiers={['centered', 'only-child']} />
+      </Card>
+    );
+  }
 
   if (form.maintenanceMode) {
     return <MaintenanceMode title={form.name} />;

--- a/src/components/FormStepSummary/utils.js
+++ b/src/components/FormStepSummary/utils.js
@@ -96,7 +96,7 @@ export const getComponentValue = (component, intl) => {
               "originalName": "my-image.jpg",
           }
       ] */
-      return inputValue.map(v => {
+      return rawValue.map(v => {
           const {size, unit} = humanFileSize(v.size);
           return (
             <Anchor key={v.url} href={v.url}>


### PR DESCRIPTION
open-formulieren/open-forms#1174

There were more places were refs were updated with data that possibly
contained immutable datastructures (because they come from the
immer reducer state). These have now been wrapped with cloneDeep to
make them immutable as well, so that Formio can apply the mutations.

This typically happens when you have two fields for example: a regular
text field, and a multiple=true text field. If you edit the regular
text field, some immutable data ends up in the state, preventing you
from adding extra items to the multiple=true text field.

Additionally, the onFormIOChange event handler has been adapted, as
it did not update the internal view on the data after adding an
item to a multiple=true text field. This is caused by the
modifiedByHuman flag being 'undefined' and the flags containing
'undefined' as values as well, making it unreliable. Instead, we now
compare if the new view on the data is different from the old view
before we effectively detect a change in data.

Finally, some bugs are likely fixed causing the Formio spinner to
spin indefinitely, or the submit button being blocked. We now dispatch
an action when the logic check is aborted or not even performed due
to Formio-level validation errors. An extra side-effect is that invalid
client side forms are now blocked from submission (client-side).