### PR TITLE
Change names of header variables to not include 'header'

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,6 @@
 import {createGlobalstate} from 'state-pool';
 
-import {CSPNonceHeader, CSRFTokenHeader, IsFormDesignerHeader} from './headers';
+import {CSPNonce, CSRFToken, IsFormDesigner} from './headers';
 
 import {
   APIError,
@@ -84,15 +84,15 @@ const addHeaders = (headers, method) => {
   if (!headers) headers = {};
 
   // add the CSP nonce request header in case the backend needs to do any post-processing
-  const CSPNonce = CSPNonceHeader.getValue();
-  if (CSPNonce != null && CSPNonce) {
-    headers[CSPNonceHeader.name] = CSPNonce;
+  const CSPNonceValue = CSPNonce.getValue();
+  if (CSPNonceValue != null && CSPNonceValue) {
+    headers[CSPNonce.headerName] = CSPNonceValue;
   }
 
   if (method !== 'GET') {
-    const csrfToken = CSRFTokenHeader.getValue();
-    if (csrfToken != null && csrfToken) {
-      headers[CSRFTokenHeader.name] = csrfToken;
+    const csrfTokenValue = CSRFToken.getValue();
+    if (csrfTokenValue != null && csrfTokenValue) {
+      headers[CSRFToken.headerName] = csrfTokenValue;
     }
   }
 
@@ -105,14 +105,14 @@ const updateStoredHeadersValues = (headers) => {
     updateSesionExpiry(parseInt(sessionExpiry), 10);
   }
 
-  const CSRFToken = headers.get(CSRFTokenHeader.name);
-  if (CSRFToken) {
-    CSRFTokenHeader.setValue(CSRFToken);
+  const CSRFTokenValue = headers.get(CSRFToken.headerName);
+  if (CSRFTokenValue) {
+    CSRFToken.setValue(CSRFTokenValue);
   }
 
-  const isFormDesigner = headers.get(IsFormDesignerHeader.name);
-  if (isFormDesigner) {
-    IsFormDesignerHeader.setValue(isFormDesigner === 'true');
+  const isFormDesignerValue = headers.get(IsFormDesigner.headerName);
+  if (isFormDesignerValue) {
+    IsFormDesigner.setValue(isFormDesignerValue === 'true');
   }
 };
 
@@ -150,7 +150,7 @@ const _unsafe = async (method = 'POST', url, data, signal) => {
       method,
       headers: {
           'Content-Type': 'application/json',
-          [CSRFTokenHeader.name]: CSRFTokenHeader.getValue(),
+          [CSRFToken.headerName]: CSRFToken.getValue(),
       },
   };
   if (data) {

--- a/src/components/FormStart/index.js
+++ b/src/components/FormStart/index.js
@@ -14,7 +14,7 @@ import {Toolbar, ToolbarList} from 'components/Toolbar';
 import Types from 'types';
 import LoginButton, {LoginButtonIcon} from 'components/LoginButton';
 import {UnprocessableEntity} from 'errors';
-import {IsFormDesignerHeader} from 'headers';
+import {IsFormDesigner} from 'headers';
 import useStartSubmission from 'hooks/useStartSubmission';
 import {getBEMClassName} from 'utils';
 
@@ -86,8 +86,8 @@ const FormStart = ({ form, onFormStart }) => {
     throw new UnprocessableEntity('Unprocessable Entity', 422, 'Form not active', 'form-inactive');
   }
 
-  const isFormDesigner = IsFormDesignerHeader.getValue();
-  if (!isFormDesigner && form.maintenanceMode) {
+  const userIsFormDesigner = IsFormDesigner.getValue();
+  if (!userIsFormDesigner && form.maintenanceMode) {
     return <MaintenanceMode title={form.name} />;
   }
 
@@ -108,7 +108,7 @@ const FormStart = ({ form, onFormStart }) => {
     <LiteralsProvider literals={form.literals}>
       <Card title={form.name}>
 
-        {isFormDesigner && form.maintenanceMode && <MaintenanceMode asToast />}
+        {userIsFormDesigner && form.maintenanceMode && <MaintenanceMode asToast />}
 
         { !!authErrors ? <AuthenticationErrors parameters={authErrors}/> : null }
 

--- a/src/components/MaintenanceMode.js
+++ b/src/components/MaintenanceMode.js
@@ -5,15 +5,15 @@ import {FormattedMessage} from 'react-intl';
 import Body from 'components/Body';
 import Card from 'components/Card';
 import FAIcon from 'components/FAIcon';
-import {IsFormDesignerHeader} from 'headers';
+import {IsFormDesigner} from 'headers';
 import {getBEMClassName} from 'utils';
 
 const MaintenanceModeAlert = () => {
   const alertClassName = getBEMClassName('alert', ['info']);
-  const isFormDesigner = IsFormDesignerHeader.getValue();
+  const userIsFormDesigner = IsFormDesigner.getValue();
 
   let message;
-  if (!isFormDesigner) {
+  if (!userIsFormDesigner) {
     message = (<FormattedMessage
       description="Maintenance mode message"
       defaultMessage="This form is currently undergoing maintenance and can not be accessed at the moment."

--- a/src/components/ProgressIndicator/index.js
+++ b/src/components/ProgressIndicator/index.js
@@ -11,7 +11,7 @@ import List from 'components/List';
 import FAIcon from 'components/FAIcon';
 import Types from 'types';
 import {getBEMClassName} from 'utils';
-import {IsFormDesignerHeader} from 'headers';
+import {IsFormDesigner} from 'headers';
 
 import ProgressItem from './ProgressItem';
 
@@ -117,7 +117,7 @@ const ProgressIndicator = ({ title, submission=null, steps, submissionAllowed, c
       // The user can navigate to a step when:
       // 1. All previous steps have been completed
       // 2. The user is a form designer
-      if (IsFormDesignerHeader.getValue()) return true;
+      if (IsFormDesigner.getValue()) return true;
 
       if (!submission) return false;
 

--- a/src/components/ProgressIndicator/test.spec.js
+++ b/src/components/ProgressIndicator/test.spec.js
@@ -7,7 +7,7 @@ import { IntlProvider } from 'react-intl';
 import ProgressIndicator from './index';
 import { SUBMISSION_ALLOWED } from 'components/constants';
 import messagesNL from 'i18n/compiled/nl.json';
-import { IsFormDesignerHeader } from 'headers';
+import { IsFormDesigner } from 'headers';
 
 jest.mock('headers');
 
@@ -160,7 +160,7 @@ it('Progress indicator does NOT let you navigate between steps if you are NOT a 
     },
   ];
 
-  IsFormDesignerHeader.getValue.mockReturnValue(false);
+  IsFormDesigner.getValue.mockReturnValue(false);
 
   act(() => {
     render(
@@ -226,7 +226,7 @@ it('Progress indicator DOES let you navigate between steps if you ARE a form des
     },
   ];
 
-  IsFormDesignerHeader.getValue.mockReturnValue(true);
+  IsFormDesigner.getValue.mockReturnValue(true);
 
   act(() => {
     render(
@@ -292,7 +292,7 @@ it('Progress indicator DOES let you navigate between steps if you are NOT a form
     },
   ];
 
-  IsFormDesignerHeader.getValue.mockReturnValue(false);
+  IsFormDesigner.getValue.mockReturnValue(false);
 
   act(() => {
     render(

--- a/src/components/RequireSubmission.js
+++ b/src/components/RequireSubmission.js
@@ -4,7 +4,7 @@ import {Redirect} from 'react-router-dom';
 
 import MaintenanceMode from 'components/MaintenanceMode';
 import {ServiceUnavailable} from 'errors';
-import {IsFormDesignerHeader} from 'headers';
+import {IsFormDesigner} from 'headers';
 
 
 /**
@@ -14,11 +14,11 @@ import {IsFormDesignerHeader} from 'headers';
  */
 const RequireSubmission = ({ submission, component: Component, ...props }) => {
   const maintenanceMode = props?.form?.maintenanceMode;
-  const isFormDesigner = IsFormDesignerHeader.getValue();
+  const userIsFormDesigner = IsFormDesigner.getValue();
   let maintenanceModeAlert = null;
-  if (!isFormDesigner && maintenanceMode) {
+  if (!userIsFormDesigner && maintenanceMode) {
     throw new ServiceUnavailable('Service Unavailable', 503, 'Form in maintenance', 'form-maintenance');
-  } else if (isFormDesigner && maintenanceMode) {
+  } else if (userIsFormDesigner && maintenanceMode) {
     maintenanceModeAlert = <MaintenanceMode />;
   }
 

--- a/src/headers.js
+++ b/src/headers.js
@@ -5,7 +5,7 @@ const IsFormDesignerHeaderName = 'X-Is-Form-Designer';
 
 const factoryHeader = (headerName, headerValue) => {
   return {
-    name: headerName,
+    headerName: headerName,
     value: headerValue,
     getValue() {
       return headerValue;
@@ -27,7 +27,7 @@ const factoryHeader = (headerName, headerValue) => {
  * The Open Forms SDK includes the value of the cspNonce as a header in fetch api calls
  * so that any HTML can be post-processed to add the correct nonce.
  */
-let CSPNonceHeader = factoryHeader(CSPNonceHeaderName, null);
+let CSPNonce = factoryHeader(CSPNonceHeaderName, null);
 
 
 /**
@@ -39,7 +39,7 @@ let CSPNonceHeader = factoryHeader(CSPNonceHeaderName, null);
  * The Open Forms SDK includes the value of the CSRF Token as a header in fetch api
  * calls if it's set.
  */
-let CSRFTokenHeader = factoryHeader(CSRFTokenHeaderName, null);
+let CSRFToken = factoryHeader(CSRFTokenHeaderName, null);
 
 
 /**
@@ -48,6 +48,6 @@ let CSRFTokenHeader = factoryHeader(CSRFTokenHeaderName, null);
  * Form designers are allowed to navigate between submission steps even if these are not completed.
  *
  */
-let IsFormDesignerHeader = factoryHeader(IsFormDesignerHeaderName, false);
+let IsFormDesigner = factoryHeader(IsFormDesignerHeaderName, false);
 
-export {CSPNonceHeader, CSRFTokenHeader, IsFormDesignerHeader};
+export {CSPNonce, CSRFToken, IsFormDesigner};

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -15,7 +15,7 @@ import './styles.scss';
 import { get } from 'api';
 import { ConfigContext, FormioTranslations } from 'Context';
 import App from 'components/App';
-import {CSPNonceHeader} from 'headers';
+import {CSPNonce} from 'headers';
 import { AddFetchAuth } from 'formio/plugins';
 import {fixIconUrls as fixLeafletIconUrls} from 'map';
 import {loadLocaleData, loadFormioTranslations} from 'i18n';
@@ -48,7 +48,7 @@ class OpenForm {
       baseUrl,
       basePath,
       formId,
-      CSPNonce,
+      CSPNonce: CSPNonceValue,
       lang,
       sentryDSN,
       sentryEnv='',
@@ -60,7 +60,7 @@ class OpenForm {
     this.formObject = null;
     this.lang = lang;
 
-    CSPNonceHeader.setValue(CSPNonce);
+    CSPNonce.setValue(CSPNonceValue);
     initialiseSentry(sentryDSN, sentryEnv);
 
     // ensure that the basename has no trailing slash (for react router)


### PR DESCRIPTION
We had discussed that having the 'header' word in the variable names made them a bit awkward to read when using them.