### PR TITLE
[OF#2341] Reformat currencies on form change

### DIFF
--- a/src/components/FormStep.js
+++ b/src/components/FormStep.js
@@ -566,6 +566,11 @@ const FormStep = ({
     logicCheckTimeout.current = {timeoutId, canSubmit: localCanSubmit};
 
     dispatch({type: 'FORMIO_CHANGE_HANDLED'});
+
+    const formInstance = formRef.current?.instance?.instance;
+    if (formInstance && !modifiedByHuman) {
+      formInstance.emit('reformatCurrencies');
+    }
   };
 
   const isLoadingSomething = (loading || isNavigating);

--- a/src/formio/components/Currency.js
+++ b/src/formio/components/Currency.js
@@ -10,6 +10,16 @@ import { applyPrefix } from '../utils';
  * Extend the default text field to modify it to our needs.
  */
 class Currency extends Formio.Components.components.currency {
+  constructor(component, options, data) {
+    super(component, options, data);
+
+    this.on('reformatCurrencies', () => {
+      const value = this.data[this.key]
+      if (!value) return;
+      this.element.value = this.getValueAsString(this.addZerosAndFormatValue(this.parseValue(value)));
+      this.redraw();
+    });
+  }
 
   formatValue(value) {
     if (this.component.requireDecimal && value && !value.includes(this.decimalSeparator)) {


### PR DESCRIPTION
Fixes open-formulieren/open-forms#2341

Best I could do for now: https://watch.screencastify.com/v/SUXZ9fpH0I1YKO3TCvHG

Drawbacks:
- Flickering 
- Sometimes the cursor jumps in unexpected ways so you accidentally write wrong numbers