### PR TITLE
Send heic/heif files to the server and trust their verdict over FormIO.

### DIFF
--- a/src/formio/components/FileField.js
+++ b/src/formio/components/FileField.js
@@ -205,6 +205,8 @@ class FileField extends Formio.Components.components.file {
         file = file.slice(0, file.size, 'application/vnd.ms-outlook');
       }
     }
+    //gh-2911 let the backend figure heic out. super is not that super
+    if (file.type === 'image/heif') return true;
 
     return super.validatePattern(file, val);
   }


### PR DESCRIPTION
Part of fix for open-formulieren/open-forms#2911