### PR TITLE
[OF#2912] Fix disappearing drag and drop area

### DIFF
--- a/src/formio/components/FileField.js
+++ b/src/formio/components/FileField.js
@@ -157,6 +157,30 @@ CSRFEnabledUrl.title = 'CSRFEnabledUrl';
  * Extend the default file field to modify it to our needs.
  */
 class FileField extends Formio.Components.components.file {
+  attach(element) {
+    super.attach(element);
+
+    this.refs.fileStatusRemove.forEach((fileStatusRemove, index) => {
+      this.removeEventListener(fileStatusRemove, 'click');
+
+      this.addEventListener(fileStatusRemove, 'click', event => {
+        event.preventDefault();
+        if (this.abortUpload) {
+          this.abortUpload();
+        }
+
+        // Formiojs bug #4555 - After deleting a file, if the drag&drop area had been hidden, it
+        // doesn't show after deleting.
+        // OF issue #2912 - We cannot use the abortUpload method, because this gets overwritten
+        // during successful upload of a file
+        this.fileDropHidden = false;
+
+        this.statuses.splice(index, 1);
+        this.redraw();
+      });
+    });
+  }
+
   upload(files) {
     if (this.component.multiple && this.component.maxNumberOfFiles) {
       // this.data.file contains files that may have already been uploaded, while the argument 'files' gives the
@@ -225,12 +249,6 @@ class FileField extends Formio.Components.components.file {
     }
 
     return super.checkComponentValidity(data, dirty, row, options);
-  }
-
-  abortUpload() {
-    // Formiojs bug #4555 - After deleting a file, if the drag&drop area had been hidden, it
-    // doesn't show after deleting.
-    this.fileDropHidden = false;
   }
 
   deleteFile(fileInfo) {


### PR DESCRIPTION
This was previously fixed by adding the `abortUpload` method. But this gets overwritten during successful upload of a file here: https://github.com/formio/formio.js/blob/v4.13.13/src/components/file/File.js#L748. So this time I tried changing the event listener to directly update the fileDropHidden attribute

Fixes open-formulieren/open-forms#2912