### PR TITLE
:bug: Replace removed session destroy endpoint

### DIFF
--- a/src/components/FormStep.js
+++ b/src/components/FormStep.js
@@ -632,6 +632,7 @@ const FormStep = ({
         closeModal={closeFormStepSaveModal}
         onSaveConfirm={onSaveConfirm}
         suspendFormUrl={`${submission.url}/_suspend`}
+        submissionId={submission.id}
       />
     </>
   );

--- a/src/components/modals/FormStepSaveModal.js
+++ b/src/components/modals/FormStepSaveModal.js
@@ -59,6 +59,7 @@ const FormStepSaveModal = ({
     closeModal,
     onSaveConfirm,
     suspendFormUrl,
+    submissionId,
 }) => {
   const history = useHistory();
   const intl = useIntl();
@@ -103,7 +104,7 @@ const FormStepSaveModal = ({
     }
     try {
       // Destroy throws an exception if the API is not successful
-      await destroy(`${config.baseUrl}authentication/session`);
+      await destroy(`${config.baseUrl}authentication/${submissionId}/session`);
     } catch (e) {
       dispatch({
         type: 'API_ERROR',
@@ -186,6 +187,7 @@ FormStepSaveModal.propTypes = {
   closeModal: PropTypes.func.isRequired,
   onSaveConfirm: PropTypes.func.isRequired,
   suspendFormUrl: PropTypes.string.isRequired,
+  submissionId: PropTypes.string.isRequired,
 };
 
 export default FormStepSaveModal;


### PR DESCRIPTION
Fixes open-formulieren/open-forms#2114

The generic logout endpoint was removed in 2.0.0, the submission- specific one needs to be used.