### PR TITLE
Fix location autofill flicker

### DIFF
--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -1,4 +1,5 @@
 import { Formio } from 'react-formio';
+import debounce from 'lodash/debounce';
 
 import { applyPrefix } from '../utils';
 import { get } from '../../api';
@@ -8,6 +9,7 @@ import enableValidationPlugins from "../validators/plugins";
 const POSTCODE_REGEX = /^[0-9]{4}\s?[a-zA-Z]{2}$/;
 const HOUSE_NUMBER_REGEX = /^\d+$/;
 
+const LOCATION_AUTOCOMPLETE_DEBOUNCE = 200;
 
 /**
  * Extend the default text field to modify it to our needs.
@@ -30,16 +32,26 @@ class TextField extends Formio.Components.components.textfield {
     return super.checkComponentValidity(data, dirty, row, {...options, async: true});
   }
 
-  setLocationData(postcode, house_number, key) {
-    get(`${this.options.baseUrl}location/get-street-name-and-city`, {postcode, house_number})
-      .then(result => {
-        if (result[key]) {
-          this.setValue(result[key]);
-        } else {
-          this.setValue('');
-        }
-      })
-      .catch(error => console.log(error));
+  /**
+   * Return a debounced method to look up and autocomplete the location data.
+   */
+  get setLocationData() {
+    if (!this._debouncedSetLocationData) {
+      this._debouncedSetLocationData = debounce((postcode, house_number, key) => {
+        get(`${this.options.baseUrl}location/get-street-name-and-city`, {postcode, house_number})
+          .then(result => {
+            if (result[key]) {
+              this.setValue(result[key]);
+            } else {
+              this.setValue('');
+            }
+          })
+          .catch(console.error);
+      }, LOCATION_AUTOCOMPLETE_DEBOUNCE);
+    } else {
+      this._debouncedSetLocationData.cancel();
+    }
+    return this._debouncedSetLocationData;
   }
 
   handleSettingLocationData(data) {

--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -46,6 +46,15 @@ class TextField extends Formio.Components.components.textfield {
     const isValidHouseNumber = HOUSE_NUMBER_REGEX.test(data[this.component.deriveHouseNumber]);
     const isValidPostcode = POSTCODE_REGEX.test(data[this.component.derivePostcode]);
 
+    // Fill data if it is not set yet or if the field is readonly (i.e. Formio's disabled).
+    // Unrelated to the HTML 'disabled' attribute.
+    // See #1717 and #1832 - we only want to make API calls if there is useful work to
+    // be done.
+    const mayAutofillValue = !this.getValue() || this.component.disabled;
+    if (!mayAutofillValue) {
+      return;
+    }
+
     if (isValidHouseNumber && isValidPostcode) {
       if (this.component.deriveStreetName) {
         this.setLocationData(

--- a/src/jstests/formio/components/textfield.spec.js
+++ b/src/jstests/formio/components/textfield.spec.js
@@ -23,6 +23,7 @@ describe('TextField Component', () => {
       form.setPristine(false);
       const componentCity = form.getComponent('city');
       componentCity.handleSettingLocationData({postcode: '1111AA', houseNumber: '1'});
+      componentCity._debouncedSetLocationData.flush();
 
       setTimeout(() => {
         expect(componentCity.getValue()).toEqual('Amsterdam');
@@ -32,7 +33,31 @@ describe('TextField Component', () => {
     }).catch(done);
   });
 
-  test('TextField with address prefill refreshes city on invalid data', (done) => {
+  test('TextField (readonly) with address prefill refreshes city on invalid data', (done) => {
+    let formJSON = _.cloneDeep(addressPrefillForm);
+    formJSON.components[2].disabled = true;
+    formJSON.components[3].disabled = true;
+    apiModule.get.mockResolvedValue({});
+
+    const element = document.createElement('div');
+
+    Formio.createForm(element, formJSON).then(form => {
+      form.setPristine(false);
+      const componentCity = form.getComponent('city');
+      componentCity.setValue('Amsterdam');
+
+      componentCity.handleSettingLocationData({postcode: '0000AA', houseNumber: '0'});
+      componentCity._debouncedSetLocationData.flush();
+
+      setTimeout(() => {
+        expect(componentCity.getValue()).toEqual('');
+        done();
+      }, 300);
+
+    }).catch(done);
+  });
+
+  test('TextField (editable) with address prefill does not modify city if already filled', (done) => {
     let formJSON = _.cloneDeep(addressPrefillForm);
     apiModule.get.mockResolvedValue({});
 
@@ -44,9 +69,11 @@ describe('TextField Component', () => {
       componentCity.setValue('Amsterdam');
 
       componentCity.handleSettingLocationData({postcode: '0000AA', houseNumber: '0'});
+      componentCity.setLocationData;  // access so that the debounced method is created
+      componentCity._debouncedSetLocationData.flush();
 
       setTimeout(() => {
-        expect(componentCity.getValue()).toEqual('');
+        expect(componentCity.getValue()).toEqual('Amsterdam');
         done();
       }, 300);
 
@@ -63,6 +90,7 @@ describe('TextField Component', () => {
       form.setPristine(false);
       const componentStreet = form.getComponent('streetName');
       componentStreet.handleSettingLocationData({postcode: '1111AA', houseNumber: '1'});
+      componentStreet._debouncedSetLocationData.flush();
 
       setTimeout(() => {
         expect(componentStreet.getValue()).toEqual('Beautiful Street');
@@ -72,7 +100,31 @@ describe('TextField Component', () => {
     }).catch(done);
   });
 
-  test('TextField with address prefill refreshes street on invalid data', (done) => {
+  test('TextField (readonly) with address prefill refreshes street on invalid data', (done) => {
+    let formJSON = _.cloneDeep(addressPrefillForm);
+    formJSON.components[2].disabled = true;
+    formJSON.components[3].disabled = true;
+    apiModule.get.mockResolvedValue({});
+
+    const element = document.createElement('div');
+
+    Formio.createForm(element, formJSON).then(form => {
+      form.setPristine(false);
+      const componentStreet = form.getComponent('streetName');
+      componentStreet.setValue('Beautiful Street');
+
+      componentStreet.handleSettingLocationData({postcode: '0000AA', houseNumber: '0'});
+      componentStreet._debouncedSetLocationData.flush();
+
+      setTimeout(() => {
+        expect(componentStreet.getValue()).toEqual('');
+        done();
+      }, 300);
+
+    }).catch(done);
+  });
+
+  test('TextField (editable) with address prefill (invalid data) does not modify street if already filled', (done) => {
     let formJSON = _.cloneDeep(addressPrefillForm);
     apiModule.get.mockResolvedValue({});
 
@@ -84,9 +136,11 @@ describe('TextField Component', () => {
       componentStreet.setValue('Beautiful Street');
 
       componentStreet.handleSettingLocationData({postcode: '0000AA', houseNumber: '0'});
+      componentStreet.setLocationData;  // access so that the debounced method is created
+      componentStreet._debouncedSetLocationData.flush();
 
       setTimeout(() => {
-        expect(componentStreet.getValue()).toEqual('');
+        expect(componentStreet.getValue()).toEqual('Beautiful Street');
         done();
       }, 300);
 


### PR DESCRIPTION
(Hopefully) fixes open-formulieren/open-forms#1832

* Only query location data when field is read-only or field has no value yet
* Debounce the location data querying

The backend has a patch which adds caching to further reduce the amount of requests sent to the BAG API.

Needs backporting to stable/1.0.x as well, and the debounce functionality should probably be ported to the main branch.