### PR TITLE
ci: visual regression test with Chromatic

### DIFF
--- a/.github/workflows/sb.yml
+++ b/.github/workflows/sb.yml
@@ -10,12 +10,6 @@ on:
       - main
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 # Allow one concurrent deployment
 concurrency:
   group: "pages-${{ github.ref_name }}"  # unique builds for branch/tag name
@@ -47,8 +41,14 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'  # Exclude PRs
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'  # Exclude PRs
     needs: storybook
     steps:
       - name: Setup Pages

--- a/.github/workflows/sb.yml
+++ b/.github/workflows/sb.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 # Allow one concurrent deployment

--- a/.github/workflows/sb.yml
+++ b/.github/workflows/sb.yml
@@ -57,3 +57,26 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
+
+  chromatic:
+    name: Visual regression test with Chromatic
+    runs-on: ubuntu-latest
+    needs:
+      - storybook
+
+    if: "${{ secrets.CHROMATIC_PROJECT_TOKEN }}" != ""
+
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: github-pages
+          path: ./storybook-static
+
+      - name: Publish to Chromatic for visual regression tests
+        uses: chromaui/action@v1
+        if: github.event.pull_request.draft == false
+        with:
+          autoAcceptChanges: main
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          storybookBuildDir: ./storybook-static


### PR DESCRIPTION
Perhaps we can use our Frameless account to do visual regression tests for a while, that seems like a better approach than @sergei-maertens spending his precious time doing visual regression tests for our changes 😅

I suspect I need to be a contributor or maintainer of this repo to be able to set this up from Chromatic, otherwise the repo won't show up in my list of options. Then someone also needs to configure the project token. Let's discuss this idea later this week.