### PR TITLE
Display max file size in File Upload widget

### DIFF
--- a/src/formio/templates/file.ejs
+++ b/src/formio/templates/file.ejs
@@ -87,6 +87,9 @@
           {{ctx.t('to attach a file.')}}
         {% } %}
 
+        {% if (ctx.component.fileMaxSize) { %}
+          {{ctx.t('maxFileSizeMessage', {maxFileSize: ctx.component.fileMaxSize})}}
+        {% } %}
     </div>
   {% } else { %}
     <div>


### PR DESCRIPTION
Fixes open-formulieren/open-forms#2124