### PR TITLE
[Draft] :bug: Fix auto login redirect for embedded forms

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -110,7 +110,6 @@ const reducer = (draft, action) => {
  */
  const Form = ({ form }) => {
   const history = useHistory();
-  const shouldAutomaticallyRedirect = useAutomaticRedirect(form);
   const queryParams = useQuery();
   usePageViews();
   const intl = useIntl();
@@ -122,6 +121,8 @@ const reducer = (draft, action) => {
   // load the state management/reducer
   const initialStateFromProps = {...initialState, config, step: steps[0]};
   const [state, dispatch] = useImmerReducer(reducer, initialStateFromProps);
+
+  const shouldAutomaticallyRedirect = useAutomaticRedirect(form, config.nextUrl, !!state.submission);
 
   const onSubmissionLoaded = (submission, next='') => {
     if (sessionExpired) return;

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -26,8 +26,8 @@ const isLastStep = (currentStepIndex, submission) => {
 };
 
 
-const getLoginUrl = (loginOption) => {
-  const nextUrl = new URL(window.location.href);
+const getLoginUrl = (loginOption, next=null) => {
+  const nextUrl = next || new URL(window.location.href);
 
   const queryParams = Array.from(nextUrl.searchParams.keys());
   queryParams.map(param => nextUrl.searchParams.delete(param));
@@ -42,7 +42,7 @@ const getLoginUrl = (loginOption) => {
 };
 
 
-const getLoginRedirectUrl = (form) => {
+const getLoginRedirectUrl = (form, nextUrl) => {
   // Automatically redirect the user to a specific login option (if configured)
   if(form.autoLoginAuthenticationBackend) {
     let autoLoginOption = form.loginOptions.find(
@@ -50,7 +50,7 @@ const getLoginRedirectUrl = (form) => {
     );
 
     if(autoLoginOption) {
-      return getLoginUrl(autoLoginOption);
+      return getLoginUrl(autoLoginOption, nextUrl);
     }
   }
 }

--- a/src/hooks/useAutomaticRedirect.js
+++ b/src/hooks/useAutomaticRedirect.js
@@ -4,11 +4,11 @@ import useStartSubmission from './useStartSubmission';
 import {getLoginRedirectUrl} from 'components/utils';
 
 
-const useAutomaticRedirect = (form) => {
-  const autoRedirectUrl = getLoginRedirectUrl(form);
+const useAutomaticRedirect = (form, nextUrl, submissionExists) => {
+  const autoRedirectUrl = getLoginRedirectUrl(form, nextUrl);
   const doStart = useStartSubmission();
 
-  const shouldAutomaticallyRedirect = !doStart && autoRedirectUrl;
+  const shouldAutomaticallyRedirect = !submissionExists && !doStart && autoRedirectUrl;
 
   useEffect(() => {
     if (shouldAutomaticallyRedirect) {

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -104,7 +104,7 @@ class OpenForm {
     ReactDOM.render(
       <React.StrictMode>
         <IntlProvider messages={messages} locale={lang} defaultLocale="nl">
-          <ConfigContext.Provider value={{baseUrl: this.baseUrl}}>
+          <ConfigContext.Provider value={{baseUrl: this.baseUrl, nextUrl: new URL(window.location.href)}}>
             <FormioTranslations.Provider value={{i18n: translations, language: lang}}>
               <Router basename={this.basePath}>
                 <App form={this.formObject} />


### PR DESCRIPTION
The automatic redirect to login doesn't seem to work for embedded forms. This is caused by the fact that the `next` url to which the user should be redirected after login is now determined later (I think? I'm not really sure how these hooks work. In my initial pull request, `getLoginUrl` was called in `sdk.js`, now this happens in `Form.js`).

Locally for instance, when embedding a form `bezwaar-maken` on path `/`, I would be redirected to `/bezwaar-maken/?_start=1`, which will simply return a 404, because this path doesn't exist.