### PR TITLE
Implement product selection step component

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -15,6 +15,9 @@ module.exports = {
     'storybook-addon-themes',
     'storybook-react-intl',
   ],
+  features: {
+    interactionsDebugger: true,
+  },
   framework: '@storybook/react',
   core: {
     builder: '@storybook/builder-webpack5',

--- a/src/components/FAIcon.js
+++ b/src/components/FAIcon.js
@@ -8,6 +8,7 @@ const FAIcon = ({
   component: Component = 'i',
   extraClassName = '',
   modifiers = [],
+  noAriaHidden = false,
   ...props
 }) => {
   const className = classNames(
@@ -18,13 +19,14 @@ const FAIcon = ({
     ...modifiers.map(mod => `fa-icon--${mod}`),
     extraClassName
   );
-
-  return <Component className={className} {...props} />;
+  const ariaHidden = noAriaHidden ? 'false' : 'true';
+  return <Component className={className} aria-hidden={ariaHidden} {...props} />;
 };
 
 FAIcon.propTypes = {
   icon: PropTypes.string.isRequired,
   modifiers: PropTypes.arrayOf(PropTypes.oneOf(['small', 'normal', 'inline'])),
+  noAriaHidden: PropTypes.bool,
   component: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
   extraClassName: PropTypes.string,
 };

--- a/src/components/PaymentOverview/__snapshots__/test.spec.js.snap
+++ b/src/components/PaymentOverview/__snapshots__/test.spec.js.snap
@@ -24,6 +24,7 @@ exports[`navigation without context displays a generic error message 1`] = `
         className="openforms-alert__icon openforms-alert__icon--wide"
       >
         <i
+          aria-hidden="true"
           className="fa fas fa-icon fa-exclamation-circle"
         />
       </span>
@@ -65,6 +66,7 @@ exports[`on valid redirect renders an error message on failure 1`] = `
           className="openforms-alert__icon openforms-alert__icon--wide"
         >
           <i
+            aria-hidden="true"
             className="fa fas fa-icon fa-exclamation-circle"
           />
         </span>

--- a/src/components/appointments/ChooseProductStep.js
+++ b/src/components/appointments/ChooseProductStep.js
@@ -1,8 +1,27 @@
+import {FieldArray, useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import Product from './Product';
+
 const ChooseProductStep = () => {
-  return <>ChooseProductStep</>;
+  const {values} = useFormikContext();
+  const products = values?.products || [];
+  return (
+    <FieldArray name="products">
+      {arrayHelpers => (
+        <>
+          {products.map(({product: productId}, index) => (
+            // blank blocks don't have a product selected yet -> so the index is added
+            // to make the key guaranteed unique
+            <div key={`${productId}-${index}`}>
+              <Product namePrefix="products" index={index} />
+            </div>
+          ))}
+        </>
+      )}
+    </FieldArray>
+  );
 };
 
 ChooseProductStep.propTypes = {};

--- a/src/components/appointments/ChooseProductStep.js
+++ b/src/components/appointments/ChooseProductStep.js
@@ -1,0 +1,10 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const ChooseProductStep = () => {
+  return <>ChooseProductStep</>;
+};
+
+ChooseProductStep.propTypes = {};
+
+export default ChooseProductStep;

--- a/src/components/appointments/ChooseProductStep.js
+++ b/src/components/appointments/ChooseProductStep.js
@@ -1,6 +1,11 @@
 import {FieldArray, useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import Button from 'components/Button';
+import FAIcon from 'components/FAIcon';
+import {getBEMClassName} from 'utils';
 
 import Product from './Product';
 
@@ -10,7 +15,7 @@ const ChooseProductStep = () => {
   return (
     <FieldArray name="products">
       {arrayHelpers => (
-        <>
+        <div className={getBEMClassName('editgrid')}>
           {products.map(({product: productId}, index) => (
             // blank blocks don't have a product selected yet -> so the index is added
             // to make the key guaranteed unique
@@ -18,7 +23,21 @@ const ChooseProductStep = () => {
               <Product namePrefix="products" index={index} />
             </div>
           ))}
-        </>
+
+          <div className={getBEMClassName('editgrid__add-button')}>
+            <Button
+              type="button"
+              variant="primary"
+              onClick={() => arrayHelpers.push({product: '', amount: 1})}
+            >
+              <FAIcon icon="plus" />
+              <FormattedMessage
+                description="Appointments: add additional product/service button text"
+                defaultMessage="Add another product"
+              />
+            </Button>
+          </div>
+        </div>
       )}
     </FieldArray>
   );

--- a/src/components/appointments/ChooseProductStep.js
+++ b/src/components/appointments/ChooseProductStep.js
@@ -12,17 +12,27 @@ import Product from './Product';
 const ChooseProductStep = () => {
   const {values} = useFormikContext();
   const products = values?.products || [];
+  const numProducts = Math.max(products.length, 1);
   return (
     <FieldArray name="products">
       {arrayHelpers => (
         <div className={getBEMClassName('editgrid')}>
-          {products.map(({product: productId}, index) => (
-            // blank blocks don't have a product selected yet -> so the index is added
-            // to make the key guaranteed unique
-            <div key={`${productId}-${index}`}>
-              <Product namePrefix="products" index={index} />
-            </div>
-          ))}
+          <div className={getBEMClassName('editgrid__groups')}>
+            {products.map(({product: productId}, index) => (
+              // blank blocks don't have a product selected yet -> so the index is added
+              // to make the key guaranteed unique
+              <div key={`${productId}-${index}`} className={getBEMClassName('editgrid__group')}>
+                <div className={getBEMClassName('editgrid__group-label')}>
+                  <FormattedMessage
+                    description="Appointments: single product label/header"
+                    defaultMessage="Product {number}/{total}"
+                    values={{number: index + 1, total: numProducts}}
+                  />
+                </div>
+                <Product namePrefix="products" index={index} />
+              </div>
+            ))}
+          </div>
 
           <div className={getBEMClassName('editgrid__add-button')}>
             <Button

--- a/src/components/appointments/ChooseProductStep.js
+++ b/src/components/appointments/ChooseProductStep.js
@@ -5,6 +5,7 @@ import {FormattedMessage} from 'react-intl';
 
 import Button from 'components/Button';
 import FAIcon from 'components/FAIcon';
+import {Toolbar, ToolbarList} from 'components/Toolbar';
 import {getBEMClassName} from 'utils';
 
 import Product from './Product';
@@ -29,7 +30,25 @@ const ChooseProductStep = () => {
                     values={{number: index + 1, total: numProducts}}
                   />
                 </div>
+
                 <Product namePrefix="products" index={index} />
+
+                {numProducts > 1 && (
+                  <Toolbar modifiers={['reverse']}>
+                    <ToolbarList>
+                      <Button
+                        type="button"
+                        variant="danger"
+                        onClick={() => arrayHelpers.remove(index)}
+                      >
+                        <FormattedMessage
+                          description="Appointments: remove product/service button text"
+                          defaultMessage="Remove"
+                        />
+                      </Button>
+                    </ToolbarList>
+                  </Toolbar>
+                )}
               </div>
             ))}
           </div>

--- a/src/components/appointments/ChooseProductStep.stories.mdx
+++ b/src/components/appointments/ChooseProductStep.stories.mdx
@@ -16,10 +16,12 @@ export const Template = args => <ChooseProductStep {...args} />;
   parameters={{
     formik: {
       initialValues: {
-        products: [{
-          product: '',
-          amount: 1,
-        }],
+        products: [
+          {
+            product: '',
+            amount: 1,
+          },
+        ],
       },
     },
     msw: {
@@ -27,5 +29,26 @@ export const Template = args => <ChooseProductStep {...args} />;
     },
   }}
 />
+
+## Choose product step
+
+The appointment form allows making appointments for one or multiple products/services.
+
+This component enables the UX to select the desired product and add additional products if desired.
+At least one product must be provided.
+
+<Canvas>
+  <Story
+    name="Empty state"
+    args={{}}
+    play={async ({canvasElement}) => {
+      const canvas = within(canvasElement);
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
 
 <ArgsTable of={ChooseProductStep} />

--- a/src/components/appointments/ChooseProductStep.stories.mdx
+++ b/src/components/appointments/ChooseProductStep.stories.mdx
@@ -7,13 +7,14 @@ import {ConfigDecorator, FormikDecorator} from 'story-utils/decorators';
 import ChooseProductStep from './ChooseProductStep';
 import {mockAppointmentProductsGet} from './mocks';
 
-export const Template = args => <ChooseProductStep {...args} />;
+export const Template = () => <ChooseProductStep />;
 
 <Meta
   title="Private API / Appointments / Steps / Choose product"
   component={ChooseProductStep}
   decorators={[FormikDecorator, ConfigDecorator]}
   parameters={{
+    controls: {hideNoControlsWarning: true},
     formik: {
       initialValues: {
         products: [
@@ -39,16 +40,91 @@ At least one product must be provided.
 
 <Canvas>
   <Story
-    name="Empty state"
-    args={{}}
+    name="Initial state"
     play={async ({canvasElement}) => {
       const canvas = within(canvasElement);
+      // we expect a single initial row
+      const dropdowns = canvas.getAllByRole('combobox');
+      await expect(dropdowns).toHaveLength(1);
+      const amountInputs = canvas.getAllByLabelText('Amount');
+      await expect(amountInputs).toHaveLength(1);
+      // there should be a button to add a row
+      await expect(canvas.getByRole('button', {name: 'Add another product'})).toBeVisible();
+      // and no button to remove the single row
+      await expect(await canvas.queryByRole('button', {name: 'Remove'})).toBeNull();
     }}
   >
     {Template.bind({})}
   </Story>
 </Canvas>
 
-## Props
+## Interaction
 
-<ArgsTable of={ChooseProductStep} />
+Users can add rows for multiple products. Additional products can be removed again after adding
+them, unless there's only a single row left - then removing that row is not allowed.
+
+<Canvas>
+  <Story
+    name="Adding products"
+    parameters={{
+      formik: {
+        initialValues: {
+          products: [
+            {
+              product: '166a5c79',
+              amount: 2,
+            },
+          ],
+        },
+      },
+    }}
+    play={async ({canvasElement}) => {
+      const canvas = within(canvasElement);
+      const addButton = canvas.getByRole('button', {name: 'Add another product'});
+      await userEvent.click(addButton);
+      const dropdowns = canvas.getAllByRole('combobox');
+      await expect(dropdowns).toHaveLength(2);
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Removing products"
+    parameters={{
+      formik: {
+        initialValues: {
+          products: [
+            {
+              product: '166a5c79',
+              amount: 2,
+            },
+            {
+              product: 'e8e045ab',
+              amount: 1,
+            },
+          ],
+        },
+      },
+    }}
+    play={async ({canvasElement}) => {
+      const canvas = within(canvasElement);
+      const dropdowns = canvas.getAllByRole('combobox');
+      await expect(dropdowns).toHaveLength(2);
+      await expect(await canvas.findByText('Paspoort aanvraag')).toBeVisible();
+      await expect(await canvas.findByText('Rijbewijs aanvraag (Drivers license)')).toBeVisible();
+      // now any of both products can be removed
+      const removeButtons = await canvas.queryAllByRole('button', {name: 'Remove'});
+      await expect(removeButtons).toHaveLength(2);
+      // and after removing one row, the last remaining one can't be removed
+      await userEvent.click(removeButtons[0]);
+      await expect(await canvas.findByText('Rijbewijs aanvraag (Drivers license)')).toBeVisible();
+      await expect(await canvas.queryByText('Paspoort aanvraag')).toBeNull();
+      await expect(await canvas.queryByRole('button', {name: 'Remove'})).toBeNull();
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/src/components/appointments/ChooseProductStep.stories.mdx
+++ b/src/components/appointments/ChooseProductStep.stories.mdx
@@ -1,0 +1,31 @@
+import {ArgsTable, Canvas, Meta, Story} from '@storybook/addon-docs';
+import {expect} from '@storybook/jest';
+import {userEvent, within} from '@storybook/testing-library';
+
+import {ConfigDecorator, FormikDecorator} from 'story-utils/decorators';
+
+import ChooseProductStep from './ChooseProductStep';
+import {mockAppointmentProductsGet} from './mocks';
+
+export const Template = args => <ChooseProductStep {...args} />;
+
+<Meta
+  title="Private API / Appointments / Steps / Choose product"
+  component={ChooseProductStep}
+  decorators={[FormikDecorator, ConfigDecorator]}
+  parameters={{
+    formik: {
+      initialValues: {
+        products: [{
+          product: '',
+          amount: 1,
+        }],
+      },
+    },
+    msw: {
+      handlers: [mockAppointmentProductsGet],
+    },
+  }}
+/>
+
+<ArgsTable of={ChooseProductStep} />


### PR DESCRIPTION
Closes open-formulieren/open-forms#3063
Depends on #419

**Changes**

* Added repeating-group like layout to add/remove products
* Within a group you can select a product from API endpoint & specify the amount
* Ability to add additional products
* Stories document all the interactions