### PR TITLE
:truck: [#2232] Rename i18nEnabled -> translationEnabled

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -12,7 +12,7 @@ import OFLibrary from './formio/templates';
 
 import './styles.scss';
 
-import { get } from 'api';
+import { get, post } from 'api';
 import { ConfigContext, FormioTranslations } from 'Context';
 import App from 'components/App';
 import {CSPNonce} from 'headers';
@@ -98,6 +98,11 @@ class OpenForm {
     const [messages, translations, formObject] = await Promise.all(promises);
 
     this.formObject = formObject;
+
+    // Explicitly set the default language if translations are disabled
+    if(!formObject.translationEnabled) {
+      await post(`${formObject.url}/set_default_language`);
+    }
 
     // render the wrapping React component
     // TODO: make this work with React 18 which has a different react-dom API

--- a/src/types/Form.js
+++ b/src/types/Form.js
@@ -43,7 +43,7 @@ const Form = PropTypes.shape({
   explanationTemplate:PropTypes.string,
   requiredFieldsWithAsterisk: PropTypes.bool,
   autoLoginAuthenticationBackend: PropTypes.string,
-  i18nEnabled: PropTypes.bool,
+  translationEnabled: PropTypes.bool,
 });
 
 export default Form;


### PR DESCRIPTION
since the djangorestframework-camel-case parser does not seem to parse i18nEnabled properly (it results in i_18n_enabled)