### PR TITLE
[open-formulieren/open-forms-sdk/issues/#417] Added Stylin…

### DIFF
--- a/src/components/forms/NumberField/NumberField.js
+++ b/src/components/forms/NumberField/NumberField.js
@@ -8,7 +8,7 @@ import {
 import {useField} from 'formik';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {useIntl} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 import {NumericFormat} from 'react-number-format';
 
 import {getBEMClassName} from 'utils';
@@ -38,7 +38,10 @@ const NumberField = ({
 
   const labelClassName = getBEMClassName('label', [isRequired && 'required'].filter(Boolean));
   const inputClassName = getBEMClassName('input', [invalid && 'invalid'].filter(Boolean));
-
+  const descriptionClassName = getBEMClassName(
+    'description',
+    [invalid && 'invalid'].filter(Boolean)
+  );
   // We get the decimal separator by formatting a arbitrary number, and then extracting the decimal separator
   const {decimalSeparator, thousandSeparator} = getSeparators(locale);
   const isInteger = step != null && Number.isInteger(step);
@@ -71,14 +74,29 @@ const NumberField = ({
   };
 
   return (
-    <UtrechtFormField type="text" invalid={invalid.toString()}>
+    <UtrechtFormField
+      type="text"
+      invalid={invalid.toString()}
+      className={getBEMClassName('form-field', [invalid && 'invalid'].filter(Boolean))}
+    >
       <Paragraph className={labelClassName}>
         <FormLabel htmlFor={id}>{label}</FormLabel>
       </Paragraph>
       <Paragraph>
         <NumericFormat {...inputProps} />
       </Paragraph>
-      {description && <FormFieldDescription invalid={invalid}>{description}</FormFieldDescription>}
+      {description && (
+        <FormFieldDescription invalid={invalid} className={descriptionClassName}>
+          {invalid ? (
+            <FormattedMessage
+              description="Error message for invalid input"
+              defaultMessage="invalid input"
+            />
+          ) : (
+            description
+          )}
+        </FormFieldDescription>
+      )}
     </UtrechtFormField>
   );
 };

--- a/src/components/forms/TextField/TextField.js
+++ b/src/components/forms/TextField/TextField.js
@@ -8,6 +8,7 @@ import {
 import {Field} from 'formik';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
 
 import {getBEMClassName} from 'utils';
 
@@ -21,22 +22,43 @@ export const TextField = ({
   invalid = false,
 }) => {
   const labelClassName = getBEMClassName('label', [isRequired && 'required'].filter(Boolean));
-
+  const descriptionClassName = getBEMClassName(
+    'description',
+    [invalid && 'invalid'].filter(Boolean)
+  );
   const inputProps = {
     id,
     disabled,
     invalid,
+    className: getBEMClassName('input'),
+    name,
+    as: Textbox,
   };
 
   return (
-    <UtrechtFormField type={'text'} invalid={invalid}>
+    <UtrechtFormField
+      type="text"
+      invalid={invalid}
+      className={getBEMClassName('form-field', [invalid && 'invalid'].filter(Boolean))}
+    >
       <Paragraph className={labelClassName}>
         <FormLabel htmlFor={id}>{label}</FormLabel>
       </Paragraph>
       <Paragraph>
-        <Field name={name} as={Textbox} {...inputProps} />
+        <Field {...inputProps} />
       </Paragraph>
-      {description && <FormFieldDescription invalid={invalid}>{description}</FormFieldDescription>}
+      {description && (
+        <FormFieldDescription invalid={invalid} className={descriptionClassName}>
+          {invalid ? (
+            <FormattedMessage
+              description="Error message for invalid input"
+              defaultMessage="invalid input"
+            />
+          ) : (
+            description
+          )}
+        </FormFieldDescription>
+      )}
     </UtrechtFormField>
   );
 };

--- a/src/scss/components/_form-field.scss
+++ b/src/scss/components/_form-field.scss
@@ -1,0 +1,23 @@
+@use 'microscope-sass/lib/bem';
+@import '../mixins/prefix';
+@import '~microscope-sass/lib/color';
+
+
+.#{prefix(form-field)} {
+  @include bem.modifier('invalid') {
+    background-color: var(--of-alert-error-bg); // Tried using $color-danger, but it's way to red it feels like.
+    padding: 1rem;
+    border-left: 6px solid $color-danger;
+
+    .#{prefix('description')} {
+      color: $color-danger;
+      font-weight: 700;
+    }
+  }
+
+
+
+
+
+}
+

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -58,3 +58,4 @@
 @import './scss/components/login-button';
 @import './scss/components/login-button-logo';
 @import './scss/components/rs-select';
+@import './scss/components/form-field';


### PR DESCRIPTION
Closes #417

styling for the `invalid` prop, across all fields. (NumberField, EmailField, TextField)
