### PR TITLE
Restart submission on language changed

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -1,5 +1,6 @@
 import React, {useContext, useEffect} from 'react';
 import {useIntl} from 'react-intl';
+import {createGlobalstate} from 'state-pool';
 import {useImmerReducer} from 'use-immer';
 import {
   Redirect,
@@ -32,6 +33,20 @@ import {findNextApplicableStep} from 'components/utils';
 import useQuery from 'hooks/useQuery';
 import Types from 'types';
 import useAutomaticRedirect from 'hooks/useAutomaticRedirect';
+
+const globalSubmissionState = createGlobalstate({hasSubmission: false});
+
+const flagActiveSubmission = () => {
+  globalSubmissionState.updateValue(state => {
+    state.hasSubmission = true;
+  });
+};
+
+const flagNoActiveSubmission = () => {
+  globalSubmissionState.updateValue(state => {
+    state.hasSubmission = false;
+  });
+};
 
 /**
  * Create a submission instance from a given form instance
@@ -132,6 +147,7 @@ const reducer = (draft, action) => {
       type: 'SUBMISSION_LOADED',
       payload: submission,
     });
+    flagActiveSubmission();
     // navigate to the first step
     const firstStepRoute = `/stap/${form.steps[0].slug}`;
     history.push(next ? next : firstStepRoute);
@@ -148,6 +164,7 @@ const reducer = (draft, action) => {
     () => {
       removeSubmissionId();
       dispatch({type: 'DESTROY_SUBMISSION'});
+      flagNoActiveSubmission();
     }
   );
 
@@ -157,6 +174,7 @@ const reducer = (draft, action) => {
       if (intl.locale !== prevLocale) {
         removeSubmissionId();
         dispatch({type: 'DESTROY_SUBMISSION'});
+        flagNoActiveSubmission();
       }
     }, [intl.locale, prevLocale, removeSubmissionId] // eslint-disable-line react-hooks/exhaustive-deps
   );
@@ -187,6 +205,7 @@ const reducer = (draft, action) => {
       type: 'SUBMISSION_LOADED',
       payload: submission,
     });
+    flagActiveSubmission();
     setSubmissionId(submission.id);
     // navigate to the first step
     const firstStepRoute = `/stap/${form.steps[0].slug}`;
@@ -352,3 +371,4 @@ Form.propTypes = {
 };
 
 export default Form;
+export {globalSubmissionState};

--- a/src/components/LanguageSelection/LanguageSelection.js
+++ b/src/components/LanguageSelection/LanguageSelection.js
@@ -23,7 +23,7 @@ const LanguageSelection = ({heading=DEFAULT_HEADING, headingLevel=2}) => {
   // Hook uses
   const { baseUrl } = useContext(ConfigContext);
   const { onLanguageChangeDone } = useContext(I18NContext);
-  const { locale } = useIntl();
+  const { locale, formatMessage } = useIntl();
   const [ updatingLanguage, setUpdatingLanguage ] = useState(false);
   const [ err, setErr ] = useState(null);
 
@@ -59,6 +59,16 @@ const LanguageSelection = ({heading=DEFAULT_HEADING, headingLevel=2}) => {
     // do nothing if this is already the active language
     // or if an update is being processed.
     if (updatingLanguage || languageCode === locale) return;
+
+    const confirmationQuestion = formatMessage(
+      {
+        description: 'change language prompt',
+        defaultMessage: 'Changing language will empty the form. Continue?'
+      }
+    );
+    if (!window.confirm(confirmationQuestion)) {
+      return;
+    }
 
     setUpdatingLanguage(true);
     // activate other language in backend

--- a/src/components/LanguageSelection/LanguageSelection.js
+++ b/src/components/LanguageSelection/LanguageSelection.js
@@ -1,10 +1,12 @@
 import PropTypes from 'prop-types';
 import React, { useContext, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { useGlobalState } from 'state-pool';
 import { useAsync } from 'react-use';
 
 import { get, put } from 'api';
 import { ConfigContext } from 'Context';
+import { globalSubmissionState } from 'components/Form';
 import Loader from 'components/Loader';
 import { I18NContext } from 'i18n';
 
@@ -26,6 +28,7 @@ const LanguageSelection = ({heading=DEFAULT_HEADING, headingLevel=2}) => {
   const { locale, formatMessage } = useIntl();
   const [ updatingLanguage, setUpdatingLanguage ] = useState(false);
   const [ err, setErr ] = useState(null);
+  const [ submissionState ] = useGlobalState(globalSubmissionState);
 
   // fetch language information from API
   const {loading, value: languageInfo, error} = useAsync(
@@ -66,8 +69,12 @@ const LanguageSelection = ({heading=DEFAULT_HEADING, headingLevel=2}) => {
         defaultMessage: 'Changing language will empty the form. Continue?'
       }
     );
-    if (!window.confirm(confirmationQuestion)) {
-      return;
+
+    // only prompt to confirm if there is an active submission
+    if (submissionState.hasSubmission) {
+      if (!window.confirm(confirmationQuestion)) {
+        return;
+      }
     }
 
     setUpdatingLanguage(true);

--- a/src/components/LanguageSelection/LanguageSelection.js
+++ b/src/components/LanguageSelection/LanguageSelection.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useContext, useState } from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage, defineMessage, useIntl } from 'react-intl';
 import { useGlobalState } from 'state-pool';
 import { useAsync } from 'react-use';
 
@@ -8,7 +8,7 @@ import { get, put } from 'api';
 import { ConfigContext } from 'Context';
 import { globalSubmissionState } from 'components/Form';
 import Loader from 'components/Loader';
-import { I18NContext } from 'i18n';
+import { I18NContext, formatMessageForLocale } from 'i18n';
 
 import LanguageSelectionDisplay from './LanguageSelectionDisplay';
 
@@ -21,11 +21,17 @@ const DEFAULT_HEADING = (
 );
 
 
+const changeLanguagePrompt = defineMessage({
+  description: 'change language prompt',
+  defaultMessage: 'Changing language will empty the form. Continue?'
+});
+
+
 const LanguageSelection = ({heading=DEFAULT_HEADING, headingLevel=2}) => {
   // Hook uses
   const { baseUrl } = useContext(ConfigContext);
   const { onLanguageChangeDone } = useContext(I18NContext);
-  const { locale, formatMessage } = useIntl();
+  const { locale } = useIntl();
   const [ updatingLanguage, setUpdatingLanguage ] = useState(false);
   const [ err, setErr ] = useState(null);
   const [ submissionState ] = useGlobalState(globalSubmissionState);
@@ -63,12 +69,7 @@ const LanguageSelection = ({heading=DEFAULT_HEADING, headingLevel=2}) => {
     // or if an update is being processed.
     if (updatingLanguage || languageCode === locale) return;
 
-    const confirmationQuestion = formatMessage(
-      {
-        description: 'change language prompt',
-        defaultMessage: 'Changing language will empty the form. Continue?'
-      }
-    );
+    const confirmationQuestion = formatMessageForLocale(languageCode, changeLanguagePrompt);
 
     // only prompt to confirm if there is an active submission
     if (submissionState.hasSubmission) {

--- a/src/components/LanguageSelection/LanguageSelection.js
+++ b/src/components/LanguageSelection/LanguageSelection.js
@@ -23,7 +23,7 @@ const DEFAULT_HEADING = (
 
 const changeLanguagePrompt = defineMessage({
   description: 'change language prompt',
-  defaultMessage: 'Changing language will empty the form. Continue?'
+  defaultMessage: 'Changing the language will require you to restart the form. Are you sure you want to continue?',
 });
 
 
@@ -72,10 +72,8 @@ const LanguageSelection = ({heading=DEFAULT_HEADING, headingLevel=2}) => {
     const confirmationQuestion = formatMessageForLocale(languageCode, changeLanguagePrompt);
 
     // only prompt to confirm if there is an active submission
-    if (submissionState.hasSubmission) {
-      if (!window.confirm(confirmationQuestion)) {
-        return;
-      }
+    if (submissionState.hasSubmission && !window.confirm(confirmationQuestion)) {
+      return;
     }
 
     setUpdatingLanguage(true);

--- a/src/components/LanguageSelection/LanguageSelection.stories.mdx
+++ b/src/components/LanguageSelection/LanguageSelection.stories.mdx
@@ -179,6 +179,7 @@ export const Template = (args) => {
       const canvas = within(canvasElement);
       // wait for api info call to return
       let frysk_button = await waitFor(() => canvas.findByText(/^fy$/i));
+      window.confirm = () => true;
       await userEvent.click(frysk_button);
       // wait for PUT api call to have completed and loading state to be resolved
       await waitFor(() => canvas.findByText(/^fy$/i));
@@ -257,6 +258,7 @@ Errors are left to bubble up to the nearest `ErrorBoundary`, e.g. if for some re
     play={async ({args, canvasElement}) => {
       const canvas = within(canvasElement);
       const frysk_button = await waitFor(() => canvas.findByText(/^fy$/i)); // wait for api info call to return
+      window.confirm = () => true;
       await userEvent.click(frysk_button);
       await waitFor(() => expect(args.onLanguageChangeDone).toHaveBeenCalledTimes(0)); // did not change language
     }}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -2,7 +2,7 @@ import React, {useContext} from 'react';
 import PropTypes from 'prop-types';
 import { createGlobalstate, useGlobalState } from 'state-pool';
 import {useAsync} from 'react-use';
-import { IntlProvider } from 'react-intl';
+import { IntlProvider, createIntl, createIntlCache } from 'react-intl';
 
 // ensure flatpickr locales are included in bundle
 import "flatpickr/dist/l10n/nl.js";
@@ -30,6 +30,18 @@ const loadLocaleData = (locale) => {
             return messagesEN;
     }
 };
+
+/*
+Functionality to localize messages in a locale outside of the usual React lifecycle.
+ */
+const cache = createIntlCache();
+
+const formatMessageForLocale = (locale, msg) => {
+  const messages = loadLocaleData(locale);
+  const intl = createIntl({locale, messages}, cache);
+  return intl.formatMessage(msg);
+};
+
 
 // TODO: add language code argument!
 const loadFormioTranslations = async (baseUrl) => {
@@ -143,6 +155,7 @@ class I18NErrorBoundary extends React.Component {
 
 export {
   setLanguage,
+  formatMessageForLocale,
   I18NManager,
   I18NContext,
   I18NErrorBoundary,

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -11,6 +11,12 @@
       "value": "Something went wrong while presenting the login option. Please contact the municipality."
     }
   ],
+  "40nqWB": [
+    {
+      "type": 0,
+      "value": "Changing language will empty the form. Continue?"
+    }
+  ],
   "5uh2hS": [
     {
       "type": 0,

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -11,6 +11,12 @@
       "value": "Er is iets fout gegaan bij het presenteren van de inlogopties. Neem alstublieft contact met ons op."
     }
   ],
+  "40nqWB": [
+    {
+      "type": 0,
+      "value": "De taal veranderen, begint met een leeg formulier. Doorgaan?"
+    }
+  ],
   "5uh2hS": [
     {
       "type": 0,

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -9,11 +9,6 @@
     "description": "Co-sign auth option not available on form",
     "originalDefault": "Something went wrong while presenting the login option. Please contact the municipality."
   },
-  "40nqWB": {
-    "defaultMessage": "Changing language will empty the form. Continue?",
-    "description": "change language prompt",
-    "originalDefault": "Changing language will empty the form. Continue?"
-  },
   "5uh2hS": {
     "defaultMessage": "Appointment cancellation failed",
     "description": "Appointment cancellation error message",
@@ -38,6 +33,11 @@
     "defaultMessage": "Please accept the privacy policy before submitting",
     "description": "Warning privacy policy not checked when submitting",
     "originalDefault": "Please accept the privacy policy before submitting"
+  },
+  "94yVWJ": {
+    "defaultMessage": "Changing the language will require you to restart the form. Are you sure you want to continue?",
+    "description": "change language prompt",
+    "originalDefault": "Changing the language will require you to restart the form. Are you sure you want to continue?"
   },
   "9AU8U0": {
     "defaultMessage": "Unfortunately, this form is no longer in use. We apologise for any inconveniences.",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -9,6 +9,11 @@
     "description": "Co-sign auth option not available on form",
     "originalDefault": "Something went wrong while presenting the login option. Please contact the municipality."
   },
+  "40nqWB": {
+    "defaultMessage": "Changing language will empty the form. Continue?",
+    "description": "change language prompt",
+    "originalDefault": "Changing language will empty the form. Continue?"
+  },
   "5uh2hS": {
     "defaultMessage": "Appointment cancellation failed",
     "description": "Appointment cancellation error message",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -9,6 +9,11 @@
     "description": "Co-sign auth option not available on form",
     "originalDefault": "Something went wrong while presenting the login option. Please contact the municipality."
   },
+  "40nqWB": {
+    "defaultMessage": "De taal veranderen, begint met een leeg formulier. Doorgaan?",
+    "description": "change language prompt",
+    "originalDefault": "Changing language will empty the form. Continue?"
+  },
   "5uh2hS": {
     "defaultMessage": "Afspraak annuleren mislukt",
     "description": "Appointment cancellation error message",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -9,11 +9,6 @@
     "description": "Co-sign auth option not available on form",
     "originalDefault": "Something went wrong while presenting the login option. Please contact the municipality."
   },
-  "40nqWB": {
-    "defaultMessage": "De taal veranderen, begint met een leeg formulier. Doorgaan?",
-    "description": "change language prompt",
-    "originalDefault": "Changing language will empty the form. Continue?"
-  },
   "5uh2hS": {
     "defaultMessage": "Afspraak annuleren mislukt",
     "description": "Appointment cancellation error message",
@@ -38,6 +33,11 @@
     "defaultMessage": "U moet akkoord gaan met het privacybeleid om door te gaan",
     "description": "Warning privacy policy not checked when submitting",
     "originalDefault": "Please accept the privacy policy before submitting"
+  },
+  "94yVWJ": {
+    "defaultMessage": "Indien u de taal verandert, dan moet u opnieuw beginnen met het formulier in te vullen. Bent u zeker dat u wilt doorgaan?",
+    "description": "change language prompt",
+    "originalDefault": "Changing the language will require you to restart the form. Are you sure you want to continue?"
   },
   "9AU8U0": {
     "defaultMessage": "Helaas is dit formulier niet langer in gebruik. Onze excuses voor eventuele ongemakken.",


### PR DESCRIPTION
Relates to https://github.com/open-formulieren/open-forms/issues/2256

This MVP has issues:
**Terrible UX**

1. The confirmation message needs improvement. But more importantly, it is shown in the current locale, which the user may not speak well.
1. The confirmation is oblivious of submission state; confusing confirmation shouldn't be asked if no data loss is at stake.

**Backend**
1. submissions are abandoned and left for a backend task to clean up
