### PR TITLE
Do not give the illusion that the login button icon is a button

### DIFF
--- a/src/components/LoginButton/LoginButtonIcon.js
+++ b/src/components/LoginButton/LoginButtonIcon.js
@@ -3,6 +3,16 @@ import PropTypes from 'prop-types';
 
 import Button from 'components/Button';
 
+// FIXME: this really should not be a <input type="image" />, it completely violates
+// the semantics and expectations of how it should be used: as an actual form submit
+// button styled with an image.
+//
+// This should be a regular anchor with a href that opens in a new window/tab,
+// having the icon/logo as graphical representation as it is contextual.
+//
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/image does not even
+// document the href attribute.
+
 const LoginButtonIcon = ({ identifier, logo: { href, imageSrc } }) => (
   <Button
     variant="image"
@@ -11,6 +21,7 @@ const LoginButtonIcon = ({ identifier, logo: { href, imageSrc } }) => (
     href={href}
     src={imageSrc}
     key={identifier}
+    onClick={() => window.open(href, '_blank', 'noopener,noreferrer')}
   />
 );
 

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -82,6 +82,7 @@ $button-padding-h: $grid-margin-2;
     @include rows(1);
     border: none;
     padding: 0;
+    cursor: default;
   }
 
   .fa-icon:not(:last-child) {


### PR DESCRIPTION
Fixes open-formulieren/open-forms#1523

The cursor is now the default instead of pointer, and if you do click
the icon, the referenced href is opened in a new tab instead.