### PR TITLE
Make SDK CSRF header capable

### DIFF
--- a/src/csrf.js
+++ b/src/csrf.js
@@ -1,0 +1,17 @@
+/**
+ * Global module-scoped variable to track the value of the CSRF Token.
+ *
+ * Embedders can set the CSRF Token value, which allows admin users to be recognized
+ * so they can use demo auth plugins (as one use case example).
+ *
+ * The Open Forms SDK includes the value of the CSRF Token as a header in fetch api
+ * calls if it's set.
+ */
+
+let CSRFToken = null;
+
+const setCSRFToken = (value) => CSRFToken = value;
+
+const getCSRFToken = () => CSRFToken;
+
+export {getCSRFToken, setCSRFToken};

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -16,6 +16,7 @@ import { get } from 'api';
 import { ConfigContext, FormioTranslations } from 'Context';
 import App from 'components/App';
 import {setCSPNonce} from 'csp';
+import {setCSRFToken} from 'csrf';
 import { AddFetchAuth } from 'formio/plugins';
 import {fixIconUrls as fixLeafletIconUrls} from 'map';
 import {loadLocaleData, loadFormioTranslations} from 'i18n';
@@ -120,3 +121,4 @@ class OpenForm {
 export default OpenForm;
 export { ANALYTICS_PROVIDERS } from 'hooks/usePageViews';
 export { OpenForm, Formio, Templates, OFLibrary, OpenFormsModule };
+export { setCSRFToken };


### PR DESCRIPTION
Fixes open-formulieren/open-forms#1410

This change makes it so:

1. Embedding pages can set the CSRF token needed for Open Forms (undocumented API)
2. If a CSRF token value is set, it is included as a request header

The DRF machinery in the backend requires the `SessionAuthentication` backend to be added to be able to recognize admin users (= users logged in to the Django admin of the backend). This in turns activates CSRF protection. The SDK is already configured to send cookies (required for the end user sessions), so the CSRF cookie - if set - is sent to the backend.

The AJAX calls need to send this token as a header (since POST bodies are JSON and not regular form-encoded data). Finally, we expose the control so the Open Forms backend (which embeds the SDK) can actually set the correct value, as only this backend is aware of the token for a given authenticated user.