### PR TITLE
[OF#2686] Add styles for select

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@formio/protected-eval": "^1.2.1",
     "@fortawesome/fontawesome-free": "^6.1.1",
-    "@open-formulieren/design-tokens": "^0.21.2",
+    "@open-formulieren/design-tokens": "^0.22.0",
     "@sentry/react": "^6.13.2",
     "@sentry/tracing": "^6.13.2",
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",

--- a/src/scss/components/_leaflet-map.scss
+++ b/src/scss/components/_leaflet-map.scss
@@ -4,6 +4,7 @@
 .#{prefix(leaflet-map)} {
   height: 400px;
   position: relative;
+  z-index: 0;
 
   @include modifier('disabled') {
     cursor: default;

--- a/src/scss/components/_select.scss
+++ b/src/scss/components/_select.scss
@@ -59,6 +59,16 @@ $select-background-color: var(--of-select-background-color, $color-white);
     font-weight: bold;
     padding: 0 $list-hpadding;
     width: 100%;
+
+    .choices__list {
+      background-color: var(--of-color-bg);
+      border-color: var(--of-field-border-color);
+      color: var(--of-color-fg);
+
+      .is-highlighted {
+        background-color: var(--of-select-highlighted-bg);
+      }
+    }
   }
 
   // The wrapper containing the select, results, and input.


### PR DESCRIPTION
Fixes open-formulieren/open-forms#2686

The style was working in the SDK, but not in embedded forms. This is because this style in the backend was overwriting the style of the select component: https://github.com/open-formulieren/open-forms/blob/master/src/openforms/scss/components/builder/_builder.scss#L78

Related token PR: https://github.com/open-formulieren/design-tokens/pull/16