### PR TITLE
Use new formio translation endpoints

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -43,9 +43,9 @@ const formatMessageForLocale = (locale, msg) => {
 };
 
 
-// TODO: add language code argument!
-const loadFormioTranslations = async (baseUrl) => {
-  return get(`${baseUrl}translations/formio`);
+const loadFormioTranslations = async (baseUrl, languageCode) => {
+  const messages = await get(`${baseUrl}i18n/formio/${languageCode}`);
+  return {[languageCode]: messages};
 };
 
 
@@ -65,7 +65,7 @@ const I18NManager = ({ languageSelectorTarget, children }) => {
     async () => {
       const promises = [
         loadLocaleData(languageCode),
-        loadFormioTranslations(baseUrl),
+        loadFormioTranslations(baseUrl, languageCode),
       ];
       const [messages, formioTranslations] = await Promise.all(promises);
       return {

--- a/src/i18n.stories.mdx
+++ b/src/i18n.stories.mdx
@@ -29,14 +29,21 @@ export const ConfigDecorator = (Story, { args }) => (
     },
     mockData: [
       {
-        url: `${BASE_URL}translations/formio`,
+        url: `${BASE_URL}i18n/formio/nl`,
         method: 'GET',
         status: 200,
         response: {
-          'nl': {
-            "Click to set value": "Klik om waarde in te stellen",
-            "Cancel": "Annuleren",
-          },
+          "Click to set value": "Klik om waarde in te stellen",
+          "Cancel": "Annuleren",
+        }
+      },
+      {
+        url: `${BASE_URL}i18n/formio/en`,
+        method: 'GET',
+        status: 200,
+        response: {
+          "Click to set value": "Click to set value",
+          "Cancel": "Cancel",
         }
       }
     ]
@@ -106,7 +113,7 @@ export const ErrorTemplate = (args) => (
     parameters={{
       mockData: [
         {
-          url: `${BASE_URL}translations/formio`,
+          url: `${BASE_URL}i18n/formio/nl`,
           method: 'GET',
           status: 503,
           response: {


### PR DESCRIPTION
Companion to open-formulieren/open-forms#2366

Now the language-specific formio translations are loaded on language changes.