### PR TITLE
Fixed some storybook bugs

### DIFF
--- a/src/formio/components/Content.stories.mdx
+++ b/src/formio/components/Content.stories.mdx
@@ -1,38 +1,24 @@
-import {Canvas, Meta, Story, ArgsTable} from '@storybook/addon-docs';
-import {FormioComponent, FormDecorator} from './story-util';
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { FormioComponent, FormDecorator } from './story-util';
 
 <Meta
   title="Form.io components/Content"
-  argTypes={{
-    id: {
-      type: {name: 'string'},
-    },
-    label: {
-      type: {name: 'string', required: false},
-    },
-    customClass: {
-      options: ['', 'info', 'warning', 'error', 'success'],
-      control: {
-        type: 'radio',
-        labels: {
-          '': '-',
-          warning: 'Warning',
-          info: 'Info',
-          error: 'Error',
-          success: 'Success',
-        },
-      },
-    },
-  }}
   decorators={[FormDecorator]}
   parameters={{
-    controls: {sort: 'requiredFirst'},
+    controls: { sort: 'requiredFirst' },
     docs: {
       source: {
         type: 'dynamic',
         excludeDecorators: true,
       }
     }
+  }}
+  argTypes={{
+    label: {type: {required: false}},
+    customClass: {
+      options: [null, 'info', 'warning', 'error', 'success'],
+      control: { type: 'radio', labels: {null: '(none)'} },
+    },
   }}
 />
 
@@ -45,14 +31,14 @@ depending on whether a style class is chosen.
 
 ## Default
 
-export const Template = ({customClass = '', html = '', id = '', label = '', ...args}) => (
+export const Template = ({customClass = null, html = '', id = '', label = '', ...args}) => (
   <FormioComponent
     component={{
+      type: 'content',
       html,
       label,
       key: id,
-      customClass,
-      type: 'content',
+      customClass: customClass || '',
     }}
   />
 );
@@ -61,14 +47,14 @@ export const Template = ({customClass = '', html = '', id = '', label = '', ...a
   <Story
     name="Default"
     args={{
-      id: 'content1',
-      html: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque a felis ante. Nunc dictum, dui et scelerisque euismod, ex dui sodales magna, quis vehicula nulla justo sed urna. Integer maximus tempus tellus vel commodo. Orci varius natoque penatibus et magnis dis parturient montes.</p>',
-      label: 'Vrije tekst',
-      customClass: '',
+      id: 'content',
+      label: '(not rendered)',
+      customClass: null,
+      html: `<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque a felis ante. Nunc dictum, dui et scelerisque euismod,
+ex dui sodales magna, quis vehicula nulla justo sed urna. Integer maximus tempus tellus vel commodo.
+Orci varius natoque penatibus et magnis dis parturient montes.</p>`
     }}
   >
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable story="Default" />

--- a/src/formio/components/TimeField.stories.mdx
+++ b/src/formio/components/TimeField.stories.mdx
@@ -1,25 +1,26 @@
-import { Canvas, Meta, Story, Props } from '@storybook/addon-docs';
-import { FormioComponent, FormDecorator } from './story-util';
+import {Canvas, Meta, Props, Story} from '@storybook/addon-docs';
+
+import {FormDecorator, FormioComponent} from './story-util';
 
 <Meta
   title="Form.io components/TimeField"
   argTypes={{
     id: {
-      type: { name: 'string' },
+      type: {name: 'string'},
     },
     label: {
-      type: { name: 'string', required: false },
+      type: {name: 'string', required: false},
     },
   }}
   decorators={[FormDecorator]}
   parameters={{
-    controls: { sort: 'requiredFirst' },
+    controls: {sort: 'requiredFirst'},
     docs: {
       source: {
         type: 'dynamic',
         excludeDecorators: true,
-      }
-    }
+      },
+    },
   }}
 />
 
@@ -27,16 +28,20 @@ import { FormioComponent, FormDecorator } from './story-util';
 
 ## Default
 
-export const Template = ({ id = '', label = '', ...args}) => (
-  <FormioComponent component={{
+export const Template = ({id = '', label = '', ...args}) => (
+  <FormioComponent
+    component={{
       key: id,
       type: 'time',
       input: true,
+      inputType: 'text',
       label,
-}}/>);
+    }}
+  />
+);
 
 <Canvas>
-  <Story name="Default" args={{ id: 'time', label: 'Tijd'}}>
+  <Story name="Default" args={{id: 'time', label: 'Tijd'}}>
     {Template.bind({})}
   </Story>
 </Canvas>


### PR DESCRIPTION
Fixes #325 

Took some time to find the root case: the `argTypes.customClass.control.labels` with an empty string is not happily accepted by storybook.