### PR TITLE
[OF#2909] Fix restoreCaretPosition for email field

### DIFF
--- a/src/formio/components/Email.js
+++ b/src/formio/components/Email.js
@@ -17,6 +17,28 @@ class Email extends Formio.Components.components.email {
     ].join(' ');
     return info;
   }
+
+  restoreCaretPosition() {
+    if (!this.root?.currentSelection || !this.refs.input?.length) return;
+
+    const {index} = this.root.currentSelection;
+    let input = this.refs.input[index];
+
+    if (!input) {
+      input = this.refs.input[this.refs.input.length];
+    }
+
+    // Issue #2909 - setSelectionRange does not work for inputs of type email.
+    // So, we first change the input type ...
+    input.setAttribute('type', 'text');
+
+    // ... then we move the cursor back to the end of the input ...
+    const lastCharacter = input.value?.length || 0;
+    input.setSelectionRange(lastCharacter, lastCharacter);
+
+    // ... and we finally restore the type to email.
+    input.setAttribute('type', 'email');
+  }
 }
 
 export default Email;


### PR DESCRIPTION
Fixes open-formulieren/open-forms#2909