### PR TITLE
:construction_worker: [#335] -- configure turbosnap

### DIFF
--- a/.github/workflows/sb.yml
+++ b/.github/workflows/sb.yml
@@ -15,7 +15,7 @@ on:
 
 # Allow one concurrent deployment
 concurrency:
-  group: "pages-${{ github.ref_name }}"  # unique builds for branch/tag name
+  group: 'pages-${{ github.ref_name }}' # unique builds for branch/tag name
   cancel-in-progress: true
 
 jobs:
@@ -51,7 +51,7 @@ jobs:
       id-token: write
 
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'  # Exclude PRs
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' # Exclude PRs
     needs: storybook
     steps:
       - name: Setup Pages
@@ -68,7 +68,7 @@ jobs:
       - storybook
 
     # do not run in forks
-    if:  github.event_name == 'push' || ! github.event.pull_request.head.repo.fork
+    if: github.event_name == 'push' || ! github.event.pull_request.head.repo.fork
 
     steps:
       - name: Checkout repository
@@ -95,3 +95,6 @@ jobs:
           autoAcceptChanges: main
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           storybookBuildDir: ./storybook-static
+          onlyChanged: true
+          externals: 'src/img/**'
+          debug: true

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "compilemessages": "formatjs compile-folder --ast src/i18n/messages src/i18n/compiled",
     "build:design-tokens": "yarn workspace @open-formulieren/design-tokens run build",
     "storybook": "start-storybook -p 6006",
-    "build:storybook": "build-storybook",
+    "build:storybook": "build-storybook --webpack-stats-json",
     "format": "prettier --write 'src/**/*.{js,scss}'",
     "checkformat": "prettier --check 'src/**/*.{js,scss}'"
   },

--- a/src/components/Card.stories.mdx
+++ b/src/components/Card.stories.mdx
@@ -1,0 +1,37 @@
+import { Canvas, Meta, Story, ArgsTable } from '@storybook/addon-docs';
+
+import Body from './Body';
+import Card from './Card';
+
+<Meta
+  title="Pure React components/Card"
+  component={Card}
+  argTypes={{
+    children: {control: false},
+    captionComponent: {control: false},
+    titleComponent: {control: false},
+  }}
+  parameters={{
+    controls: {sort: 'requiredFirst'}
+  }}
+/>
+
+# Cards
+
+Cards allow presenting some content with an (optional) title.
+
+export const Template = ({label, ...args}) => (
+    <Card {...args}>
+        <Body>By Blanck Mass</Body>
+    </Card>
+);
+
+<Canvas>
+  <Story name="Default" args={{title: 'The Rig', caption: '', modifiers: []}}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={Card} />


### PR DESCRIPTION
Closes #335

This is an attempt at setting up Turbosnap, with the pull request trigger intact. For PRs, the github action looks at the branch head commit to compare changes, which might work in our case and the one-flow git branching model.