### PR TITLE
:art: emit own styles/design tokens in openforms-theme scope

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,3 @@
+<script defer>
+  document.documentElement.classList.add("openforms-theme");
+</script>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -27,6 +27,7 @@ export const parameters = {
   },
   themes: {
     default: "Open Forms",
+    target: 'root',
     list: [
       { name: 'Open Forms', class: 'openforms-theme', color: '#01689B' },
       { name: 'Gemeente Den Haag', class: 'denhaag-theme', color: 'hsl(138 58% 33%)' },

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+1.3.0 (2022-??-??) - in development
+===================================
+
+.. warning:: The default Open Forms theme is now only applied within the
+   ``.openforms-theme`` selector. If you embed the SDK 1.3, you need to ensure a/the
+   parent element has this class name.
+
 1.2.4 (2022-10-24)
 ==================
 

--- a/src/components/Button.stories.mdx
+++ b/src/components/Button.stories.mdx
@@ -21,7 +21,7 @@ import FAIcon from "./FAIcon";
     onDisabledClick: {table: {disable: true}},
   }}
   parameters={{
-    controls: {sort: 'requiredFirst'}
+    controls: {sort: 'requiredFirst'},
   }}
 />
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -8,8 +8,8 @@
 @import 'flatpickr/dist/flatpickr.min.css';
 @import "formiojs/dist/formio.form.css";
 
-// output the design tokens in :root
-@import "@open-formulieren/design-tokens/dist/root.css";
+// output the design tokens under the .openforms-theme classname
+@import "@open-formulieren/design-tokens/dist/index.css";
 
 @import "./scss/settings";
 


### PR DESCRIPTION
Relates to open-formulieren/open-forms#2225

To avoid overriding design tokens from *other* themes, include our own scoped design token values only if the openforms theme is set.