### PR TITLE
[OF#2440] Don't display hidden components in repeating groups

### DIFF
--- a/src/formio/templates/editGridRow.ejs
+++ b/src/formio/templates/editGridRow.ejs
@@ -1,6 +1,8 @@
 <div class="{{ctx.ofPrefix}}editgrid__row">
     {% for (const key in ctx.flattenedComponents) { %}
-        <div>{{ctx.flattenedComponents[key].label}}: {{ ctx.getView(ctx.flattenedComponents[key], ctx.row[key]) }}</div>
+        {% if (ctx.isVisibleInRow(ctx.flattenedComponents[key])) { %}
+            <div>{{ctx.flattenedComponents[key].label}}: {{ ctx.getView(ctx.flattenedComponents[key], ctx.row[key]) }}</div>
+        {% } %}
     {% } %}
 
   {% if (!ctx.self.options.readOnly) { %}


### PR DESCRIPTION
Fixes open-formulieren/open-forms#2440

![Screenshot from 2022-12-22 15-38-08](https://user-images.githubusercontent.com/19154114/209158131-97555df9-54a6-4ab3-945d-77a056038809.png)
