### PR TITLE
:wheelchair: nr.2270 add focus-styles and tabindex

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@formio/protected-eval": "^1.2.1",
     "@fortawesome/fontawesome-free": "^6.1.1",
-    "@open-formulieren/design-tokens": "^0.13.0",
+    "@open-formulieren/design-tokens": "^0.15.0",
     "@sentry/react": "^6.13.2",
     "@sentry/tracing": "^6.13.2",
     "classnames": "^2.3.1",

--- a/src/formio/templates/signature.ejs
+++ b/src/formio/templates/signature.ejs
@@ -4,7 +4,11 @@
   tabindex="{{ctx.component.tabindex || 0}}"
   ref="padBody"
 >
-  <button type="button" class="btn btn-sm btn-light signature-pad-refresh utrecht-button utrecht-button--html-button utrecht-button--subtle" ref="refresh">
+  <button
+    type="button"
+    class="btn btn-sm btn-light signature-pad-refresh utrecht-button utrecht-button--html-button utrecht-button--subtle"
+    ref="refresh"
+  >
     <i class="{{ctx.iconClass('refresh')}}"></i>
   </button>
   <canvas class="signature-pad-canvas" height="{{ctx.component.height}}" ref="canvas"></canvas>
@@ -13,10 +17,10 @@
     <i class="{{ctx.iconClass('asterisk')}}"></i>
   </span>
   {% } %}
-  <img ref="signatureImage" class="signature-pad-body__image">
+  <img ref="signatureImage" class="signature-pad-body__image" />
 </div>
 {% if (ctx.component.footer) { %}
-  <div class="signature-pad-footer">
-    {{ctx.t(ctx.component.footer, { _userInput: true })}}
-  </div>
+<div class="signature-pad-footer">
+  {{ctx.t(ctx.component.footer, {_userInput: true})}}
+</div>
 {% } %}

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -26,14 +26,17 @@ $button-padding-h: $grid-margin-2;
   $color-active: null,
   $color-background-active: null,
   $color-border-active: null,
-  $force-colors: false
+  $force-colors: false,
+  $color-border-focus: null
 ) {
   // build the selector either as just the parent or the parent with modifier,
   // based on the theme name
   $sel: #{&};
+
   @if $name != '' {
     $sel: '#{&}--#{$name}';
   }
+
   // now output the actual CSS rules
   @at-root #{$sel} {
     @if $force-colors {
@@ -48,6 +51,17 @@ $button-padding-h: $grid-margin-2;
     // border color
     border-right-color: $color-border !important;
     border-bottom-color: $color-border !important;
+
+    &:focus,
+    &:focus-visible {
+      // TODO: can be removed once there are utrecht design tokens for the bottom/right border color
+      // issue: https: //github.com/nl-design-system/utrecht/issues/1406
+      border-color: $color-border-focus !important;
+      border-right-color: $color-border-focus !important;
+      border-bottom-color: $color-border-focus !important;
+      // TODO: can be removed once there are utrecht design tokens for the border-width
+      border-width: 2px !important;
+    }
 
     &:not([aria-disabled='true']):hover {
       @if $color-background-hover {
@@ -72,6 +86,7 @@ $button-padding-h: $grid-margin-2;
       @if $color-active {
         color: $color-active !important;
       }
+
       @if $color-background-active {
         background-color: $color-background-active !important;
       }
@@ -100,8 +115,12 @@ $button-padding-h: $grid-margin-2;
     $color-background-hover: var(--of-button-hover-bg),
     $color-border-hover: var(--of-button-hover-color-border),
     $color-active: var(--of-button-active-fg),
-    $color-background-active: var(--of-button-active-bg),
-    $color-border-active: var(--of-button-active-color-border)
+    $color-background-active:
+      var(--of-button-active-bg, var(--utrecht-button-active-background-color)),
+    $color-border-active:
+      var(--of-button-active-color-border, var(--utrecht-button-active-border-color)),
+    $color-border-focus:
+      var(--of-button-focus-color-border, var(--utrecht-button-focus-border-color))
   );
   @include button-theme(
     'primary',
@@ -112,7 +131,12 @@ $button-padding-h: $grid-margin-2;
     $color-border-hover: var(--of-button-primary-hover-color-border),
     $color-active: var(--of-button-primary-active-fg),
     $color-background-active: var(--of-button-primary-active-bg),
-    $color-border-active: var(--of-button-primary-active-color-border)
+    $color-border-active: var(--of-button-primary-active-color-border),
+    $color-border-focus:
+      var(
+        --of-button-primary-focus-color-border,
+        var(--utrecht-button-primary-action-focus-border-color)
+      )
   );
   @include button-theme(
     'anchor',
@@ -125,8 +149,9 @@ $button-padding-h: $grid-margin-2;
     $color-active: var(--of-button-anchor-active-fg),
     $color-background-active: var(--of-button-anchor-active-bg),
     $color-border-active: var(--of-button-anchor-active-color-border),
-    $force-colors: true,
-    // there's no anchor variant for utrecht button yet
+    $color-border-focus:
+      var(--of-button-anchor-focus-color-border, var(--utrecht-button-focus-border-color)),
+    $force-colors: true // there's no anchor variant for utrecht button yet
   );
   @include button-theme(
     'danger',
@@ -137,7 +162,12 @@ $button-padding-h: $grid-margin-2;
     $color-border-hover: var(--of-button-danger-hover-color-border),
     $color-active: var(--of-button-danger-active-fg),
     $color-background-active: var(--of-button-danger-active-bg),
-    $color-border-active: var(--of-button-danger-active-color-border)
+    $color-border-active: var(--of-button-danger-active-color-border),
+    $color-border-focus:
+      var(
+        --of-button-danger-focus-color-border,
+        var(--utrecht-button-primary-action-danger-focus-border-color)
+      )
   );
 
   appearance: none;


### PR DESCRIPTION
Fixes open-formulieren/open-forms#2270
Fixes open-formulieren/open-forms#2410

with a new proposal for a thicker border on-focus in buttons than the other elements that have a set focus style (like the radiobuttons).

The changes in this branch are related to the changes in this PR in the Design-Tokens repo: https://github.com/open-formulieren/design-tokens/pull/10
