### PR TITLE
[OF#1533] Infinite redirects

### DIFF
--- a/src/Context.js
+++ b/src/Context.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const ConfigContext = React.createContext({baseUrl: ''});
+const ConfigContext = React.createContext({baseUrl: '', basePath: ''});
 ConfigContext.displayName = 'ConfigContext';
 
 const FormioTranslations = React.createContext({i18n: {}, language: ''});

--- a/src/hooks/useAutomaticRedirect.js
+++ b/src/hooks/useAutomaticRedirect.js
@@ -1,20 +1,32 @@
-import {useEffect} from 'react';
+import {useContext, useEffect} from 'react';
+import {useLocation} from 'react-router-dom';
 
 import useStartSubmission from './useStartSubmission';
 import {getLoginRedirectUrl} from 'components/utils';
+import {ConfigContext} from '../Context';
 
 
 const useAutomaticRedirect = (form) => {
+  const location = useLocation();
+  const {basePath} = useContext(ConfigContext);
+
+  // In basePath, the end / is stripped
+  let pathname = location.pathname;
+  if (pathname.endsWith('/')) {
+    pathname = pathname.slice(0, pathname.length - 1);
+  }
+
+  const isStartPage = pathname === basePath;
   const autoRedirectUrl = getLoginRedirectUrl(form);
   const doStart = useStartSubmission();
 
-  const shouldAutomaticallyRedirect = !doStart && autoRedirectUrl;
+  const shouldAutomaticallyRedirect = isStartPage && !doStart && autoRedirectUrl;
 
   useEffect(() => {
     if (shouldAutomaticallyRedirect) {
       window.location = autoRedirectUrl;
     }
-  }, [shouldAutomaticallyRedirect, autoRedirectUrl])
+  }, [shouldAutomaticallyRedirect, autoRedirectUrl]);
 
   return shouldAutomaticallyRedirect;
 };

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -104,7 +104,7 @@ class OpenForm {
     ReactDOM.render(
       <React.StrictMode>
         <IntlProvider messages={messages} locale={lang} defaultLocale="nl">
-          <ConfigContext.Provider value={{baseUrl: this.baseUrl}}>
+          <ConfigContext.Provider value={{baseUrl: this.baseUrl, basePath: this.basePath}}>
             <FormioTranslations.Provider value={{i18n: translations, language: lang}}>
               <Router basename={this.basePath}>
                 <App form={this.formObject} />


### PR DESCRIPTION
Fixes open-formulieren/open-forms#1533

The problem was that the hook `useAutomaticRedirect` was not checking the current location. So on any pathname without the `_start=1` queryparam it was redirecting to login. 