### PR TITLE
[#2465] fix SDK templates

### DIFF
--- a/src/formio/templates/label.ejs
+++ b/src/formio/templates/label.ejs
@@ -2,7 +2,7 @@
   class="utrecht-form-label {{ctx.ofPrefix}}label {{ctx.label.className}} {% if (ctx.component.validate.required) { %}required-field utrecht-form-label--required{% } %}"
   for="{{ctx.instance.id}}-{{ctx.component.key}}"
 >
-  {{ ctx.t(ctx.component.label) }}
+  {{ ctx.t(ctx.component.label, { _userInput: true }) }}
   {% if (!ctx.component.validate.required && !ctx.requiredFieldsWithAsterisk) { %}
     {{ ctx.t('(optional)') }}
   {% } %}

--- a/src/formio/templates/radio.ejs
+++ b/src/formio/templates/radio.ejs
@@ -27,7 +27,7 @@
             <div class="{{ctx.ofPrefix}}checkbox__checkmark"></div>
 
             {% if (!ctx.component.optionsLabelPosition || ctx.component.optionsLabelPosition === 'right' || ctx.component.optionsLabelPosition === 'bottom') { %}
-                <label class="{{ctx.ofPrefix}}checkbox__label utrecht-form-label utrecht-form-label--radio {% if (ctx.disabled) { %}utrecht-form-label--disabled{% } %}" for="{{ctx.id}}{{ctx.row}}-{{item.value}}">{{ctx.t(item.label)}}</label>
+                <label class="{{ctx.ofPrefix}}checkbox__label utrecht-form-label utrecht-form-label--radio {% if (ctx.disabled) { %}utrecht-form-label--disabled{% } %}" for="{{ctx.id}}{{ctx.row}}-{{item.value}}">{{ctx.t(item.label, { _userInput: true })}}</label>
             {% } %}
         </div>
     </div>


### PR DESCRIPTION
Closes open-formulieren/open-forms#2465 

- the label and radio templates were missing a tag that's used in the context of sanitizing HTML