### PR TITLE
Sort out summary rendering

### DIFF
--- a/src/components/FormStepSummary/ComponentValueDisplay.js
+++ b/src/components/FormStepSummary/ComponentValueDisplay.js
@@ -18,12 +18,6 @@ import {getFormattedDateString, getFormattedTimeString} from 'utils';
 import {humanFileSize} from './utils';
 
 
-// const EmptyDisplay = () => (
-//   <FormattedMessage
-//     description="Value display for empty value"
-//     defaultMessage="(empty)"
-//   />
-// );
 const EmptyDisplay = () => '';
 
 const DefaultDisplay = ({component, value}) => {

--- a/src/components/FormStepSummary/fixtures.js
+++ b/src/components/FormStepSummary/fixtures.js
@@ -14,7 +14,7 @@ export const testStepDataEmptyDate = {
     "dateOfBirth": ""
   },
   "configuration": {
-    "components": [
+    "flattenedComponents": [
       {
         "id": "em3xsol",
         "key": "dateOfBirth",
@@ -45,7 +45,7 @@ export const testStepDataSelectMultivalue = {
     "selectPets": ["dog", "fish"]
   },
   "configuration": {
-    "components": [
+    "flattenedComponents": [
       {
         "id": "em3xsol",
         "key": "selectPets",
@@ -96,7 +96,7 @@ export const testStepEmptyFields = {
     "uploadFile": []
   },
   "configuration": {
-    "components": [
+    "flattenedComponents": [
       {
         "id": "em3xsol",
         "key": "amountToPay",
@@ -179,52 +179,6 @@ export const testStepEmptyFields = {
         "input": true,
         "multiple": false,
         "label": "Select field",
-        "data": {
-          "value": undefined,
-        }
-      }
-    ]
-  }
-};
-
-export const testStepHiddenFields = {
-  "submissionStep": {
-    "id": "31bd9fc8-57b7-4b32-bae7-a0b6d8c076cc",
-    "name": "Details",
-    "url": "http://testserver.nl/api/v1/submissions/774db9fc-1c0f-42ef-a7f7-b96d8c7d5905/steps/31bd9fc8-57b7-4b32-bae7-a0b6d8c076cc",
-    "formStep": "http://testserver.nl/api/v1/forms/3ef4c822-c6c7-496d-99d6-897c1d1c1219/steps/31bd9fc8-57b7-4b32-bae7-a0b6d8c076cc",
-    "isApplicable": true,
-    "completed": true,
-    "optional": false,
-    "canSubmit": true
-  },
-  "title": "Test hidden fields",
-  "data": {
-    "visibleField": "Some data",
-    "hiddenField": ""
-  },
-  "configuration": {
-    "components": [
-      {
-        "id": "em3xsol",
-        "key": "visibleField",
-        "type": "textfield",
-        "input": true,
-        "multiple": false,
-        "label": "Visible field",
-        "hidden": false,
-        "data": {
-          "value": undefined,
-        }
-      },
-      {
-        "id": "em3xsal",
-        "key": "hiddenField",
-        "type": "textfield",
-        "input": true,
-        "multiple": false,
-        "hidden": true,
-        "label": "Hidden field",
         "data": {
           "value": undefined,
         }

--- a/src/components/FormStepSummary/fixtures.js
+++ b/src/components/FormStepSummary/fixtures.js
@@ -240,3 +240,45 @@ export const testStepColumns = {
     ])
   }
 };
+
+export const testStepHiddenFieldsetHeader = {
+  "submissionStep": {
+    "id": "31bd9fc8-57b7-4b32-bae7-a0b6d8c076cc",
+    "name": "Details",
+    "url": "http://testserver.nl/api/v1/submissions/774db9fc-1c0f-42ef-a7f7-b96d8c7d5905/steps/31bd9fc8-57b7-4b32-bae7-a0b6d8c076cc",
+    "formStep": "http://testserver.nl/api/v1/forms/3ef4c822-c6c7-496d-99d6-897c1d1c1219/steps/31bd9fc8-57b7-4b32-bae7-a0b6d8c076cc",
+    "isApplicable": true,
+    "completed": true,
+    "optional": false,
+    "canSubmit": true
+  },
+  "title": "Test empty upload file field",
+  "data": {
+    "input1": "First input",
+    "input2": "Second input",
+  },
+  "configuration": {
+    "flattenedComponents": getSummaryComponents([
+      {
+        key: 'fieldset',
+        type: 'fieldset',
+        label: 'Fieldset',
+        hideHeader: true,
+        components: [
+          {
+            key: 'input1',
+            type: 'textfield',
+            label: 'Input 1',
+            input: true,
+          },
+          {
+            key: 'input2',
+            type: 'textfield',
+            label: 'Input 2',
+            input: true,
+          }
+        ]
+      }
+    ])
+  }
+};

--- a/src/components/FormStepSummary/fixtures.js
+++ b/src/components/FormStepSummary/fixtures.js
@@ -1,3 +1,5 @@
+import {getSummaryComponents} from 'components/Summary/utils';
+
 export const testStepDataEmptyDate = {
   "submissionStep": {
     "id": "31bd9fc8-57b7-4b32-bae7-a0b6d8c076cc",
@@ -184,5 +186,57 @@ export const testStepEmptyFields = {
         }
       }
     ]
+  }
+};
+
+
+export const testStepColumns = {
+  "submissionStep": {
+    "id": "31bd9fc8-57b7-4b32-bae7-a0b6d8c076cc",
+    "name": "Details",
+    "url": "http://testserver.nl/api/v1/submissions/774db9fc-1c0f-42ef-a7f7-b96d8c7d5905/steps/31bd9fc8-57b7-4b32-bae7-a0b6d8c076cc",
+    "formStep": "http://testserver.nl/api/v1/forms/3ef4c822-c6c7-496d-99d6-897c1d1c1219/steps/31bd9fc8-57b7-4b32-bae7-a0b6d8c076cc",
+    "isApplicable": true,
+    "completed": true,
+    "optional": false,
+    "canSubmit": true
+  },
+  "title": "Test empty upload file field",
+  "data": {
+    "input1": "First input",
+    "input2": "Second input",
+  },
+  "configuration": {
+    "flattenedComponents": getSummaryComponents([
+      {
+        key: 'columns',
+        type: 'columns',
+        label: 'Columns',
+        columns: [
+          {
+            size: 6,
+            components: [
+              {
+                key: 'input1',
+                type: 'textfield',
+                label: 'Input 1',
+                input: true,
+              }
+            ]
+          },
+          {
+            size: 6,
+            components: [
+              {
+                key: 'input2',
+                type: 'textfield',
+                label: 'Input 2',
+                input: true,
+              }
+            ]
+          }
+        ]
+      }
+    ])
   }
 };

--- a/src/components/FormStepSummary/index.js
+++ b/src/components/FormStepSummary/index.js
@@ -12,6 +12,27 @@ import {getComponentLabel, iterComponentsWithData} from 'components/FormStepSumm
 import ComponentValueDisplay from './ComponentValueDisplay';
 
 
+const SummaryTableRow = ({ component }) => {
+  const label = getComponentLabel(component);
+  if (!label && !component.value) return null;
+
+  const {type} = component;
+  const className = getBEMClassName('summary-row', [type]);
+  return (
+    <TableRow className={className}>
+      <TableHead>{label}</TableHead>
+      <TableCell>
+        <ComponentValueDisplay component={component} />
+      </TableCell>
+    </TableRow>
+  );
+};
+
+SummaryTableRow.propTypes = {
+  component: PropTypes.object.isRequired,
+};
+
+
 const FormStepSummary = ({stepData, editStepUrl, editStepText}) => {
   const history = useHistory();
   return (
@@ -44,20 +65,9 @@ const FormStepSummary = ({stepData, editStepUrl, editStepText}) => {
           * Note that the `components` must already be flattened and non-summary display
           * components removed.
           */
-          iterComponentsWithData(stepData.configuration.flattenedComponents, stepData.data).map((component) => {
-            const {key, type} = component;
-            const className = getBEMClassName('summary-row', [type]);
-            return (
-              <TableRow key={key} className={className}>
-                <TableHead>
-                  {getComponentLabel(component)}
-                </TableHead>
-                <TableCell>
-                  <ComponentValueDisplay component={component} />
-                </TableCell>
-              </TableRow>
-            );
-          })
+          iterComponentsWithData(stepData.configuration.flattenedComponents, stepData.data).map((component) => (
+            <SummaryTableRow component={component} key={`${component.key}-${component.id}`} />
+          ))
         }
       </Table>
 

--- a/src/components/FormStepSummary/index.js
+++ b/src/components/FormStepSummary/index.js
@@ -7,7 +7,7 @@ import Caption from 'components/Caption';
 import { Table, TableRow, TableHead, TableCell } from 'components/Table';
 import { Toolbar, ToolbarList } from 'components/Toolbar';
 import {getBEMClassName} from 'utils';
-import {getComponentLabel, iterVisibleComponentsWithData} from 'components/FormStepSummary/utils';
+import {getComponentLabel, iterComponentsWithData} from 'components/FormStepSummary/utils';
 
 import ComponentValueDisplay from './ComponentValueDisplay';
 
@@ -41,9 +41,10 @@ const FormStepSummary = ({stepData, editStepUrl, editStepText}) => {
           * Loop through each (not hidden) field in the step
           * stepData contains 4 things.
           * title (string), submissionStep (object), data (object), configuration (object)
-          * Note that the `components` should already be flattened!
+          * Note that the `components` must already be flattened and non-summary display
+          * components removed.
           */
-          iterVisibleComponentsWithData(stepData.configuration.components, stepData.data).map((component) => {
+          iterComponentsWithData(stepData.configuration.flattenedComponents, stepData.data).map((component) => {
             const {key, type} = component;
             const className = getBEMClassName('summary-row', [type]);
             return (

--- a/src/components/FormStepSummary/test.spec.js
+++ b/src/components/FormStepSummary/test.spec.js
@@ -9,6 +9,7 @@ import {
   testStepDataEmptyDate,
   testStepDataSelectMultivalue,
   testStepEmptyFields,
+  testStepColumns,
 } from './fixtures';
 
 
@@ -95,4 +96,28 @@ it('Empty fields', () => {
   for (const emptyValue of emptyValues) {
     expect(emptyValue.textContent).toEqual('');
   }
+});
+
+it('Columns without labels are not rendered', () => {
+  act(() => {
+    render(
+      <IntlProvider
+        locale="nl"
+        messages={messagesNL}
+      >
+        <FormStepSummary
+          stepData={testStepColumns}
+          editStepUrl="http://test-url.nl"
+          editStepText="Change"
+        />
+      </IntlProvider>,
+      container
+    );
+  });
+
+  const tableRows = container.getElementsByClassName('openforms-table__row');
+
+  expect(tableRows.length).toEqual(2);
+  expect(tableRows[0].querySelector('.openforms-table__head').textContent).toEqual('Input 1');
+  expect(tableRows[1].querySelector('.openforms-table__head').textContent).toEqual('Input 2');
 });

--- a/src/components/FormStepSummary/test.spec.js
+++ b/src/components/FormStepSummary/test.spec.js
@@ -8,7 +8,7 @@ import messagesNL from 'i18n/compiled/nl.json';
 import {
   testStepDataEmptyDate,
   testStepDataSelectMultivalue,
-  testStepEmptyFields, testStepHiddenFields,
+  testStepEmptyFields,
 } from './fixtures';
 
 
@@ -95,27 +95,4 @@ it('Empty fields', () => {
   for (const emptyValue of emptyValues) {
     expect(emptyValue.textContent).toEqual('');
   }
-});
-
-it('Hidden fields not shown', () => {
-  act(() => {
-    render(
-      <IntlProvider
-        locale="nl"
-        messages={messagesNL}
-      >
-        <FormStepSummary
-          stepData={testStepHiddenFields}
-          editStepUrl="http://test-url.nl"
-          editStepText="Change"
-        />
-      </IntlProvider>,
-      container
-    );
-  });
-
-  const fieldsShown = container.getElementsByClassName("openforms-table__head");
-
-  expect(fieldsShown.length).toEqual(1);
-  expect(fieldsShown[0].textContent).toEqual('Visible field');
 });

--- a/src/components/FormStepSummary/test.spec.js
+++ b/src/components/FormStepSummary/test.spec.js
@@ -10,6 +10,7 @@ import {
   testStepDataSelectMultivalue,
   testStepEmptyFields,
   testStepColumns,
+  testStepHiddenFieldsetHeader,
 } from './fixtures';
 
 
@@ -107,6 +108,30 @@ it('Columns without labels are not rendered', () => {
       >
         <FormStepSummary
           stepData={testStepColumns}
+          editStepUrl="http://test-url.nl"
+          editStepText="Change"
+        />
+      </IntlProvider>,
+      container
+    );
+  });
+
+  const tableRows = container.getElementsByClassName('openforms-table__row');
+
+  expect(tableRows.length).toEqual(2);
+  expect(tableRows[0].querySelector('.openforms-table__head').textContent).toEqual('Input 1');
+  expect(tableRows[1].querySelector('.openforms-table__head').textContent).toEqual('Input 2');
+});
+
+it('Columns without labels are not rendered', () => {
+  act(() => {
+    render(
+      <IntlProvider
+        locale="nl"
+        messages={messagesNL}
+      >
+        <FormStepSummary
+          stepData={testStepHiddenFieldsetHeader}
           editStepUrl="http://test-url.nl"
           editStepText="Change"
         />

--- a/src/components/FormStepSummary/utils.js
+++ b/src/components/FormStepSummary/utils.js
@@ -1,7 +1,7 @@
-const iterVisibleComponentsWithData = (components, data) => {
+const iterComponentsWithData = (components, data) => {
   // Iterate over (pre-flattened) components and return key/values
-  // Often used in combination with flattenComponents and getComponentLabel/getComponentValue
-  return components.filter(component => !component.hidden).map(component => ({
+  // Use in combination with getSummaryComponents and getComponentLabel
+  return components.map(component => ({
     ...component,
     value: data[component.key],
   }));
@@ -19,6 +19,9 @@ const getComponentLabel = (component) => {
   switch (type) {
     case 'fieldset' : {
       return (<strong>{label}</strong>);
+    }
+    case 'columns': {
+      return '';
     }
     default:
       return label;
@@ -42,4 +45,4 @@ const humanFileSize = (size) => {
   return {size: newSize, unit};
 };
 
-export {iterVisibleComponentsWithData, getComponentLabel, humanFileSize};
+export {iterComponentsWithData, getComponentLabel, humanFileSize};

--- a/src/components/FormStepSummary/utils.js
+++ b/src/components/FormStepSummary/utils.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 const iterComponentsWithData = (components, data) => {
   // Iterate over (pre-flattened) components and return key/values
   // Use in combination with getSummaryComponents and getComponentLabel
@@ -18,6 +20,7 @@ const getComponentLabel = (component) => {
 
   switch (type) {
     case 'fieldset' : {
+      if (component.hideHeader) return '';
       return (<strong>{label}</strong>);
     }
     case 'columns': {

--- a/src/components/Summary/index.js
+++ b/src/components/Summary/index.js
@@ -16,9 +16,10 @@ import {findPreviousApplicableStep} from 'components/utils';
 import {SubmissionContext} from 'Context';
 import useRefreshSubmission from 'hooks/useRefreshSubmission';
 import Types from 'types';
-import { flattenComponents } from 'utils';
 import SummaryConfirmation from 'components/SummaryConfirmation';
 import {SUBMISSION_ALLOWED} from 'components/constants';
+
+import {getSummaryComponents} from './utils';
 
 
 const PRIVACY_POLICY_ENDPOINT = '/api/v1/config/privacy_policy_info';
@@ -60,7 +61,7 @@ const loadStepsData = async (submission) => {
       return {submissionStep: submissionStep};
     }
 
-    submissionStepDetail.formStep.configuration.components = flattenComponents(
+    submissionStepDetail.formStep.configuration.flattenedComponents = getSummaryComponents(
       submissionStepDetail.formStep.configuration.components
     );
 

--- a/src/components/Summary/utils.js
+++ b/src/components/Summary/utils.js
@@ -1,0 +1,66 @@
+import FormioUtils from 'formiojs/utils';
+
+const shouldDisplayComponent = (component) => {
+  // hidden components are never shown
+  if (component.hidden) return false;
+
+  // non-layout components depend on their configured properties and/or defaults
+  if ( !FormioUtils.isLayoutComponent(component) ) {
+    // otherwise, check what's configured in the form designer (if nothing, default
+    // to displaying it)
+    return component.showInSummary ?? true;
+  }
+
+  // layout component - only visible if the children are visible!
+  const children = getComponentChildren(component);
+  const visibleChildren = children.filter(child => shouldDisplayComponent(child));
+  return visibleChildren.length > 0;
+};
+
+
+// taken/modified from FormioUtils.eachComponent
+const getComponentChildren = (component) => {
+  const hasColumns = component.columns && Array.isArray(component.columns);
+  const hasRows = component.rows && Array.isArray(component.rows);
+  const hasComps = component.components && Array.isArray(component.components);
+
+  let children = [];
+  if (hasColumns) {
+    component.columns.forEach((column) => {
+      children = children.concat(column.components)
+    });
+  }
+
+  else if (hasRows) {
+    component.rows.forEach((row) => {
+      if (Array.isArray(row)) {
+        row.forEach((column) => {
+          children = children.concat(column.components)
+        });
+      }
+    });
+  }
+
+  else if (hasComps) {
+    children = children.concat(component.components);
+  }
+
+  return children;
+};
+
+
+export const getSummaryComponents = (components) => {
+  let flattenedComponents = [];
+
+  FormioUtils.eachComponent(components, (component) => {
+    // if it's not a layout component, add it directly to the list
+    if (!shouldDisplayComponent(component)) return;
+
+    flattenedComponents.push(component);
+    const children = getComponentChildren(component);
+    flattenedComponents = flattenedComponents.concat(getSummaryComponents(children));
+    return true; // no recursing, we do that ourselves
+  }, true);
+
+  return flattenedComponents;
+};

--- a/src/components/Summary/utils.spec.js
+++ b/src/components/Summary/utils.spec.js
@@ -1,0 +1,99 @@
+import {getSummaryComponents} from './utils';
+
+test('getSummaryComponents should filter out hidden components', () => {
+
+  const components = [
+    {
+      "id": "em3xsol",
+      "key": "visibleField",
+      "type": "textfield",
+      "input": true,
+      "multiple": false,
+      "label": "Visible field",
+      "hidden": false,
+      "data": {
+        "value": undefined,
+      }
+    },
+    {
+      "id": "em3xsal",
+      "key": "hiddenField",
+      "type": "textfield",
+      "input": true,
+      "multiple": false,
+      "hidden": true,
+      "label": "Hidden field",
+      "data": {
+        "value": undefined,
+      }
+    }
+  ];
+
+  const summaryComponents = getSummaryComponents(components);
+
+  expect(summaryComponents.length).toEqual(1);
+  expect(summaryComponents[0].key).toEqual('visibleField');
+
+});
+
+describe('getSummaryComponents with nested components', () => {
+  it('should not show without children', () => {
+    const components = [{
+      type: 'fieldset',
+      key: 'fieldset',
+      components: [],
+    }];
+
+    const summaryComponents = getSummaryComponents(components);
+
+    expect(summaryComponents.length).toEqual(0);
+  });
+
+  it('should not show with hidden children', () => {
+    const components = [{
+      type: 'fieldset',
+      key: 'fieldset',
+      components: [
+        {
+          "id": "em3xsal",
+          "key": "hiddenField",
+          "type": "textfield",
+          "input": true,
+          "multiple": false,
+          "hidden": true,
+          "label": "Hidden field",
+        },
+      ],
+    }];
+
+    const summaryComponents = getSummaryComponents(components);
+
+    expect(summaryComponents.length).toEqual(0);
+  });
+
+  it('should show with visible children', () => {
+    const components = [{
+      type: 'fieldset',
+      key: 'fieldset',
+      label: 'A fieldset',
+      components: [
+        {
+          "id": "em3xsal",
+          "key": "visibleField",
+          "type": "textfield",
+          "input": true,
+          "multiple": false,
+          "hidden": false,
+          "label": "Visible field",
+        },
+      ],
+    }];
+
+    const summaryComponents = getSummaryComponents(components);
+
+    expect(summaryComponents.length).toEqual(2);
+    expect(summaryComponents[0].label).toEqual('A fieldset');
+    expect(summaryComponents[1].label).toEqual('Visible field');
+  });
+
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,26 +22,5 @@ export const getBEMClassName = (base, modifiers=[]) => {
 };
 
 
-export const flattenComponents = (components) => {
-  const flattenedComponents = components.map(component => {
-    if(component.components) {
-      return [component].concat(flattenComponents(component.components));
-    } else if (component.columns) {
-      const flattenedColumnComponents =  component.columns.map(column => {
-        return [].concat(flattenComponents(column.components));
-      });
-      // Convert an array of arrays (one array per column) to a single array
-      return [].concat.apply([], flattenedColumnComponents);
-    }
-    else {
-      return [component];
-    }
-  });
-
-  // Convert an array of arrays to a single array
-  return [].concat.apply([], flattenedComponents);
-};
-
-
 // usage: await sleep(3000);
 export const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
Related to open-formulieren/open-forms#1451

Mimicks the backend implementation with the renderer:

* Do not display column labels, ever
* Only display container elements if visible and has visible children
* Respect the component `showInSummary` config from form builder