### PR TITLE
Handle HTTP 403 errors (and others)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "./hooks/*": "./dist/esm/hooks/*",
     "./types/*": "./dist/esm/types/*",
     "./map/*": "./dist/esm/map/*",
+    "./errors": "./dist/esm/errors.js",
     "./sdk": "./dist/esm/sdk.js",
     "./utils": "./dist/esm/utils.js"
   },

--- a/src/api.js
+++ b/src/api.js
@@ -20,7 +20,7 @@ const updateSesionExpiry = (seconds) => {
   // TODO: we can schedule a message to be set if expiry is getting close
 };
 
-const apiCall = async (url, opts, alertOnPermissionDenied=false) => {
+const apiCall = async (url, opts) => {
   const options = { ...fetchDefaults, ...opts };
   if (!options.headers) options.headers = {};
 
@@ -40,12 +40,6 @@ const apiCall = async (url, opts, alertOnPermissionDenied=false) => {
   const sessionExpiry = response.headers.get(SessionExpiresInHeader);
   if (sessionExpiry) {
     updateSesionExpiry(parseInt(sessionExpiry), 10);
-  }
-
-  if (response.status === 403 && alertOnPermissionDenied) {
-    const data = await response.json();
-    alert(data.detail);
-    response.json = () => Promise.resolve(data);
   }
   return response;
 };

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {FormattedMessage} from 'react-intl';
+import { Link } from 'react-router-dom';
 
-import ErrorMessage from 'components/ErrorMessage';
+import Anchor from 'components/Anchor';
+import Body from 'components/Body';
 import Card from 'components/Card';
+import ErrorMessage from 'components/ErrorMessage';
 
 
 const logError = (error, errorInfo) => {
@@ -14,34 +17,93 @@ const logError = (error, errorInfo) => {
 class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { hasError: false };
+    this.state = { hasError: false, error: null };
   }
 
   static getDerivedStateFromError(error) {
-    return { hasError: true };
+    return {
+      hasError: true,
+      error,
+    };
   }
 
   componentDidCatch(error, errorInfo) {
+    // TODO: depending on the error type, send to sentry?
     logError(error, errorInfo);
   }
 
   render() {
-    if (!this.state.hasError) {
-      return this.props.children;
+    const { useCard, children } = this.props;
+    const { hasError, error } = this.state;
+    if (!hasError) {
+      return children;
     }
 
-    const Wrapper = this.props.useCard ? Card : React.Fragment;
-
+    const ErrorComponent = ERROR_TYPE_MAP[error.name] || GenericError;
+    const Wrapper = useCard ? Card : React.Fragment;
     return (
-      <Wrapper title={<FormattedMessage description="Error boundary title" defaultMessage="Oops!" />}>
-        <ErrorMessage>Er ging helaas iets fout!</ErrorMessage>
-      </Wrapper>
+      <ErrorComponent wrapper={Wrapper} error={error} />
     );
   }
 }
 
 ErrorBoundary.propTypes = {
   useCard: PropTypes.bool,
+};
+
+
+const GenericError = ({ wrapper: Wrapper, error }) => (
+  <Wrapper title={<FormattedMessage description="Error boundary title" defaultMessage="Oops!" />}>
+    <ErrorMessage>
+      <FormattedMessage
+        description="Generic error message"
+        defaultMessage="Unfortunately something went wrong!"
+      />
+    </ErrorMessage>
+    {error.detail && <Body>{error.detail}</Body>}
+  </Wrapper>
+);
+
+GenericError.propTypes = {
+  wrapper: PropTypes.elementType.isRequired,
+  error: PropTypes.object, // exception instance
+};
+
+
+const PermissionDeniedError = ({ wrapper: Wrapper, error }) => {
+  return (
+    <Wrapper title={<FormattedMessage
+        description="'Permission denied' error title"
+        defaultMessage="Authentication problem" />}>
+      <ErrorMessage>
+        <FormattedMessage
+          description="Authentication error message"
+          defaultMessage="There was an authentication and/or permission problem."
+        />
+      </ErrorMessage>
+
+      {error.detail && <Body>{error.detail}</Body>}
+
+      <Link to="/" component={Anchor}>
+        <FormattedMessage
+          description="return to form start link after 403"
+          defaultMessage="Back to form start"
+        />
+      </Link>
+
+    </Wrapper>
+  );
+};
+
+PermissionDeniedError.propTypes = {
+  wrapper: PropTypes.elementType.isRequired,
+  error: PropTypes.object, // exception instance
+};
+
+
+// map the type of error to the component to render
+const ERROR_TYPE_MAP = {
+  'PermissionDenied': PermissionDeniedError,
 };
 
 export default ErrorBoundary;

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
 
 import ErrorMessage from 'components/ErrorMessage';
+import Card from 'components/Card';
 
 
 const logError = (error, errorInfo) => {
@@ -27,8 +29,13 @@ class ErrorBoundary extends React.Component {
     if (!this.state.hasError) {
       return this.props.children;
     }
+
+    const Wrapper = this.props.useCard ? Card : React.Fragment;
+
     return (
-      <ErrorMessage>Er ging helaas iets fout!</ErrorMessage>
+      <Wrapper title={<FormattedMessage description="Error boundary title" defaultMessage="Oops!" />}>
+        <ErrorMessage>Er ging helaas iets fout!</ErrorMessage>
+      </Wrapper>
     );
   }
 }

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import ErrorMessage from 'components/ErrorMessage';
 
@@ -31,5 +32,9 @@ class ErrorBoundary extends React.Component {
     );
   }
 }
+
+ErrorBoundary.propTypes = {
+  useCard: PropTypes.bool,
+};
 
 export default ErrorBoundary;

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -258,51 +258,57 @@ const reducer = (draft, action) => {
         <Switch>
 
           <Route exact path="/">
-            <ErrorBoundary>
+            <ErrorBoundary useCard>
               <FormStart form={form} onFormStart={onFormStart} />
             </ErrorBoundary>
           </Route>
 
           <Route exact path="/overzicht">
-            <RequireSession expired={sessionExpired} expiryDate={expiryDate}>
-              <RequireSubmission
-                submission={state.submission}
-                form={form}
-                processingError={state.processingError}
-                onConfirm={onSubmitForm}
-                onLogout={onLogout}
-                component={Summary}
-                onClearProcessingErrors={() => dispatch({type: 'CLEAR_PROCESSING_ERROR'})}
-              />
-            </RequireSession>
+            <ErrorBoundary useCard>
+              <RequireSession expired={sessionExpired} expiryDate={expiryDate}>
+                <RequireSubmission
+                  submission={state.submission}
+                  form={form}
+                  processingError={state.processingError}
+                  onConfirm={onSubmitForm}
+                  onLogout={onLogout}
+                  component={Summary}
+                  onClearProcessingErrors={() => dispatch({type: 'CLEAR_PROCESSING_ERROR'})}
+                />
+              </RequireSession>
+            </ErrorBoundary>
           </Route>
 
           <Route exact path="/bevestiging">
-            <RequireSubmission
-              submission={state.submittedSubmission}
-              statusUrl={state.processingStatusUrl}
-              onFailure={onProcessingFailure}
-              onConfirmed={() => dispatch({type: 'PROCESSING_SUCCEEDED'})}
-              component={SubmissionConfirmation} />
+            <ErrorBoundary useCard>
+              <RequireSubmission
+                submission={state.submittedSubmission}
+                statusUrl={state.processingStatusUrl}
+                onFailure={onProcessingFailure}
+                onConfirmed={() => dispatch({type: 'PROCESSING_SUCCEEDED'})}
+                component={SubmissionConfirmation} />
+              </ErrorBoundary>
           </Route>
 
           <Route exact path="/betaaloverzicht">
-            <ErrorBoundary>
+            <ErrorBoundary useCard>
               <PaymentOverview />
             </ErrorBoundary>
           </Route>
 
           <Route path="/stap/:step" render={() => (
-            <RequireSession expired={sessionExpired} expiryDate={expiryDate}>
-              <RequireSubmission
-                form={form}
-                submission={state.submission}
-                onLogicChecked={(submission) => dispatch({type: 'SUBMISSION_LOADED', payload: submission})}
-                onStepSubmitted={onStepSubmitted}
-                onLogout={onLogout}
-                component={FormStep}
-              />
-            </RequireSession>
+            <ErrorBoundary useCard>
+              <RequireSession expired={sessionExpired} expiryDate={expiryDate}>
+                <RequireSubmission
+                  form={form}
+                  submission={state.submission}
+                  onLogicChecked={(submission) => dispatch({type: 'SUBMISSION_LOADED', payload: submission})}
+                  onStepSubmitted={onStepSubmitted}
+                  onLogout={onLogout}
+                  component={FormStep}
+                />
+              </RequireSession>
+            </ErrorBoundary>
           )} />
 
         </Switch>

--- a/src/components/FormStart/index.js
+++ b/src/components/FormStart/index.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import PropTypes from 'prop-types';
 import {FormattedMessage, useIntl} from 'react-intl';
 
@@ -56,6 +56,7 @@ const FormStart = ({ form, onFormStart }) => {
   const doStart = useStartSubmission();
   const outagePluginId = useDetectAuthenticationOutage();
   const authErrors = useDetectAuthErrorMessages();
+  const [error, setError] = useState(null);
   const hasAuthErrors = !!outagePluginId || !!authErrors;
 
   const onFormStartCalledRef = useRef(false);
@@ -70,11 +71,24 @@ const FormStart = ({ form, onFormStart }) => {
       return;
     }
 
+    const startForm = async () => {
+      try {
+        await onFormStart();
+      } catch (e) {
+        setError(e);
+      }
+    }
+
     if (doStart && !hasAuthErrors) {
-      onFormStart();
+      startForm();
       onFormStartCalledRef.current = true;
     }
   }, [doStart, hasAuthErrors, onFormStart]);
+
+  // let errors bubble up to the error boundaries
+  if (error) {
+    throw error;
+  }
 
   // do not re-render the login options while we're redirecting
   if (doStart && !hasAuthErrors) {

--- a/src/errors.js
+++ b/src/errors.js
@@ -34,3 +34,15 @@ export class ValidationError extends ExtendableError {
   }
 
 };
+
+export class APIError extends ExtendableError {
+  constructor(message, statusCode, detail) {
+    super(message);
+    this.statusCode = statusCode;
+    this.detail = detail;
+  }
+}
+
+export class NotAuthenticated extends APIError {}
+export class PermissionDenied extends APIError {}
+export class NotFound extends APIError {}

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -23,6 +23,12 @@
       "value": "Appointment cancellation failed"
     }
   ],
+  "6GNK65": [
+    {
+      "type": 0,
+      "value": "There was an authentication and/or permission problem."
+    }
+  ],
   "6sTcEM": [
     {
       "type": 0,
@@ -73,6 +79,12 @@
     {
       "type": 0,
       "value": "This form is currently undergoing maintenance and can not be accessed at the moment."
+    }
+  ],
+  "DK2ewv": [
+    {
+      "type": 0,
+      "value": "Authentication problem"
     }
   ],
   "DvlDIB": [
@@ -137,6 +149,18 @@
       "value": "Your email address"
     }
   ],
+  "KMs17v": [
+    {
+      "type": 0,
+      "value": "Unfortunately something went wrong!"
+    }
+  ],
+  "KvSkZT": [
+    {
+      "type": 0,
+      "value": "Oops!"
+    }
+  ],
   "LEeGSv": [
     {
       "options": {
@@ -177,6 +201,12 @@
       "value": "Payment is required for this product"
     }
   ],
+  "Qu8SM1": [
+    {
+      "type": 0,
+      "value": "Extend"
+    }
+  ],
   "R5NUuU": [
     {
       "type": 0,
@@ -203,16 +233,6 @@
     {
       "type": 0,
       "value": "no"
-    }
-  ],
-  "STW5dH": [
-    {
-      "type": 0,
-      "value": "Your session will expire "
-    },
-    {
-      "type": 1,
-      "value": "delta"
     }
   ],
   "UWylpR": [
@@ -321,6 +341,12 @@
       "value": "Your payment is received and processed."
     }
   ],
+  "dFTtOX": [
+    {
+      "type": 0,
+      "value": "Back to form start"
+    }
+  ],
   "eO6Ysb": [
     {
       "type": 0,
@@ -361,6 +387,26 @@
     {
       "type": 0,
       "value": "Your appointment has been cancelled"
+    }
+  ],
+  "mMYAWl": [
+    {
+      "type": 0,
+      "value": "Your session is about to expire "
+    },
+    {
+      "type": 1,
+      "value": "delta"
+    },
+    {
+      "type": 0,
+      "value": ". Extend your session if you wish to continue."
+    }
+  ],
+  "nwQjsz": [
+    {
+      "type": 0,
+      "value": "Your session will expire soon."
     }
   ],
   "oMvPQU": [

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -23,6 +23,12 @@
       "value": "Afspraak annuleren mislukt"
     }
   ],
+  "6GNK65": [
+    {
+      "type": 0,
+      "value": "U moet ingelogd zijn voor deze actie."
+    }
+  ],
   "6sTcEM": [
     {
       "type": 0,
@@ -73,6 +79,12 @@
     {
       "type": 0,
       "value": "Dit formulier is momenteel in onderhoud en daardoor tijdelijk niet beschikbaar."
+    }
+  ],
+  "DK2ewv": [
+    {
+      "type": 0,
+      "value": "Inlogprobleem"
     }
   ],
   "DvlDIB": [
@@ -135,6 +147,18 @@
     {
       "type": 0,
       "value": "Uw e-mailadres"
+    }
+  ],
+  "KMs17v": [
+    {
+      "type": 0,
+      "value": "Er ging helaas iets fout!"
+    }
+  ],
+  "KvSkZT": [
+    {
+      "type": 0,
+      "value": "Oeps!"
     }
   ],
   "LEeGSv": [
@@ -203,16 +227,6 @@
     {
       "type": 0,
       "value": "nee"
-    }
-  ],
-  "STW5dH": [
-    {
-      "type": 0,
-      "value": "Uw sessie vervalt "
-    },
-    {
-      "type": 1,
-      "value": "delta"
     }
   ],
   "UWylpR": [
@@ -319,6 +333,12 @@
     {
       "type": 0,
       "value": "Uw betaling is ontvangen en verwerkt."
+    }
+  ],
+  "dFTtOX": [
+    {
+      "type": 0,
+      "value": "Terug naar begin"
     }
   ],
   "eO6Ysb": [

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -19,6 +19,11 @@
     "description": "Appointment cancellation error message",
     "originalDefault": "Appointment cancellation failed"
   },
+  "6GNK65": {
+    "defaultMessage": "There was an authentication and/or permission problem.",
+    "description": "Authentication error message",
+    "originalDefault": "There was an authentication and/or permission problem."
+  },
   "6sTcEM": {
     "defaultMessage": "Pay now",
     "description": "Start payment button",
@@ -58,6 +63,11 @@
     "defaultMessage": "This form is currently undergoing maintenance and can not be accessed at the moment.",
     "description": "Maintenance mode message",
     "originalDefault": "This form is currently undergoing maintenance and can not be accessed at the moment."
+  },
+  "DK2ewv": {
+    "defaultMessage": "Authentication problem",
+    "description": "'Permission denied' error title",
+    "originalDefault": "Authentication problem"
   },
   "DvlDIB": {
     "defaultMessage": "Are you sure that you want to logout?",
@@ -104,6 +114,16 @@
     "description": "Form save modal email field label",
     "originalDefault": "Your email address"
   },
+  "KMs17v": {
+    "defaultMessage": "Unfortunately something went wrong!",
+    "description": "Generic error message",
+    "originalDefault": "Unfortunately something went wrong!"
+  },
+  "KvSkZT": {
+    "defaultMessage": "Oops!",
+    "description": "Error boundary title",
+    "originalDefault": "Oops!"
+  },
   "LEeGSv": {
     "defaultMessage": "{isApplicable, select, false {{label} (n/a)} other {{label}} }",
     "description": "Step label in progress indicator",
@@ -118,6 +138,11 @@
     "defaultMessage": "Payment is required for this product",
     "description": "Payment required info text",
     "originalDefault": "Payment is required for this product"
+  },
+  "Qu8SM1": {
+    "defaultMessage": "Extend",
+    "description": "Extend session button (in modal)",
+    "originalDefault": "Extend"
   },
   "R5NUuU": {
     "defaultMessage": "Confirm",
@@ -138,11 +163,6 @@
     "defaultMessage": "no",
     "description": "'False' display",
     "originalDefault": "no"
-  },
-  "STW5dH": {
-    "defaultMessage": "Your session will expire {delta}",
-    "description": "Session expiry timer",
-    "originalDefault": "Your session will expire {delta}"
   },
   "UWylpR": {
     "defaultMessage": "This form is temporarily unavailable because of an outage with the {label} authentication service. Please try again later.",
@@ -204,6 +224,11 @@
     "description": "payment registered status",
     "originalDefault": "Your payment is received and processed."
   },
+  "dFTtOX": {
+    "defaultMessage": "Back to form start",
+    "description": "return to form start link after 403",
+    "originalDefault": "Back to form start"
+  },
   "eO6Ysb": {
     "defaultMessage": "Your payment is currently processing.",
     "description": "payment processing status",
@@ -238,6 +263,16 @@
     "defaultMessage": "Your appointment has been cancelled",
     "description": "Appointment cancellated body",
     "originalDefault": "Your appointment has been cancelled"
+  },
+  "mMYAWl": {
+    "defaultMessage": "Your session is about to expire {delta}. Extend your session if you wish to continue.",
+    "description": "Session expiry warning message (in modal)",
+    "originalDefault": "Your session is about to expire {delta}. Extend your session if you wish to continue."
+  },
+  "nwQjsz": {
+    "defaultMessage": "Your session will expire soon.",
+    "description": "Session expiry warning title (in modal)",
+    "originalDefault": "Your session will expire soon."
   },
   "oMvPQU": {
     "defaultMessage": "Your session has expired",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -19,6 +19,11 @@
     "description": "Appointment cancellation error message",
     "originalDefault": "Appointment cancellation failed"
   },
+  "6GNK65": {
+    "defaultMessage": "U moet ingelogd zijn voor deze actie.",
+    "description": "Authentication error message",
+    "originalDefault": "There was an authentication and/or permission problem."
+  },
   "6sTcEM": {
     "defaultMessage": "Nu betalen",
     "description": "Start payment button",
@@ -58,6 +63,11 @@
     "defaultMessage": "Dit formulier is momenteel in onderhoud en daardoor tijdelijk niet beschikbaar.",
     "description": "Maintenance mode message",
     "originalDefault": "This form is currently undergoing maintenance and can not be accessed at the moment."
+  },
+  "DK2ewv": {
+    "defaultMessage": "Inlogprobleem",
+    "description": "'Permission denied' error title",
+    "originalDefault": "Authentication problem"
   },
   "DvlDIB": {
     "defaultMessage": "Weet u zeker dat u wilt uitloggen?",
@@ -104,6 +114,16 @@
     "description": "Form save modal email field label",
     "originalDefault": "Your email address"
   },
+  "KMs17v": {
+    "defaultMessage": "Er ging helaas iets fout!",
+    "description": "Generic error message",
+    "originalDefault": "Unfortunately something went wrong!"
+  },
+  "KvSkZT": {
+    "defaultMessage": "Oeps!",
+    "description": "Error boundary title",
+    "originalDefault": "Oops!"
+  },
   "LEeGSv": {
     "defaultMessage": "{isApplicable, select, false {{label} (n.v.t.)} other {{label}} }",
     "description": "Step label in progress indicator",
@@ -138,11 +158,6 @@
     "defaultMessage": "nee",
     "description": "'False' display",
     "originalDefault": "no"
-  },
-  "STW5dH": {
-    "defaultMessage": "Uw sessie vervalt {delta}",
-    "description": "Session expiry timer",
-    "originalDefault": "Your session will expire {delta}"
   },
   "UWylpR": {
     "defaultMessage": "Dit formulier is tijdelijk niet beschikbaar wegens een storing bij de {label} authenticatieservice. Gelieve later opnieuw te proberen.",
@@ -203,6 +218,11 @@
     "defaultMessage": "Uw betaling is ontvangen en verwerkt.",
     "description": "payment registered status",
     "originalDefault": "Your payment is received and processed."
+  },
+  "dFTtOX": {
+    "defaultMessage": "Terug naar begin",
+    "description": "return to form start link after 403",
+    "originalDefault": "Back to form start"
   },
   "eO6Ysb": {
     "defaultMessage": "Uw betaling wordt momenteel verwerkt.",


### PR DESCRIPTION
This PR adds some robustness for backend errors with special attention for permission errors (HTTP 403).

* ensure that components that talk to the backend are wrapped in the error boundary
* throw HTTP 400-599 errors as exceptions
* track backend errors in component callbacks/event handlers/async calls
* display relevant information to the end-user

Example HTTP 403 error during login:

![image](https://user-images.githubusercontent.com/5518550/180229169-3c7e996a-c4d0-4cef-95cf-a8fb885a919b.png)
