### PR TITLE
Add support for pluggable/configurable replacement components

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ indent_size = 2
 
 [*.{yml,yaml}]
 indent_size = 2
+
+[*.mdx]
+indent_size = 2

--- a/src/Context.js
+++ b/src/Context.js
@@ -1,6 +1,13 @@
 import React from 'react';
 
-const ConfigContext = React.createContext({baseUrl: '', basePath: ''});
+const ConfigContext = React.createContext({
+  baseUrl: '',
+  basePath: '',
+  displayComponents: {
+    form: null,
+    progressIndicator: null,
+  },
+});
 ConfigContext.displayName = 'ConfigContext';
 
 const FormioTranslations = React.createContext({i18n: {}, language: ''});

--- a/src/Context.js
+++ b/src/Context.js
@@ -4,6 +4,7 @@ const ConfigContext = React.createContext({
   baseUrl: '',
   basePath: '',
   displayComponents: {
+    app: null,
     form: null,
     progressIndicator: null,
   },

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,12 +4,15 @@ import {Switch, Route} from 'react-router-dom';
 
 import AppDebug from 'components/AppDebug';
 import Form from 'components/Form';
-import {Layout, LayoutRow} from 'components/Layout';
-import ManageAppointment from 'components/appointments/ManageAppointment';
 import LanguageSelection from 'components/LanguageSelection';
+import {LayoutRow} from 'components/Layout';
+import ManageAppointment from 'components/appointments/ManageAppointment';
+import {ConfigContext} from 'Context';
 import {I18NContext} from 'i18n';
 import Types from 'types';
 import {DEBUG} from 'utils';
+
+import AppDisplay from './AppDisplay';
 
 const LanguageSwitcher = () => {
   const {languageSelectorTarget: target} = useContext(I18NContext);
@@ -26,32 +29,30 @@ const LanguageSwitcher = () => {
 Top level router - routing between an actual form or supporting screens.
  */
 const App = ({...props}) => {
+  const config = useContext(ConfigContext);
   const {
     form: {translationEnabled},
     noDebug = false,
   } = props;
+
+  const AppDisplayComponent = config?.displayComponents?.app ?? AppDisplay;
+
+  const languageSwitcher = translationEnabled ? <LanguageSwitcher /> : null;
+  const router = (
+    <Switch>
+      {/* Anything dealing with appointments gets routed to it's own sub-router */}
+      <Route path="/afspraak*" component={ManageAppointment} />
+
+      {/* All the rest goes to the actual form flow */}
+      <Route path="/">
+        <Form {...props} />
+      </Route>
+    </Switch>
+  );
+  const appDebug = DEBUG && !noDebug ? <AppDebug /> : null;
+
   return (
-    <Layout>
-      {translationEnabled ? <LanguageSwitcher /> : null}
-
-      <LayoutRow>
-        <Switch>
-          {/* Anything dealing with appointments gets routed to it's own sub-router */}
-          <Route path="/afspraak*" component={ManageAppointment} />
-
-          {/* All the rest goes to the actual form flow */}
-          <Route path="/">
-            <Form {...props} />
-          </Route>
-        </Switch>
-      </LayoutRow>
-
-      {DEBUG && !noDebug ? (
-        <LayoutRow>
-          <AppDebug />
-        </LayoutRow>
-      ) : null}
-    </Layout>
+    <AppDisplayComponent router={router} languageSwitcher={languageSwitcher} appDebug={appDebug} />
   );
 };
 

--- a/src/components/AppDisplay.js
+++ b/src/components/AppDisplay.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {Layout, LayoutRow} from 'components/Layout';
+
+const AppDisplay = ({router, languageSwitcher = null, appDebug = null}) => {
+  return (
+    <Layout>
+      {languageSwitcher}
+      <LayoutRow>{router}</LayoutRow>
+      {appDebug ? <LayoutRow>{appDebug}</LayoutRow> : null}
+    </Layout>
+  );
+};
+
+AppDisplay.propTypes = {
+  router: PropTypes.element.isRequired,
+  languageSwitcher: PropTypes.element,
+  appDebug: PropTypes.element,
+};
+
+export default AppDisplay;

--- a/src/components/AppDisplay.stories.mdx
+++ b/src/components/AppDisplay.stories.mdx
@@ -1,0 +1,52 @@
+import {Meta, Canvas, Story, ArgsTable} from '@storybook/addon-docs';
+
+import Body from 'components/Body';
+
+import AppDisplay from './AppDisplay';
+
+<Meta
+  title="Composites/App display"
+  component={AppDisplay}
+  argTypes={{
+    router: { table: {disable: true}},
+    languageSwitcher: { table: {disable: true}},
+    appDebug: { control: 'boolean' },
+  }}
+/>
+
+The `AppDisplay` component allows you to tweak the markup for the general SDK scaffolding.
+
+export const SpacedDiv = ({children}) => (
+    <div style={{
+        background: 'white',
+        margin: '.5em',
+        padding: '1em',
+        width: '100%',
+    }}>
+        {children}
+    </div>
+);
+
+export const Template = (args) => {
+    return (
+        <AppDisplay
+            router={<SpacedDiv><Body>{'<Router>'}</Body></SpacedDiv>}
+            languageSwitcher={
+              <div style={{marginLeft: 'auto', marginRight: 'auto'}}>
+                <Body>{'<Language switcher>'}</Body>
+              </div>}
+            appDebug={args.appDebug ? <SpacedDiv><Body>{'<App debug>'}</Body></SpacedDiv>: null}
+        />
+    );
+}
+
+<Canvas>
+  <Story
+    name="Default"
+    args={{appDebug: false }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable of={AppDisplay} />

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -14,6 +14,7 @@ import usePageViews from 'hooks/usePageViews';
 import useRecycleSubmission from 'hooks/useRecycleSubmission';
 import useSessionTimeout from 'hooks/useSessionTimeout';
 import ErrorBoundary from 'components/ErrorBoundary';
+import FormDisplay from 'components/FormDisplay';
 import FormStart from 'components/FormStart';
 import FormStep from 'components/FormStep';
 import {LayoutColumn} from 'components/Layout';
@@ -276,86 +277,89 @@ const Form = ({form}) => {
     );
   }
 
+  const progressIndicator = form.showProgressIndicator ? (
+    <ProgressIndicator
+      title={form.name}
+      steps={form.steps}
+      submission={state.submission || state.submittedSubmission}
+      submissionAllowed={form.submissionAllowed}
+      completed={state.completed}
+    />
+  ) : null;
+
+  // Route the correct page based on URL
+  const router = (
+    <Switch>
+      <Route exact path="/">
+        <ErrorBoundary useCard>
+          <FormStart form={form} onFormStart={onFormStart} />
+        </ErrorBoundary>
+      </Route>
+
+      <Route exact path="/overzicht">
+        <ErrorBoundary useCard>
+          <RequireSession expired={sessionExpired} expiryDate={expiryDate}>
+            <RequireSubmission
+              submission={state.submission}
+              form={form}
+              processingError={state.processingError}
+              onConfirm={onSubmitForm}
+              onLogout={onLogout}
+              component={Summary}
+              onClearProcessingErrors={() => dispatch({type: 'CLEAR_PROCESSING_ERROR'})}
+            />
+          </RequireSession>
+        </ErrorBoundary>
+      </Route>
+
+      <Route exact path="/bevestiging">
+        <ErrorBoundary useCard>
+          <RequireSubmission
+            submission={state.submittedSubmission}
+            statusUrl={state.processingStatusUrl}
+            onFailure={onProcessingFailure}
+            onConfirmed={() => dispatch({type: 'PROCESSING_SUCCEEDED'})}
+            component={SubmissionConfirmation}
+          />
+        </ErrorBoundary>
+      </Route>
+
+      <Route exact path="/betaaloverzicht">
+        <ErrorBoundary useCard>
+          <PaymentOverview />
+        </ErrorBoundary>
+      </Route>
+
+      <Route
+        path="/stap/:step"
+        render={() => (
+          <ErrorBoundary useCard>
+            <RequireSession expired={sessionExpired} expiryDate={expiryDate}>
+              <RequireSubmission
+                form={form}
+                submission={state.submission}
+                onLogicChecked={submission =>
+                  dispatch({type: 'SUBMISSION_LOADED', payload: submission})
+                }
+                onStepSubmitted={onStepSubmitted}
+                onLogout={onLogout}
+                component={FormStep}
+              />
+            </RequireSession>
+          </ErrorBoundary>
+        )}
+      />
+    </Switch>
+  );
+
   // render the form step if there's an active submission (and no summary)
   return (
-    <>
-      <LayoutColumn modifiers={['mobile-order-2', 'mobile-padding-top']}>
-        {/* Route the correct page based on URL */}
-        <Switch>
-          <Route exact path="/">
-            <ErrorBoundary useCard>
-              <FormStart form={form} onFormStart={onFormStart} />
-            </ErrorBoundary>
-          </Route>
-
-          <Route exact path="/overzicht">
-            <ErrorBoundary useCard>
-              <RequireSession expired={sessionExpired} expiryDate={expiryDate}>
-                <RequireSubmission
-                  submission={state.submission}
-                  form={form}
-                  processingError={state.processingError}
-                  onConfirm={onSubmitForm}
-                  onLogout={onLogout}
-                  component={Summary}
-                  onClearProcessingErrors={() => dispatch({type: 'CLEAR_PROCESSING_ERROR'})}
-                />
-              </RequireSession>
-            </ErrorBoundary>
-          </Route>
-
-          <Route exact path="/bevestiging">
-            <ErrorBoundary useCard>
-              <RequireSubmission
-                submission={state.submittedSubmission}
-                statusUrl={state.processingStatusUrl}
-                onFailure={onProcessingFailure}
-                onConfirmed={() => dispatch({type: 'PROCESSING_SUCCEEDED'})}
-                component={SubmissionConfirmation}
-              />
-            </ErrorBoundary>
-          </Route>
-
-          <Route exact path="/betaaloverzicht">
-            <ErrorBoundary useCard>
-              <PaymentOverview />
-            </ErrorBoundary>
-          </Route>
-
-          <Route
-            path="/stap/:step"
-            render={() => (
-              <ErrorBoundary useCard>
-                <RequireSession expired={sessionExpired} expiryDate={expiryDate}>
-                  <RequireSubmission
-                    form={form}
-                    submission={state.submission}
-                    onLogicChecked={submission =>
-                      dispatch({type: 'SUBMISSION_LOADED', payload: submission})
-                    }
-                    onStepSubmitted={onStepSubmitted}
-                    onLogout={onLogout}
-                    component={FormStep}
-                  />
-                </RequireSession>
-              </ErrorBoundary>
-            )}
-          />
-        </Switch>
-      </LayoutColumn>
-
-      {form.showProgressIndicator && !paymentOverviewMatch ? (
-        <LayoutColumn modifiers={['secondary', 'mobile-order-1', 'mobile-sticky']}>
-          <ProgressIndicator
-            title={form.name}
-            steps={form.steps}
-            submission={state.submission || state.submittedSubmission}
-            submissionAllowed={form.submissionAllowed}
-            completed={state.completed}
-          />
-        </LayoutColumn>
-      ) : null}
-    </>
+    <FormDisplay
+      router={router}
+      progressIndicator={progressIndicator}
+      showProgressIndicator={form.showProgressIndicator}
+      isPaymentOverview={!!paymentOverviewMatch}
+    />
   );
 };
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -353,8 +353,9 @@ const Form = ({form}) => {
   );
 
   // render the form step if there's an active submission (and no summary)
+  const FormDisplayComponent = config?.displayComponents?.form ?? FormDisplay;
   return (
-    <FormDisplay
+    <FormDisplayComponent
       router={router}
       progressIndicator={progressIndicator}
       showProgressIndicator={form.showProgressIndicator}

--- a/src/components/FormDisplay.js
+++ b/src/components/FormDisplay.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {LayoutColumn} from 'components/Layout';
+
+/**
+ * Layout component to render the form container.
+ * @return {JSX}
+ */
+const FormDisplay = ({
+  router,
+  progressIndicator = null,
+  showProgressIndicator = true,
+  isPaymentOverview = false,
+}) => {
+  const renderProgressIndicator = progressIndicator && showProgressIndicator && !isPaymentOverview;
+  return (
+    <>
+      <LayoutColumn modifiers={['mobile-order-2', 'mobile-padding-top']}>{router}</LayoutColumn>
+      {renderProgressIndicator ? (
+        <LayoutColumn modifiers={['secondary', 'mobile-order-1', 'mobile-sticky']}>
+          {progressIndicator}
+        </LayoutColumn>
+      ) : null}
+    </>
+  );
+};
+
+FormDisplay.propTypes = {
+  router: PropTypes.element.isRequired,
+  progressIndicator: PropTypes.element,
+  showProgressIndicator: PropTypes.bool,
+  isPaymentOverview: PropTypes.bool,
+};
+
+export default FormDisplay;

--- a/src/components/FormDisplay.stories.mdx
+++ b/src/components/FormDisplay.stories.mdx
@@ -1,0 +1,74 @@
+import {Meta, Canvas, Story, ArgsTable} from '@storybook/addon-docs';
+
+import Card from 'components/Card';
+import {Layout, LayoutRow} from 'components/Layout';
+import Body from 'components/Body';
+
+import FormDisplay from './FormDisplay';
+
+export const PaddedDiv = ({className, children}) => (
+  <div style={{padding: '1em 0'}} className={className}>{children}</div>
+);
+
+export const LayoutDecorator = (Story) => {
+  return (
+    <Layout component={PaddedDiv}>
+      <LayoutRow>
+        <Story />
+      </LayoutRow>
+    </Layout>
+  );
+};
+
+<Meta
+  title="Composites/Form display"
+  component={FormDisplay}
+  argTypes={{
+    showProgressIndicator: {control: 'boolean'},
+    isPaymentOverview: {control: 'boolean'},
+    router: { table: {disable: true}},
+    progressIndicator: { table: {disable: true}},
+  }}
+  decorators={[LayoutDecorator]}
+  parameters={{
+    docs: {
+      source: {
+        type: 'dynamic',
+        excludeDecorators: true,
+      }
+    }
+  }}
+/>
+
+The `FormDisplay` component allows you to manage the layout when forms and sub-pages are rendered.
+By default, it displays the form step and progress indicator in two columns.
+
+export const DummyRouter = () => <Card><Body>Body with routing capabilities</Body></Card>;
+
+export const DummyProgressIndicator = () => <Card><Body>Progress indicator</Body></Card>;
+
+export const Template = (args) => {
+  return (
+    <FormDisplay
+      router={<DummyRouter />}
+      progressIndicator={<DummyProgressIndicator />}
+      {...args}
+    />
+  );
+};
+
+<Canvas>
+  <Story
+    name="Default"
+    args={{
+      showProgressIndicator: true,
+      isPaymentOverview: false,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={FormDisplay} />

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types';
 
 import {getBEMClassName} from 'utils';
 
-const Layout = ({children, component = 'div'}) => {
+const Layout = ({children, component: Component = 'div'}) => {
   const className = getBEMClassName('layout');
-  const Component = `${component}`;
   return <Component className={className}>{children}</Component>;
 };
 

--- a/src/components/ProgressIndicator/ProgressIndicatorDisplay.js
+++ b/src/components/ProgressIndicator/ProgressIndicatorDisplay.js
@@ -3,13 +3,13 @@ import {FormattedMessage} from 'react-intl';
 import {Link} from 'react-router-dom';
 import PropTypes from 'prop-types';
 
-import {getBEMClassName} from 'utils';
 import FAIcon from 'components/FAIcon';
 import Caption from 'components/Caption';
 import Anchor from 'components/Anchor';
 import Body from 'components/Body';
 import Card from 'components/Card';
 import List from 'components/List';
+import {getBEMClassName} from 'utils';
 
 import {STEP_LABELS} from './constants';
 import ProgressItem from './ProgressItem';

--- a/src/components/ProgressIndicator/index.js
+++ b/src/components/ProgressIndicator/index.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, {useContext} from 'react';
 import PropTypes from 'prop-types';
 import {useRouteMatch} from 'react-router-dom';
 
 import {SUBMISSION_ALLOWED} from 'components/constants';
-import Types from 'types';
+import {ConfigContext} from 'Context';
 import {IsFormDesigner} from 'headers';
+import Types from 'types';
 
 import ProgressIndicatorDisplay from './ProgressIndicatorDisplay';
 import {STEP_LABELS} from './constants';
@@ -16,6 +17,7 @@ const ProgressIndicator = ({
   submissionAllowed,
   completed = false,
 }) => {
+  const config = useContext(ConfigContext);
   const summaryMatch = !!useRouteMatch('/overzicht');
   const stepMatch = useRouteMatch('/stap/:step');
   const confirmationMatch = !!useRouteMatch('/bevestiging');
@@ -76,8 +78,11 @@ const ProgressIndicator = ({
   const showOverview = submissionAllowedSpec !== SUBMISSION_ALLOWED.noWithoutOverview;
   const showConfirmation = submissionAllowedSpec === SUBMISSION_ALLOWED.yes;
 
+  const ProgressIndicatorDisplayComponent =
+    config?.displayComponents?.progressIndicator ?? ProgressIndicatorDisplay;
+
   return (
-    <ProgressIndicatorDisplay
+    <ProgressIndicatorDisplayComponent
       activeStepTitle={activeStepTitle}
       formTitle={title}
       steps={getStepsInfo(steps)}

--- a/src/custom-display-components.js
+++ b/src/custom-display-components.js
@@ -1,0 +1,92 @@
+import React from 'react';
+
+import Body from 'components/Body';
+import {STEP_LABELS} from 'components/ProgressIndicator/constants';
+
+const CustomAppDisplay = ({router, languageSwitcher = null, appDebug = null}) => (
+  <div style={{maxWidth: '1200px', margin: '0 auto'}}>
+    <div style={{display: 'flex', justifyContent: 'center'}}>{languageSwitcher}</div>
+    <div>{router}</div>
+    {appDebug ? <div>{appDebug}</div> : null}
+  </div>
+);
+
+const FormDisplay = ({
+  router,
+  progressIndicator = null,
+  showProgressIndicator = true,
+  isPaymentOverview = false,
+}) => {
+  const renderProgressIndicator = progressIndicator && showProgressIndicator && !isPaymentOverview;
+  return (
+    <>
+      {renderProgressIndicator ? (
+        <div style={{marginBottom: '1em'}}>{progressIndicator}</div>
+      ) : null}
+      <div>{router}</div>
+    </>
+  );
+};
+
+const ProgressIndicatorDisplay = ({
+  activeStepTitle,
+  formTitle,
+  steps,
+  hasSubmission,
+  isStartPage,
+  isSummary,
+  isConfirmation,
+  isSubmissionComplete,
+  areApplicableStepsCompleted,
+  showOverview,
+  showConfirmation,
+}) => {
+  const overviewLabel = showOverview ? STEP_LABELS.overview : false;
+  const confirmationLabel = showConfirmation ? STEP_LABELS.confirmation : false;
+
+  const labels = [
+    STEP_LABELS.login,
+    ...steps.map(step => step.formDefinition),
+    overviewLabel,
+    confirmationLabel,
+  ].filter(Boolean);
+
+  let children = [];
+  labels.forEach((label, index) => {
+    const isLast = index === labels.length - 1;
+    children.push(
+      <span key={index} style={{padding: '1em'}}>
+        <Body>{label}</Body>
+      </span>
+    );
+    if (!isLast)
+      children.push(
+        <span key={`sep-${index}`} style={{padding: '0 1em'}}>
+          •
+        </span>
+      );
+  });
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-around',
+        alignItems: 'center',
+        backgroundColor: 'var(--of-color-primary)',
+        color: 'var(--of-color-bg)',
+        '--of-color-fg': 'white',
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+const displayComponents = {
+  app: CustomAppDisplay,
+  form: FormDisplay,
+  progressIndicator: ProgressIndicatorDisplay,
+};
+
+export default displayComponents;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import {OpenForm} from './sdk';
 import './index.scss';
+// import displayComponents from './custom-display-components';
 
 const {REACT_APP_BASE_API_URL, REACT_APP_FORM_ID} = process.env;
 
@@ -10,6 +11,7 @@ window.onload = () => {
     baseUrl: REACT_APP_BASE_API_URL,
     formId: formId || REACT_APP_FORM_ID,
     basePath: '/',
+    // displayComponents,
   });
   form.init();
 };

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -39,6 +39,11 @@ Formio.libraries = {
 
 fixLeafletIconUrls();
 
+const defaultDisplayComponents = {
+  form: null,
+  progressIndicator: null,
+};
+
 class OpenForm {
   constructor(targetNode, opts) {
     const {
@@ -50,6 +55,7 @@ class OpenForm {
       sentryDSN,
       sentryEnv = '',
       languageSelectorTarget,
+      displayComponents = {}, // TODO: document as unstable API
     } = opts;
 
     this.targetNode = targetNode;
@@ -57,6 +63,7 @@ class OpenForm {
     this.formId = formId;
     this.formObject = null;
     this.lang = lang;
+    this.displayComponents = {...defaultDisplayComponents, ...displayComponents};
 
     switch (typeof languageSelectorTarget) {
       case 'string': {
@@ -104,7 +111,12 @@ class OpenForm {
     ReactDOM.render(
       <React.StrictMode>
         <ConfigContext.Provider
-          value={{baseUrl: this.baseUrl, basePath: this.basePath, titlePrefix: this.titlePrefix}}
+          value={{
+            baseUrl: this.baseUrl,
+            basePath: this.basePath,
+            titlePrefix: this.titlePrefix,
+            displayComponents: this.displayComponents,
+          }}
         >
           <I18NErrorBoundary>
             <I18NManager

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -40,6 +40,7 @@ Formio.libraries = {
 fixLeafletIconUrls();
 
 const defaultDisplayComponents = {
+  app: null,
   form: null,
   progressIndicator: null,
 };


### PR DESCRIPTION
Fixes open-formulieren/open-forms#1517

- [x] Split up the `Form` component into smart and "dumb" part
- [x] Provide mechanism to override default components

Quick demo with some alternative layout (ugly [code](https://github.com/open-formulieren/open-forms-sdk/pull/295/files#diff-e2e7a692ca6f6636dc97a0ca1fd80791aecfe66b5c6e2fcd4cfdcb9987c07138)!):

![image](https://user-images.githubusercontent.com/5518550/204020605-6e5275fb-5238-4b6b-8a33-6cb009e39fe5.png)

(also 
![image](https://user-images.githubusercontent.com/5518550/204020865-3bc86343-fca7-4e38-b48c-2617e2df6555.png)
)
