### PR TITLE
Add NLDS component for button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # developers
 .vscode/
+.idea/
 /env/
 
 # dependencies

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
   ],
   "devDependencies": {
     "@formatjs/cli": "^4.2.33",
+    "@gemeente-denhaag/components-css": "^0.1.1-alpha.168",
     "babel-plugin-formatjs": "^10.3.8",
     "react-test-renderer": "^17.0.2",
     "typescript": "^4.4.3",

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -1,130 +1,13 @@
 @use "sass:math";
 
 @import '~microscope-sass/lib/grid';
-@import '~microscope-sass/lib/typography';
 
 @import '../mixins/bem';
 @import '../mixins/prefix';
 
-$button-line-height: $typography-line-height-text-big * $typography-font-size-text-big;
-$button-line-height-px: math.div($button-line-height, ($button-line-height * 0 + 1)) * 16px;
-$button-padding-v: math.div(($grid-row-height - $button-line-height-px), 2) - $typography-size-border;
-$button-padding-h: $grid-margin-2;
-
-@mixin button-theme(
-  $name,
-  $color,
-  $color-background,
-  $color-border: var(--of-color-bg),
-  $decorate-on-hover: false,
-  $color-background-hover: null,
-  $color-border-hover: null,
-  $color-active: null,
-  $color-background-active: null,
-  $color-border-active: null,
-) {
-  // build the selector either as just the parent or the parent with modifier,
-  // based on the theme name
-  $sel: #{&};
-  @if $name != '' {
-    $sel: "#{&}--#{$name}";
-  }
-  // now output the actual CSS rules
-  @at-root #{$sel} {
-    color: $color;
-    background-color: $color-background;
-    border-right-color: $color-border;
-    border-bottom-color: $color-border;
-
-    &:not([aria-disabled="true"]):hover {
-      @if $color-background-hover {
-        background-color: $color-background-hover;
-      }
-
-      @if $color-border-hover {
-        border-right-color: $color-border-hover;
-        border-bottom-color: $color-border-hover;
-      }
-
-      @if $decorate-on-hover {
-        @include anchor(true);
-      }
-    }
-
-    &:active {
-      @if $color-active {
-        color: $color-active;
-      }
-      @if $color-background-active {
-        background-color: $color-background-active;
-      }
-
-      @if $color-border-active {
-        border-top-color: $color-border-active;
-        border-right-color: transparent;
-        border-left-color: $color-border-active;
-        border-bottom-color: transparent;
-      }
-    }
-  }
-}
-
 .#{prefix(button)} {
-  @include body;
-  @include body--big;
-  @include border(all, $color: transparent, $size: 2px);
-  @include button-theme(
-    '',
-    $typography-color-text,
-    $color-background,
-    $color-border,
-    $color-background-hover: var(--of-button-hover-bg),
-    $color-border-hover: var(--of-button-hover-color-border),
-    $color-active: var(--of-button-active-fg),
-    $color-background-active: var(--of-button-active-bg),
-    $color-border-active: var(--of-button-active-color-border),
-  );
-  @include button-theme(
-    'primary',
-    var(--of-button-primary-fg),
-    var(--of-button-primary-bg),
-    var(--of-button-primary-color-border),
-    $color-background-hover: var(--of-button-primary-hover-bg),
-    $color-border-hover: var(--of-button-primary-hover-color-border),
-    $color-active: var(--of-button-primary-active-fg),
-    $color-background-active: var(--of-button-primary-active-bg),
-    $color-border-active: var(--of-button-primary-active-color-border),
-  );
-  @include button-theme(
-    'anchor',
-    var(--of-button-anchor-fg),
-    var(--of-button-anchor-bg),
-    var(--of-button-anchor-color-border),
-    true,
-    $color-background-hover: var(--of-button-anchor-hover-bg),
-    $color-border-hover: var(--of-button-anchor-hover-color-border),
-    $color-active: var(--of-button-anchor-active-fg),
-    $color-background-active: var(--of-button-anchor-active-bg),
-    $color-border-active: var(--of-button-anchor-active-color-border),
-  );
-  @include button-theme(
-    'danger',
-    var(--of-button-danger-fg),
-    var(--of-button-danger-bg),
-    var(--of-button-danger-color-border),
-    $color-background-hover: var(--of-button-danger-hover-bg),
-    $color-border-hover: var(--of-button-danger-hover-color-border),
-    $color-active: var(--of-button-danger-active-fg),
-    $color-background-active: var(--of-button-danger-active-bg),
-    $color-border-active: var(--of-button-danger-active-color-border),
-  );
+  @extend .denhaag-button;
 
-  appearance: none;
-  border-radius: 0;
-  display: flex;
-  align-items: center;
-  padding: $button-padding-v $button-padding-h;
-  text-decoration: none;
   float: left;
 
   @media print {
@@ -138,18 +21,17 @@ $button-padding-h: $grid-margin-2;
   // styling for disabled button
   &[aria-disabled="true"] {
     cursor: not-allowed;
-    filter: saturate(0);
     opacity: 0.5;
+    filter: saturate(0);
   }
 
   @include modifier('image') {
     @include rows(1);
-    border: none;
     padding: 0;
     cursor: default;
+    border: none;
   }
 
-  .fa-icon:not(:last-child) {
-    margin-right: $button-padding-h;
+  @include modifier('primary') {
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,7 @@
 // Open Forms SDK styles
 // TODO: we should see if we can re-use even smaller bits to shed dead weight and
 // reduce the bundle size
+@use "../node_modules/@gemeente-denhaag/components-css/dist/index.css";
 @import '@fortawesome/fontawesome-free/scss/fontawesome';
 @import '@fortawesome/fontawesome-free/scss/brands';
 @import '@fortawesome/fontawesome-free/scss/regular';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,6 +1578,11 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.1.tgz#bf5d45611ab74890be386712a0e5d998c65ee2a1"
   integrity sha512-J/3yg2AIXc9wznaVqpHVX3Wa5jwKovVF0AMYSnbmcXTiL3PpRPfF58pzWucCwEiCJBp+hCNRLWClTomD8SseKg==
 
+"@gemeente-denhaag/components-css@^0.1.1-alpha.168":
+  version "0.1.1-alpha.168"
+  resolved "https://registry.yarnpkg.com/@gemeente-denhaag/components-css/-/components-css-0.1.1-alpha.168.tgz#9371f4daa69b8cdfd90a4b8925636a7b2c308d4f"
+  integrity sha512-BN93vkPEymiLoCrLJOXsz9Fj5PDUz9Jwbb+3CEG/gyRIttYSxSvSq/DP7+r7zc+4hEdy81nnooM1LMA1flPmOw==
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"


### PR DESCRIPTION
This PR uses the Den Haag CSS to implement design tokens on the Open Forms button. Doing this allows most of the CSS to be deleted in favor of community maintained CSS. I've decided on using Den Haag CSS instead of Utrecht, as The Hague requires icon support in the buttons, and The Hague button is already in use in a few applications. 

This approach extends the `denhaag-button` css on the `openforms-button` selector. Of course we could also change the markup to directly use Den Haag classnames. 

@sergei-maertens what's your thoughts on this approach? In order for this to look properly we'll need to update the Open Forms theme to style the Den Haag button into the original OF theme.

## Results with DH design tokens loaded in
<img width="545" alt="image" src="https://user-images.githubusercontent.com/24610692/171849098-8588503e-3c6e-4b05-ac15-117f13a06fe0.png">
