### PR TITLE
[#2875] fix siteimprove

### DIFF
--- a/src/hooks/usePageViews.js
+++ b/src/hooks/usePageViews.js
@@ -1,12 +1,32 @@
-import {useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import {useLocation} from 'react-router-dom';
-import {usePrevious} from 'react-use';
 
 const isDev = process.env.NODE_ENV === 'development';
 
+function usePrevious(value) {
+  const ref = useRef({
+    value: value,
+    prev: null,
+  });
+
+  const current = ref.current.value;
+
+  if (value !== current) {
+    ref.current = {
+      value: value,
+      prev: current,
+    };
+  }
+
+  return ref.current.prev;
+}
+
 const ANALYTICS_PROVIDERS = {
   debug: async location =>
-    isDev && console.log(`Tracking navigation to ${location.pathname}${location.hash}`),
+    isDev &&
+    console.log(
+      `Tracking navigation to ${window.location.origin + location.pathname}${location.hash}`
+    ),
   gtag: async location => {
     /* Google Analytics
     Hashrouting support: https://support.google.com/analytics/thread/20971249/track-hashtag-in-url-but-after-site-was-loaded
@@ -22,23 +42,22 @@ const ANALYTICS_PROVIDERS = {
   siteimprove: async (location, previousLocation) =>
     /* SiteImprove
     Docs: https://support.siteimprove.com/hc/en-gb/articles/115001615171-Siteimprove-Analytics-Custom-Visit-Tracking
-    Unsure if SiteImprove subscribes to URL changes or not, if they do - we'll fire double events here.
-    Hashrouting support: Unknown, so we follow the same concept as Matomo by pretending there is no hash.
+		Note: siteimprove requires the full URL to track pages, not merely the path
     */
     window._sz &&
     window._sz.push([
       'trackdynamic',
       {
-        url: location.pathname + location.hash.substring(1),
+        url: window.location.origin + location.pathname + location.hash.substring(1),
         ref:
-          (previousLocation && previousLocation.pathname + previousLocation.hash.substring(1)) ||
-          window.location.pathname + window.location.hash.substring(1),
+          previousLocation &&
+          window.location.origin + previousLocation.pathname + previousLocation.hash.substring(1),
         title: document.title,
       },
     ]),
   matomoOrPiwik: async (location, previousLocation) => {
     /* Matomo, Piwik and Piwik PRO are all supported
-    Matomo: https://matomo.org/docs/guides/spa-tracking/
+		Matomo: https://developer.matomo.org/guides/spa-tracking
     Piwik: https://piwik.org/docs/tracking-javascript-guide/
     Piwik PRO: https://developers.piwik.pro/en/latest/data_collection/web/guides.html
     Hashrouting support: https://developer.matomo.org/guides/spa-tracking / alternatively: https://www.npmjs.com/package/@datapunt/matomo-tracker-react (from Amsterdam)
@@ -59,8 +78,10 @@ const ANALYTICS_PROVIDERS = {
  * We assume that the provider has been included already in the global scope of the
  * containing page where the SDK is embedded.
  */
-const trackPageView = location => {
-  const promises = Object.values(ANALYTICS_PROVIDERS).map(callback => callback(location));
+const trackPageView = (location, previousLocation) => {
+  const promises = Object.values(ANALYTICS_PROVIDERS).map(callback =>
+    callback(location, previousLocation)
+  );
   Promise.all(promises).catch(error => {
     throw error;
   });
@@ -87,5 +108,4 @@ const usePageViews = async () => {
 
 export default usePageViews;
 export {ANALYTICS_PROVIDERS};
-// exporting makes it possible to plug in other providers that are not supported out of
-// the box.
+// exporting makes it possible to plug in other providers that are not supported out of the box.


### PR DESCRIPTION
Fixes open-formulieren/open-forms#2875

* the `usePrevious` hook ([doc](https://usehooks.com/usePrevious/)) doesn't work properly and returns the same path/url for the current and previous page. It is replaced with a custom hook that stores current/previous values manually instead of relying on the magic of `useEffect`
* in addition, we send the full URL to siteimprove instead of path