### PR TITLE
Check if the submit is triggered by a submit button

### DIFF
--- a/src/components/FormStep.js
+++ b/src/components/FormStep.js
@@ -40,7 +40,7 @@ import Card from 'components/Card';
 import FormStepDebug from 'components/FormStepDebug';
 import Loader from 'components/Loader';
 import FormStepSaveModal from 'components/modals/FormStepSaveModal';
-import {findPreviousApplicableStep, isLastStep} from 'components/utils';
+import {eventTriggeredBySubmitButton, findPreviousApplicableStep, isLastStep} from 'components/utils';
 import ButtonsToolbar from 'components/ButtonsToolbar';
 import {ConfigContext, FormioTranslations} from 'Context';
 import { ValidationError } from 'errors';
@@ -418,6 +418,12 @@ const FormStep = ({
   // into that to handle the actual submission.
   const onReactSubmit = async (event) => {
     event.preventDefault();
+
+    // Issue #2084 - The button to save a row of an editgrid triggers a submit if there are validation errors
+    if(!eventTriggeredBySubmitButton(event)) {
+      return;
+    }
+
     if (!canSubmit) return;
 
     // current is the component, current.instance is the component instance, and that

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -55,4 +55,21 @@ const getLoginRedirectUrl = (form) => {
   }
 }
 
-export {findNextApplicableStep, findPreviousApplicableStep, isLastStep, getLoginRedirectUrl, getLoginUrl};
+const eventTriggeredBySubmitButton = (event) => {
+  const submitterAttributes = event.nativeEvent.submitter.attributes;
+
+  for (const attribute of submitterAttributes) {
+    if (attribute.name === 'type' && attribute.value === 'submit') return true;
+  }
+
+  return false;
+};
+
+export {
+  findNextApplicableStep,
+  findPreviousApplicableStep,
+  isLastStep,
+  getLoginRedirectUrl,
+  getLoginUrl,
+  eventTriggeredBySubmitButton,
+};


### PR DESCRIPTION
open-formulieren/open-forms#2084

This is really a bandaid, but we should try to figure out why the `onReactSubmit` is triggered in the case of 
submitting an editgrid row with validation errors.