### PR TITLE
[#1452] Enabled remote validators for PhoneNumberField

### DIFF
--- a/src/formio/components/PhoneNumberField.js
+++ b/src/formio/components/PhoneNumberField.js
@@ -1,5 +1,6 @@
 import {Formio} from "formiojs";
 import {applyPrefix} from "../utils";
+import enableValidationPlugins from "../validators/plugins";
 
 const PhoneNumber = Formio.Components.components.phoneNumber;
 
@@ -30,6 +31,7 @@ class PhoneNumberField extends PhoneNumber {
       super(component, options, data);
       this.validator.validators.phoneNumber = PhoneNumberValidator;
       this.validators.push("phoneNumber");
+      enableValidationPlugins(this);
     }
 
     get inputInfo() {

--- a/src/formio/components/PhoneNumberField.js
+++ b/src/formio/components/PhoneNumberField.js
@@ -40,6 +40,10 @@ class PhoneNumberField extends PhoneNumber {
       info.attr.class = applyPrefix('input');
       return info;
     }
+
+  checkComponentValidity(data, dirty, row, options = {}){
+    return super.checkComponentValidity(data, dirty, row, {...options, async: true});
+  }
 }
 
 export default PhoneNumberField;

--- a/src/formio/validators/plugins.js
+++ b/src/formio/validators/plugins.js
@@ -4,13 +4,17 @@ const errorMessageMap = {
   'kvk-kvkNumber': 'Invalid Kvk Number',
   'kvk-rsin': 'Invalid RSIN',
   'kvk-branchNumber': 'Invalid Branch Number',
+  'phonenumber-international': 'Invalid international phonenumber',
+  'phonenumber-nl': 'Invalid Dutch phonenumber',
 };
 
 
 const pluginAPIValidator = (plugin) => {
-  const defaultMsg = errorMessageMap[plugin];
+  let defaultMsg = errorMessageMap[plugin];
   // catches undefined too
-  if (defaultMsg == null) return null;
+  if (defaultMsg == null) {
+    defaultMsg = "Invalid";
+  }
 
   return {
     key: `validate.${plugin}`,


### PR DESCRIPTION
Attempt at running the SDK part of https://github.com/open-formulieren/open-forms/issues/1452

There seems to be an issue where the invalidation error message doesn't show up in the form even though the API response with an invalidation response.

Backend PR: https://github.com/open-formulieren/open-forms/pull/1457#partial-pull-merging