### PR TITLE
[OF#2788] Change startpage URL and name in progress indicator

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -295,6 +295,9 @@ const Form = ({form}) => {
   const router = (
     <Switch>
       <Route exact path="/">
+        <Redirect to="/startpagina" />
+      </Route>
+      <Route exact path="/startpagina">
         <ErrorBoundary useCard>
           <FormStart form={form} onFormStart={onFormStart} />
         </ErrorBoundary>

--- a/src/components/ProgressIndicator/constants.js
+++ b/src/components/ProgressIndicator/constants.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {FormattedMessage} from 'react-intl';
 
 const STEP_LABELS = {
-  login: <FormattedMessage description="Start page title" defaultMessage="Log in" />,
+  login: <FormattedMessage description="Start page title" defaultMessage="Start page" />,
   overview: <FormattedMessage description="Summary page title" defaultMessage="Summary" />,
   confirmation: (
     <FormattedMessage description="Confirmation page title" defaultMessage="Confirmation" />

--- a/src/components/ProgressIndicator/test.spec.js
+++ b/src/components/ProgressIndicator/test.spec.js
@@ -57,7 +57,7 @@ it('Progress Indicator submission allowed', () => {
   });
 
   const progressIndicatorSteps = container.getElementsByTagName('ol')[0];
-  expect(progressIndicatorSteps.textContent).toContain('Inloggen');
+  expect(progressIndicatorSteps.textContent).toContain('Startpagina');
   expect(progressIndicatorSteps.textContent).toContain('Overzicht');
   expect(progressIndicatorSteps.textContent).toContain('Bevestiging');
 });
@@ -83,7 +83,7 @@ it('Progress Indicator submission not allowed, with overview page', () => {
   });
 
   const progressIndicatorSteps = container.getElementsByTagName('ol')[0];
-  expect(progressIndicatorSteps.textContent).toContain('Inloggen');
+  expect(progressIndicatorSteps.textContent).toContain('Startpagina');
   expect(progressIndicatorSteps.textContent).toContain('Overzicht');
   expect(progressIndicatorSteps.textContent).not.toContain('Bevestiging');
 });
@@ -109,7 +109,7 @@ it('Progress Indicator submission not allowed, without overview page', () => {
   });
 
   const progressIndicatorSteps = container.getElementsByTagName('ol')[0];
-  expect(progressIndicatorSteps.textContent).toContain('Inloggen');
+  expect(progressIndicatorSteps.textContent).toContain('Startpagina');
   expect(progressIndicatorSteps.textContent).not.toContain('Overzicht');
   expect(progressIndicatorSteps.textContent).not.toContain('Bevestiging');
 });
@@ -132,7 +132,7 @@ it('Form landing page, no submission present in session', () => {
   });
 
   const progressIndicatorSteps = container.getElementsByTagName('ol')[0];
-  expect(progressIndicatorSteps.textContent).toContain('Inloggen');
+  expect(progressIndicatorSteps.textContent).toContain('Startpagina');
   expect(progressIndicatorSteps.textContent).toContain('Overzicht');
   expect(progressIndicatorSteps.textContent).toContain('Bevestiging');
 });

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -503,6 +503,12 @@
       "value": "Toggle the progress status display"
     }
   ],
+  "kH9Cpi": [
+    {
+      "type": 0,
+      "value": "Start page"
+    }
+  ],
   "mMYAWl": [
     {
       "type": 0,

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -503,6 +503,12 @@
       "value": "Toon/verberg de voortgang in het formulier"
     }
   ],
+  "kH9Cpi": [
+    {
+      "type": 0,
+      "value": "Startpagina"
+    }
+  ],
   "mMYAWl": [
     {
       "type": 0,

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -329,6 +329,11 @@
     "description": "Progress step indicator toggle icon (mobile)",
     "originalDefault": "Toggle the progress status display"
   },
+  "kH9Cpi": {
+    "defaultMessage": "Start page",
+    "description": "Start page title",
+    "originalDefault": "Start page"
+  },
   "mMYAWl": {
     "defaultMessage": "Your session is about to expire {delta}. Extend your session if you wish to continue.",
     "description": "Session expiry warning message (in modal)",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -329,6 +329,11 @@
     "description": "Progress step indicator toggle icon (mobile)",
     "originalDefault": "Toggle the progress status display"
   },
+  "kH9Cpi": {
+    "defaultMessage": "Startpagina",
+    "description": "Start page title",
+    "originalDefault": "Start page"
+  },
   "mMYAWl": {
     "defaultMessage": "Uw sessie staat op het punt om te vervallen {delta}. Verleng uw sessie indien u door wenst te gaan.",
     "description": "Session expiry warning message (in modal)",


### PR DESCRIPTION
Changes:
* Now the URL for the initial landing page has 'startpagina' in the URL
* The step in the progress indicator is called 'start page' instead of 'inloggen'

Fixes open-formulieren/open-forms#2788