### PR TITLE
[OF#2516] Replace crosses with bins

### DIFF
--- a/src/formio/templates/editGridRow.ejs
+++ b/src/formio/templates/editGridRow.ejs
@@ -10,7 +10,7 @@
                 <button class="{{ctx.ofPrefix}}button editRow"><i class="{{ ctx.iconClass('edit') }}"></i></button>
             </li>
             <li class="{{ctx.ofPrefix}}toolbar__list-item">
-                <button class="{{ctx.ofPrefix}}button {{ctx.ofPrefix}}button--danger removeRow"><i class="{{ ctx.iconClass('trash') }}"></i></button>
+                <button class="{{ctx.ofPrefix}}button {{ctx.ofPrefix}}button--danger removeRow"><i class="{{ ctx.iconClass('trash-can') }}"></i></button>
             </li>
         </ul>
     </div>

--- a/src/formio/templates/file.ejs
+++ b/src/formio/templates/file.ejs
@@ -19,7 +19,7 @@
           {% if (!ctx.disabled) { %}
             <div class="col-md-1">
               <button type="button" class="{{ctx.ofPrefix}}button {{ctx.ofPrefix}}button--icon-only {{ctx.ofPrefix}}button--danger" ref="removeLink" title="{{ctx.t('Remove')}}">
-                <i class="{{ctx.iconClass('remove')}}"></i>
+                <i class="{{ctx.iconClass('trash-can')}}"></i>
               </button>
             </div>
           {% } %}
@@ -54,7 +54,7 @@
         <span>
           <img ref="fileImage" src="" alt="{{file.originalName || file.name}}" style="width:{{ctx.component.imageSize}}px">
           {% if (!ctx.disabled) { %}
-            <i class="{{ctx.iconClass('remove')}}" ref="removeLink"></i>
+            <i class="{{ctx.iconClass('trash-can')}}" ref="removeLink"></i>
           {% } %}
         </span>
       </div>
@@ -108,7 +108,7 @@
     <div class="row">
       <div class="fileName col-form-label col-sm-10">
         <span class="fileName__file">{{status.originalName}}</span>
-        <i class="{{ctx.iconClass('remove')}}" ref="fileStatusRemove" title="{{ctx.t('remove')}}"></i>
+        <i class="{{ctx.iconClass('trash-can')}}" ref="fileStatusRemove" title="{{ctx.t('remove')}}"></i>
       </div>
       <div class="fileSize col-form-label col-sm-2 text-right">{{ctx.fileSize(status.size)}}</div>
     </div>

--- a/src/formio/templates/multiValueRow.ejs
+++ b/src/formio/templates/multiValueRow.ejs
@@ -5,7 +5,7 @@
   {% if (!ctx.disabled) { %}
   <td class="{{ctx.ofPrefix}}multi-value-row__remove">
     <button type="button" class="{{ctx.ofPrefix}}button {{ctx.ofPrefix}}button--icon-only {{ctx.ofPrefix}}button--danger" title="{{ctx.t('Remove')}}" ref="removeRow">
-      <i class="{{ctx.iconClass('remove')}}"></i>
+      <i class="{{ctx.iconClass('trash-can')}}"></i>
     </button>
   </td>
   {% } %}


### PR DESCRIPTION
Fixes open-formulieren/open-forms#2516

I went with `trash-can` instead of `trash` because I thought it looked nicer
![Screenshot from 2022-12-22 15-11-44](https://user-images.githubusercontent.com/19154114/209152558-8d7f08e9-763f-42bf-ba4a-04f60cee3ae8.png)

