### PR TITLE
Display 'return to main website' on confirmation page

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -51,6 +51,7 @@ const initialState = {
   submittedSubmission: null,
   processingStatusUrl: '',
   processingError: '',
+  completed: false,
 };
 
 
@@ -75,6 +76,11 @@ const reducer = (draft, action) => {
       draft.processingError = action.payload;
       // put the submission back in the state as well, so we can re-submit
       draft.submission = draft.submittedSubmission;
+      break;
+    }
+    case 'PROCESSING_SUCCEEDED': {
+      draft.processingError = null;
+      draft.completed = true;
       break;
     }
     case 'CLEAR_PROCESSING_ERROR': {
@@ -273,6 +279,7 @@ const reducer = (draft, action) => {
               submission={state.submittedSubmission}
               statusUrl={state.processingStatusUrl}
               onFailure={onProcessingFailure}
+              onConfirmed={() => dispatch({type: 'PROCESSING_SUCCEEDED'})}
               component={SubmissionConfirmation} />
           </Route>
 
@@ -308,6 +315,7 @@ const reducer = (draft, action) => {
               steps={form.steps}
               submission={state.submission || state.submittedSubmission}
               submissionAllowed={form.submissionAllowed}
+              completed={state.completed}
             />
           </LayoutColumn>
         )

--- a/src/components/ProgressIndicator/index.js
+++ b/src/components/ProgressIndicator/index.js
@@ -82,7 +82,7 @@ const stepLabels = {
 };
 
 
-const ProgressIndicator = ({ title, submission=null, steps, submissionAllowed }) => {
+const ProgressIndicator = ({ title, submission=null, steps, submissionAllowed, completed=false }) => {
   const summaryMatch = !!useRouteMatch('/overzicht');
   const stepMatch = useRouteMatch('/stap/:step');
   const confirmationMatch = !!useRouteMatch('/bevestiging');
@@ -163,7 +163,7 @@ const ProgressIndicator = ({ title, submission=null, steps, submissionAllowed })
         {
           showConfirmation
           && (
-            <ProgressItem completed={false}>
+            <ProgressItem completed={completed}>
               <Anchor
                 component="span"
                 modifiers={getLinkModifiers(confirmationMatch, confirmationMatch && applicableCompleted)}
@@ -188,6 +188,7 @@ ProgressIndicator.propTypes = {
     formDefinition: PropTypes.string.isRequired,
   })).isRequired,
   submissionAllowed: PropTypes.oneOf(Object.values(SUBMISSION_ALLOWED)).isRequired,
+  completed: PropTypes.bool,
 };
 
 

--- a/src/components/SubmissionConfirmation.js
+++ b/src/components/SubmissionConfirmation.js
@@ -5,12 +5,14 @@ import useAsync from 'react-use/esm/useAsync';
 
 import { post } from 'api';
 import Body from 'components/Body';
+import Button from 'components/Button';
 import Card from 'components/Card';
 import ErrorBoundary from 'components/ErrorBoundary';
 import FAIcon from 'components/FAIcon';
 import Anchor from 'components/Anchor';
 import Loader from 'components/Loader';
 import PaymentForm from 'components/PaymentForm';
+import {Toolbar, ToolbarList} from 'components/Toolbar';
 import usePoll from 'hooks/usePoll';
 
 const RESULT_FAILED = 'failed';
@@ -119,11 +121,14 @@ const SubmissionConfirmation = ({statusUrl, onFailure}) => {
     publicReference,
     reportDownloadUrl,
     confirmationPageContent,
+    mainWebsiteUrl,
   } = statusResponse;
 
   if (result === RESULT_FAILED) {
     throw new Error('Failure should have been handled in the onFailure prop.');
   }
+
+  const showBackToMainWebsite = mainWebsiteUrl && !paymentUrl;
 
   return (
     <>
@@ -139,7 +144,7 @@ const SubmissionConfirmation = ({statusUrl, onFailure}) => {
           dangerouslySetInnerHTML={{__html: confirmationPageContent}}
         />
 
-        <>
+        <Body>
           <FAIcon icon="download" aria-hidden="true" modifiers={['inline']} />
           <Anchor href={reportDownloadUrl} target="_blank" rel="noopener noreferrer">
             <FormattedMessage
@@ -147,7 +152,25 @@ const SubmissionConfirmation = ({statusUrl, onFailure}) => {
               defaultMessage="Download PDF"
             />
           </Anchor>
-        </>
+        </Body>
+
+        { showBackToMainWebsite
+          ? (
+            <Toolbar modifiers={['reverse']}>
+              <ToolbarList>
+                <Anchor href={mainWebsiteUrl} rel="noopener noreferrer">
+                  <Button type="button" variant="primary">
+                    <FormattedMessage
+                      description="Back to main website link title"
+                      defaultMessage="Return to main website"
+                    />
+                  </Button>
+                </Anchor>
+              </ToolbarList>
+            </Toolbar>
+          )
+          : null
+        }
 
       </Card>
 

--- a/src/components/SubmissionConfirmation.js
+++ b/src/components/SubmissionConfirmation.js
@@ -16,6 +16,7 @@ import {Toolbar, ToolbarList} from 'components/Toolbar';
 import usePoll from 'hooks/usePoll';
 
 const RESULT_FAILED = 'failed';
+const RESULT_SUCCESS = 'success';
 
 const getStartPaymentUrl = (apiUrl) => {
   const nextUrl = new URL(window.location.href);
@@ -63,8 +64,9 @@ StartPayment.propTypes = {
  * Renders the confirmation page displayed after submitting a form.
  * @param {String} statusUrl The URL where to check if the processing of the submission is complete
  * @param {Function} onFailure Callback to invoke if the background processing result is failure.
+ * @param {Function} onConfirmed Callback to invoke if the background processing result is success.
  */
-const SubmissionConfirmation = ({statusUrl, onFailure}) => {
+const SubmissionConfirmation = ({statusUrl, onFailure, onConfirmed}) => {
   const [statusResponse, setStatusResponse] = useState(null);
   const intl = useIntl();
   const genericErrorMessage = intl.formatMessage({
@@ -82,6 +84,8 @@ const SubmissionConfirmation = ({statusUrl, onFailure}) => {
           if (response.result === RESULT_FAILED) {
             const errorMessage = response.errorMessage || genericErrorMessage;
             onFailure && onFailure(errorMessage);
+          } else if (response.result === RESULT_SUCCESS) {
+            onConfirmed && onConfirmed();
           }
           return true;
         }
@@ -184,6 +188,7 @@ const SubmissionConfirmation = ({statusUrl, onFailure}) => {
 SubmissionConfirmation.propTypes = {
   statusUrl: PropTypes.string.isRequired,
   onFailure: PropTypes.func,
+  onConfirmed: PropTypes.func,
 }
 
 export default SubmissionConfirmation;

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -438,5 +438,11 @@
       "type": 0,
       "value": "Failed to determine the appointment time"
     }
+  ],
+  "zkdWYe": [
+    {
+      "type": 0,
+      "value": "Return to main website"
+    }
   ]
 }

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -438,5 +438,11 @@
       "type": 0,
       "value": "Het systeem kon de afspraak niet vinden"
     }
+  ],
+  "zkdWYe": [
+    {
+      "type": 0,
+      "value": "Terug naar de website"
+    }
   ]
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -278,5 +278,10 @@
     "defaultMessage": "Failed to determine the appointment time",
     "description": "Appointment cancellation missing time query string parameter",
     "originalDefault": "Failed to determine the appointment time"
+  },
+  "zkdWYe": {
+    "defaultMessage": "Return to main website",
+    "description": "Back to main website link title",
+    "originalDefault": "Return to main website"
   }
 }

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -278,5 +278,10 @@
     "defaultMessage": "Het systeem kon de afspraak niet vinden",
     "description": "Appointment cancellation missing time query string parameter",
     "originalDefault": "Failed to determine the appointment time"
+  },
+  "zkdWYe": {
+    "defaultMessage": "Terug naar de website",
+    "description": "Back to main website link title",
+    "originalDefault": "Return to main website"
   }
 }


### PR DESCRIPTION
Fixes open-formulieren/open-forms#940

Depends on https://github.com/open-formulieren/open-forms/pull/1005

---

A plain link was quite ugly, so decided on a button in the bottom right (sticking to the user flow of starting top-left going to bottom-right).

The button is only displayed if:

* form is configured to display it
* there is no payment required - if payment is required you want people to enter that flow

![image](https://user-images.githubusercontent.com/5518550/155977768-99124dd3-c702-4371-9cb0-33eb07296a9e.png)

**checkbox on full completion**

![image](https://user-images.githubusercontent.com/5518550/155979061-4b4b64e4-a89a-4011-95ca-491ded8797dc.png)
