### PR TITLE
Apply debounce behaviour from bugfix

### DIFF
--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -1,4 +1,5 @@
 import { Formio } from 'react-formio';
+import debounce from 'lodash/debounce';
 
 import { applyPrefix } from '../utils';
 import { get } from '../../api';
@@ -8,6 +9,7 @@ import enableValidationPlugins from "../validators/plugins";
 const POSTCODE_REGEX = /^[0-9]{4}\s?[a-zA-Z]{2}$/;
 const HOUSE_NUMBER_REGEX = /^\d+$/;
 
+const LOCATION_AUTOCOMPLETE_DEBOUNCE = 200;
 
 /**
  * Extend the default text field to modify it to our needs.
@@ -34,16 +36,26 @@ class TextField extends Formio.Components.components.textfield {
     return super.checkComponentValidity(data, dirty, row, updatedOptions);
   }
 
-  setLocationData(postcode, house_number, key) {
-    get(`${this.options.baseUrl}location/get-street-name-and-city`, {postcode, house_number})
-      .then(result => {
-        if (result[key]) {
-          this.setValue(result[key]);
-        } else {
-          this.setValue('');
-        }
-      })
-      .catch(error => console.log(error));
+  /**
+   * Return a debounced method to look up and autocomplete the location data.
+   */
+  get setLocationData() {
+    if (!this._debouncedSetLocationData) {
+      this._debouncedSetLocationData = debounce((postcode, house_number, key) => {
+        get(`${this.options.baseUrl}location/get-street-name-and-city`, {postcode, house_number})
+          .then(result => {
+            if (result[key]) {
+              this.setValue(result[key]);
+            } else {
+              this.setValue('');
+            }
+          })
+          .catch(console.error);
+        }, LOCATION_AUTOCOMPLETE_DEBOUNCE);
+    } else {
+      this._debouncedSetLocationData.cancel();
+    }
+    return this._debouncedSetLocationData;
   }
 
   handleSettingLocationData(data) {
@@ -53,16 +65,20 @@ class TextField extends Formio.Components.components.textfield {
     if (isValidHouseNumber && isValidPostcode) {
       // Fill data if it is not set yet or if the field is readonly (i.e. Formio's disabled).
       // Unrelated to the HTML 'disabled' attribute.
+      // See also #1832 for how this can lead to way too many API calls.
       const mayAutofillValue = !this.getValue() || this.component.disabled;
+      if (!mayAutofillValue) {
+        return;
+      }
 
-      if (this.component.deriveStreetName && mayAutofillValue) {
+      if (this.component.deriveStreetName) {
         this.setLocationData(
           data[this.component.derivePostcode],
           data[this.component.deriveHouseNumber],
           'streetName'
         );
       }
-      if (this.component.deriveCity && mayAutofillValue) {
+      if (this.component.deriveCity) {
         this.setLocationData(
           data[this.component.derivePostcode],
           data[this.component.deriveHouseNumber],

--- a/src/jstests/formio/components/textfield.spec.js
+++ b/src/jstests/formio/components/textfield.spec.js
@@ -23,6 +23,7 @@ describe('TextField Component', () => {
       form.setPristine(false);
       const componentCity = form.getComponent('city');
       componentCity.handleSettingLocationData({postcode: '1111AA', houseNumber: '1'});
+      componentCity._debouncedSetLocationData.flush();
 
       setTimeout(() => {
         expect(componentCity.getValue()).toEqual('Amsterdam');
@@ -46,6 +47,7 @@ describe('TextField Component', () => {
       componentCity.setValue('Amsterdam');
 
       componentCity.handleSettingLocationData({postcode: '0000AA', houseNumber: '0'});
+      componentCity._debouncedSetLocationData.flush();
 
       setTimeout(() => {
         expect(componentCity.getValue()).toEqual('');
@@ -67,6 +69,8 @@ describe('TextField Component', () => {
       componentCity.setValue('Amsterdam');
 
       componentCity.handleSettingLocationData({postcode: '0000AA', houseNumber: '0'});
+      componentCity.setLocationData; // access the getter so the debounced method is created
+      componentCity._debouncedSetLocationData.flush();
 
       setTimeout(() => {
         expect(componentCity.getValue()).toEqual('Amsterdam');
@@ -86,6 +90,7 @@ describe('TextField Component', () => {
       form.setPristine(false);
       const componentStreet = form.getComponent('streetName');
       componentStreet.handleSettingLocationData({postcode: '1111AA', houseNumber: '1'});
+      componentStreet._debouncedSetLocationData.flush();
 
       setTimeout(() => {
         expect(componentStreet.getValue()).toEqual('Beautiful Street');
@@ -109,6 +114,7 @@ describe('TextField Component', () => {
       componentStreet.setValue('Beautiful Street');
 
       componentStreet.handleSettingLocationData({postcode: '0000AA', houseNumber: '0'});
+      componentStreet._debouncedSetLocationData.flush();
 
       setTimeout(() => {
         expect(componentStreet.getValue()).toEqual('');
@@ -130,6 +136,8 @@ describe('TextField Component', () => {
       componentStreet.setValue('Beautiful Street');
 
       componentStreet.handleSettingLocationData({postcode: '0000AA', houseNumber: '0'});
+componentStreet.setLocationData; // access the getter so the debounced method is created
+      componentStreet._debouncedSetLocationData.flush();
 
       setTimeout(() => {
         expect(componentStreet.getValue()).toEqual('Beautiful Street');


### PR DESCRIPTION
Taken from #220 

Debouncing helps preventing a tsunami of API calls firing for every
keystroke in the form. Additionally, it helps preventing bad auto-fill
because the relevant postcode/house number fields were only partially
filled (e.g. using 15 rather than 153 as house number).