### PR TITLE
Add label to repeating group

### DIFF
--- a/src/formio/templates/editGrid.ejs
+++ b/src/formio/templates/editGrid.ejs
@@ -5,6 +5,7 @@
     <ul>
       {% ctx.rows.forEach(function(row, rowIndex) { %}
       <div class="{{ctx.ofPrefix}}editgrid__group">
+        {% if (!!ctx.component.groupLabel) { %}<div class="{{ctx.ofPrefix}}editgrid__group-label">{{ ctx.component.groupLabel }} {{ rowIndex + 1 }}</div>{% } %}
         <li class="{{ctx.ofPrefix}}editgrid__list" ref="{{ctx.ref.row}}">
           {{row}}
 

--- a/src/scss/components/_editgrid.scss
+++ b/src/scss/components/_editgrid.scss
@@ -26,6 +26,11 @@
     }
   }
 
+  &__group-label {
+    @include h4;
+    padding-bottom: $grid-margin-4;
+  }
+
   &__list {
     list-style: none;
   }


### PR DESCRIPTION
Fixes open-formulieren/open-forms#2101

With group label:
![Screenshot from 2022-10-05 16-08-56](https://user-images.githubusercontent.com/19154114/194081274-1bb6da73-2073-4847-a510-033337fd520a.png)

If no group label is specified in the editor:
![Screenshot from 2022-10-05 16-09-42](https://user-images.githubusercontent.com/19154114/194081468-ae679733-fef7-4c11-bdcc-919db110ffc9.png)
