### PR TITLE
Load translations onLanguageChanged

### DIFF
--- a/src/Context.js
+++ b/src/Context.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const ConfigContext = React.createContext({baseUrl: '', basePath: ''});
+const ConfigContext = React.createContext({baseUrl: '', basePath: '', onLanguageChanged: console.log});
 ConfigContext.displayName = 'ConfigContext';
 
 const FormioTranslations = React.createContext({i18n: {}, language: ''});

--- a/src/components/LanguageSelection/LanguageSelection.js
+++ b/src/components/LanguageSelection/LanguageSelection.js
@@ -21,10 +21,9 @@ const DEFAULT_HEADING = (
 const LanguageSelection = ({
   heading=DEFAULT_HEADING,
   headingLevel=2,
-  onLanguageChanged=console.log,
 }) => {
   // Hook uses
-  const { baseUrl } = useContext(ConfigContext);
+  const { baseUrl, onLanguageChanged } = useContext(ConfigContext);
   const { locale } = useIntl();
   const [ updatingLanguage, setUpdatingLanguage ] = useState(false);
   const [ err, setErr ] = useState(null);

--- a/src/components/LanguageSelection/LanguageSelection.stories.mdx
+++ b/src/components/LanguageSelection/LanguageSelection.stories.mdx
@@ -1,7 +1,7 @@
 import {useState} from 'react';
 import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs';
 import { within, userEvent, waitFor } from '@storybook/testing-library';
-import { expect, fn } from '@storybook/jest';
+import { expect } from '@storybook/jest';
 import { IntlProvider } from 'react-intl';
 
 import { ConfigContext } from 'Context';

--- a/src/components/LanguageSelection/LanguageSelection.stories.mdx
+++ b/src/components/LanguageSelection/LanguageSelection.stories.mdx
@@ -1,7 +1,7 @@
 import {useState} from 'react';
 import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs';
 import { within, userEvent, waitFor } from '@storybook/testing-library';
-import { expect } from '@storybook/jest';
+import { expect, fn } from '@storybook/jest';
 import { IntlProvider } from 'react-intl';
 
 import { ConfigContext } from 'Context';
@@ -12,7 +12,7 @@ import { LanguageSelection, LanguageSelectionDisplay } from '.';
 export const BASE_URL = 'http://localhost:8000/api/v2/';
 
 export const ConfigDecorator = (Story, { args }) => (
-  <ConfigContext.Provider value={{ baseUrl: args.baseUrl || BASE_URL }}>
+  <ConfigContext.Provider value={{ baseUrl: args.baseUrl || BASE_URL, onLanguageChanged: args.onLanguageChanged }}>
     <Story />
   </ConfigContext.Provider>
 );
@@ -33,7 +33,6 @@ export const ConfigDecorator = (Story, { args }) => (
         type: { summary: 'number' },
       },
     },
-    onLanguageChanged: { table: { disable: true } },
   }}
   parameters={{
     mockData: [
@@ -103,7 +102,6 @@ export const DisplayTemplate = (args) => <LanguageSelectionDisplay {...args} />;
           current: false,
         },
       ],
-      onLanguageChange: console.log,
     }}
   >
     {DisplayTemplate.bind({})}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,19 +1,99 @@
-import messagesNL from './i18n/compiled/nl.json';
-import messagesEN from './i18n/compiled/en.json';
-import { get } from 'api';
+import React, { useState } from "react";
+import { useAsync } from "react-use";
+import { IntlProvider } from "react-intl";
+
+import App from "components/App";
+import Loader from "components/Loader";
+
+import { get, post } from "api";
+import { ConfigContext, FormioTranslations } from "Context";
+
+import messagesNL from "./i18n/compiled/nl.json";
+import messagesEN from "./i18n/compiled/en.json";
 
 const loadLocaleData = (locale) => {
-    switch (locale) {
-        case 'nl':
-            return messagesNL;
-        default:
-            return messagesEN;
-    }
+  switch (locale) {
+    case "nl":
+      return messagesNL;
+    default:
+      return messagesEN;
+  }
 };
 
 const loadFormioTranslations = async (baseUrl) => {
   return get(`${baseUrl}translations/formio`);
 };
 
+/**
+ * A form language manager.
+ *
+ * Component concerned with managing the active language of a form
+ * it's responsible for (re-)loading all i18n strings a form may need.
+ *
+ * @param {string} initialLang - Initially requested default language
+ * @param {string} baseUrl - Open Forms API base URL
+ * @param {string} basePath - Base path of the form router
+ * @param {HTMLElement=} languageSelectorTarget - (optional) Element to render the LanaguageSelector in
+ * @return {JSX} - App with required context
+ */
+const I18NManager = ({
+  initialLang,
+  baseUrl,
+  basePath,
+  languageSelectorTarget,
+  formUrl,
+}) => {
+  const [lang, setLang] = useState(initialLang);
 
-export {loadLocaleData, loadFormioTranslations};
+  const loadForm = async (formUrl) => {
+    const formInfo = await get(formUrl);
+    if (!formInfo.translationEnabled) {
+      // force the default form language
+      const { activeLanguage } = await post(
+        `${formInfo.url}/activate_default_language`
+      );
+      // trigger reload if needed
+      setLang(activeLanguage);
+    }
+    return formInfo;
+  };
+
+  const { loading, value, error } = useAsync(async () => {
+    // Optimistically start loading strings
+    const [formInfo, messages, translations] = await Promise.all([
+      loadForm(formUrl), //but start form load first; it might trigger a reload
+      loadLocaleData(lang),
+      loadFormioTranslations(baseUrl),
+    ]);
+    return [formInfo, messages, translations];
+  }, [lang, baseUrl, formUrl]);
+
+  if (loading) return <Loader />;
+  if (error) throw error;
+  // Clear to unpack all promises
+  const [formInfo, messages, translations] = value;
+
+  return (
+    <ConfigContext.Provider
+      value={{
+        baseUrl: baseUrl,
+        basePath: basePath,
+        onLanguageChanged: setLang,
+      }}
+    >
+      <IntlProvider messages={messages} locale={lang} defaultLocale="nl">
+        <FormioTranslations.Provider
+          value={{ i18n: translations, language: lang }}
+        >
+          <App
+            languageSelectorTarget={languageSelectorTarget}
+            form={formInfo}
+          />
+        </FormioTranslations.Provider>
+      </IntlProvider>
+    </ConfigContext.Provider>
+  );
+};
+
+export default I18NManager;
+export { I18NManager, loadLocaleData, loadFormioTranslations };

--- a/src/sdk.spec.js
+++ b/src/sdk.spec.js
@@ -51,8 +51,8 @@ describe("OpenForm", () => {
     const target = document.createElement("div");
 
     apiModule.get
-      .mockReturnValueOnce({})  // formio translations
       .mockReturnValueOnce(FORM)  // form detail endpoint
+      .mockReturnValueOnce({})  // formio translations
       .mockReturnValueOnce(LANGUAGE_INFO)  // language info
     ;
 
@@ -82,8 +82,8 @@ describe("OpenForm", () => {
     const target = document.getElementById("my-languages-element");
 
     apiModule.get
-      .mockReturnValueOnce({})  // formio translations
       .mockReturnValueOnce(FORM)  // form detail endpoint
+      .mockReturnValueOnce({})  // formio translations
       .mockReturnValueOnce(LANGUAGE_INFO)  // language info
     ;
 


### PR DESCRIPTION
 - Adds I18NManager to cantain all language string loading and signalling re-renders.
 - Moves `onLanguageChanged` callback from `LanguageSelection` params to `ConfigContext`
   
 Closes open-formulieren/open-forms#2255