### PR TITLE
Restart submission on language change

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -9,6 +9,7 @@ import {usePrevious} from 'react-use';
 import {ConfigContext} from 'Context';
 
 import {destroy, post} from 'api';
+import {START_FORM_QUERY_PARAM} from 'components/constants';
 import usePageViews from 'hooks/usePageViews';
 import useRecycleSubmission from 'hooks/useRecycleSubmission';
 import useSessionTimeout from 'hooks/useSessionTimeout';
@@ -166,6 +167,7 @@ const Form = ({form}) => {
         removeSubmissionId();
         dispatch({type: 'DESTROY_SUBMISSION'});
         flagNoActiveSubmission();
+        history.push(`/?${START_FORM_QUERY_PARAM}=1`);
       }
     },
     [intl.locale, prevLocale, removeSubmissionId] // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Fixes open-formulieren/open-forms#2256

Instead of going back to the start and presenting the user with the login options again, immediately start a new submission as their session should still be valid.