### PR TITLE
[#2539] fix mime type validation

### DIFF
--- a/src/formio/components/FileField.js
+++ b/src/formio/components/FileField.js
@@ -189,6 +189,18 @@ class FileField extends Formio.Components.components.file {
     super.upload(files);
   }
 
+  validatePattern(file, val) {
+    // file type not recognized; get file extension and specify mime type manually
+    if (file.type === '') {
+      let ext = file.name.split('.').pop();
+      if (ext === 'msg') {
+        file = file.slice(0, file.size, 'application/vnd.ms-outlook');
+      }
+    }
+
+    return super.validatePattern(file, val);
+  }
+
   checkComponentValidity(data, dirty, row, options = {}) {
     if (this.loading) {
       // This prevents the FormStep from being submitted before the file upload is finished.


### PR DESCRIPTION
Fixes open-formulieren/open-forms#2539 (partly).

Added support for mime type validation on the frontend where the default validation performed by formio doesn't work (e.g. the type of msg files is not recognized by browsers).