### PR TITLE
🐛 [open-formulieren/open-forms#2384] Fix initial language switch

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -163,14 +163,14 @@ const Form = ({form}) => {
   useEffect(
     () => {
       if (prevLocale === undefined) return;
-      if (intl.locale !== prevLocale) {
+      if (intl.locale !== prevLocale && state.submission) {
         removeSubmissionId();
         dispatch({type: 'DESTROY_SUBMISSION'});
         flagNoActiveSubmission();
         history.push(`/?${START_FORM_QUERY_PARAM}=1`);
       }
     },
-    [intl.locale, prevLocale, removeSubmissionId] // eslint-disable-line react-hooks/exhaustive-deps
+    [intl.locale, prevLocale, removeSubmissionId, state.submission] // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   const paymentOverviewMatch = useRouteMatch('/betaaloverzicht');


### PR DESCRIPTION
Don't start a new submission if none were already started. The user may not have logged in yet, and if the form requires login, user won't have permission to go to first step yet.

Stopped my attempt at writing `Form.spec.js` when after 3 mocks and 2 contexts in, I still didn't come past the Loader. There are way to many moving parts to make Form testable in isolation. :disappointed: 

Fixes open-formulieren/open-forms#2384