### PR TITLE
Ensure that for local dev we get CSRF tokens

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { OpenForm } from './sdk';
+import { OpenForm, setCSRFToken } from './sdk';
 import './index.scss';
 
 const {REACT_APP_BASE_API_URL, REACT_APP_FORM_ID} = process.env;
@@ -6,10 +6,38 @@ const {REACT_APP_BASE_API_URL, REACT_APP_FORM_ID} = process.env;
 window.onload = () => {
     const formId = (new URLSearchParams(document.location.search)).get('form');
     const targetNode = document.getElementById('root');
-    const form = new OpenForm(targetNode, {
-        baseUrl: REACT_APP_BASE_API_URL,
-        formId: formId || REACT_APP_FORM_ID,
-        basePath: '/',
+    extractAndSetCSRFToken().then(() => {
+      const form = new OpenForm(targetNode, {
+          baseUrl: REACT_APP_BASE_API_URL,
+          formId: formId || REACT_APP_FORM_ID,
+          basePath: '/',
+      });
+      form.init();
     });
-    form.init();
+};
+
+
+// development only (with CRA SPA) - grab the admin login page and extract the CSRF token
+// from the DOM
+const extractAndSetCSRFToken = () => {
+  const loginUrl = `${REACT_APP_BASE_API_URL}../../admin/login/`;
+  return window.fetch(loginUrl, {credentials: 'include'})
+    .then(response => {
+      if (response.url.endsWith('/admin/')) {
+        // already logged in, grab the token from another page
+        const passwordResetUrl = `${REACT_APP_BASE_API_URL}../../admin/password_change/`;
+        return window
+          .fetch(passwordResetUrl, {credentials: 'include'})
+          .then(response => response.text());
+      }
+      else {
+        return response.text();
+      }
+    })
+    .then(html => {
+      const parser = new DOMParser();
+      const htmlDoc = parser.parseFromString(html, 'text/html');
+      const hiddenInput = htmlDoc.querySelector('[name="csrfmiddlewaretoken"]');
+      hiddenInput && setCSRFToken(hiddenInput.value);
+    });
 };


### PR DESCRIPTION
If we are logged in to the admin in the same browser as debugging the
SDK with CRA, then we obtain the CSRF Token from some admin pages
which are enforced when logged in as admin user by the API.

This removes the need to use an incognito window or different browser
to develop backend/frontend at the same time.