### PR TITLE
Date field with date picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^13.2.1",
     "@utrecht/component-library-css": "^1.0.0-alpha.417",
-    "@utrecht/component-library-react": "^1.0.0-alpha.321",
+    "@utrecht/component-library-react": "^1.0.0-alpha.334",
     "@utrecht/components": "^1.0.0-alpha.473",
     "@utrecht/design-tokens": "^1.0.0-alpha.505",
     "babel-jest": "^27.4.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "license": "EUPL-1.2",
   "dependencies": {
+    "@floating-ui/react": "^0.24.2",
     "@formio/protected-eval": "^1.2.1",
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@open-formulieren/design-tokens": "^0.30.0",

--- a/src/components/forms/DateField/DateField.js
+++ b/src/components/forms/DateField/DateField.js
@@ -1,0 +1,197 @@
+import {
+  FormField,
+  FormFieldDescription,
+  Paragraph,
+  Textbox,
+} from '@utrecht/component-library-react';
+import parse from 'date-fns/parse';
+import {Field, useFormikContext} from 'formik';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {useIntl} from 'react-intl';
+
+import FAIcon from 'components/FAIcon';
+import {FloatingWidget, Label, ValidationErrors, useFloatingWidget} from 'components/forms';
+import {getBEMClassName} from 'utils';
+
+import DatePickerCalendar from './DatePickerCalendar';
+
+const parseDate = value => {
+  if (!value) return undefined;
+  const parsed = parse(value, 'yyyy-MM-dd', new Date());
+  // Invalid Date is apparently a thing :ThisIsFine:
+  if (isNaN(parsed)) return undefined;
+  return parsed;
+};
+
+const DatePicker = ({name, onChange, id, calendarProps, ...extra}) => {
+  const intl = useIntl();
+  const {getFieldProps} = useFormikContext();
+  const {
+    refs,
+    floatingStyles,
+    context,
+    getFloatingProps,
+    getReferenceProps,
+    isOpen,
+    setIsOpen,
+    arrowRef,
+  } = useFloatingWidget();
+
+  const calendarIconClassName = getBEMClassName('datepicker-textbox__calendar-toggle');
+  const {value} = getFieldProps(name);
+  const currentDate = parseDate(value);
+
+  const {onFocus, ...referenceProps} = getReferenceProps();
+  return (
+    <>
+      <Paragraph className={getBEMClassName('datepicker-textbox')}>
+        <Textbox
+          ref={refs.setReference}
+          name={name}
+          id={id}
+          className="utrecht-textbox--openforms"
+          autoComplete="off"
+          placeholder={intl.formatMessage({
+            description: 'Datepicker text input placeholder',
+            // See open-formulieren/open-forms-sdk#433 for locale-aware formats support
+            defaultMessage: 'yyyy-mm-dd',
+          })}
+          {...extra}
+          onChange={onChange}
+          onFocus={event => {
+            onFocus(event);
+            extra?.onFocus?.(event);
+          }}
+          {...referenceProps}
+        />
+        <FAIcon
+          icon="calendar-days"
+          extraClassName={calendarIconClassName}
+          noAriaHidden
+          aria-label={intl.formatMessage({
+            description: 'Datepicker: accessible calendar toggle label',
+            defaultMessage: 'Toggle calendar',
+          })}
+          aria-controls={referenceProps['aria-controls']}
+          aria-expanded={referenceProps['aria-expanded']}
+          aria-haspopup={referenceProps['aria-haspopup']}
+          onClick={() => !isOpen && setIsOpen(true)}
+        />
+      </Paragraph>
+      <FloatingWidget
+        isOpen={isOpen}
+        context={context}
+        setFloating={refs.setFloating}
+        floatingStyles={floatingStyles}
+        getFloatingProps={getFloatingProps}
+        arrowRef={arrowRef}
+      >
+        <DatePickerCalendar
+          onCalendarClick={selectedDate => {
+            // TODO: shouldn't this return a Date instance? -> question asked in nl-ds Slack
+            const truncated = selectedDate.substring(0, 10);
+            onChange({target: {name, value: truncated}});
+            setIsOpen(false, {keepDismissed: true});
+          }}
+          currentDate={currentDate}
+          {...calendarProps}
+        />
+      </FloatingWidget>
+    </>
+  );
+};
+
+DatePicker.propTypes = {
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  id: PropTypes.string,
+  calendarProps: PropTypes.shape({
+    minDate: PropTypes.instanceOf(Date),
+    maxDate: PropTypes.instanceOf(Date),
+    events: PropTypes.arrayOf(
+      PropTypes.shape({
+        date: PropTypes.string,
+        emphasis: PropTypes.bool,
+        selected: PropTypes.bool,
+        disabled: PropTypes.bool,
+      })
+    ),
+  }),
+};
+
+/**
+ * Implements a form field to select dates.
+ *
+ * For accessibility reasons, there should always be a text field allowing users to
+ * manually type in the date. However, when the field is focused, this toggles the
+ * calendar where a date can be selected using a pointer device.
+ *
+ * TODO: on mobile devices, use the native date picker?
+ * TODO: add prop/option to use a split date field for day/month/year? See
+ * https://design-system.service.gov.uk/patterns/dates/
+ * TODO: when typing in the value, use the pattern/mask approach like form.io?
+ *
+ * NL DS tickets:
+ *  - https://github.com/nl-design-system/backlog/issues/189
+ *  - https://github.com/nl-design-system/backlog/issues/188
+ *  - https://github.com/nl-design-system/backlog/issues/35#issuecomment-1547704753
+ *
+ * Other references: https://medium.com/samsung-internet-dev/making-input-type-date-complicated-a544fd27c45a
+ */
+const DateField = ({
+  name,
+  label = '',
+  isRequired = false,
+  description = '',
+  id = '',
+  disabled = false,
+  minDate,
+  maxDate,
+  disabledDates = [],
+}) => {
+  const {getFieldMeta} = useFormikContext();
+  const {error} = getFieldMeta(name);
+  const invalid = !!error;
+
+  id = id || React.useId();
+
+  const calendarEvents = disabledDates.map(date => ({
+    date: date,
+    emphasis: false,
+    selected: false,
+    disabled: true,
+  }));
+
+  return (
+    <FormField type="text" invalid={invalid} className="utrecht-form-field--openforms">
+      <Label id={id} isRequired={isRequired} disabled={disabled}>
+        {label}
+      </Label>
+      <Field
+        as={DatePicker}
+        name={name}
+        id={id}
+        disabled={disabled}
+        invalid={invalid}
+        calendarProps={{minDate, maxDate, events: calendarEvents}}
+      />
+      {description && <FormFieldDescription>{description}</FormFieldDescription>}
+      <ValidationErrors error={error} />
+    </FormField>
+  );
+};
+
+DateField.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  isRequired: PropTypes.bool,
+  description: PropTypes.string,
+  id: PropTypes.string,
+  disabled: PropTypes.bool,
+  minDate: PropTypes.instanceOf(Date),
+  maxDate: PropTypes.instanceOf(Date),
+  disabledDates: PropTypes.arrayOf(PropTypes.string),
+};
+
+export default DateField;

--- a/src/components/forms/DateField/DateField.js
+++ b/src/components/forms/DateField/DateField.js
@@ -154,7 +154,8 @@ const DateField = ({
   const {error} = getFieldMeta(name);
   const invalid = !!error;
 
-  id = id || React.useId();
+  const generatedId = React.useId();
+  id = id || generatedId;
 
   const calendarEvents = disabledDates.map(date => ({
     date: date,

--- a/src/components/forms/DateField/DateField.stories.mdx
+++ b/src/components/forms/DateField/DateField.stories.mdx
@@ -1,0 +1,213 @@
+import {ArgsTable, Canvas, Meta, Story} from '@storybook/addon-docs';
+import {expect} from '@storybook/jest';
+import {userEvent, within} from '@storybook/testing-library';
+import {addDays, subDays} from 'date-fns';
+
+import {FormikDecorator} from 'story-utils/decorators';
+
+import DateField from './DateField';
+
+export const Template = args => <DateField {...args} />;
+
+<Meta
+  title="Pure React Components / Forms / DateField"
+  component={DateField}
+  decorators={[FormikDecorator]}
+  parameters={{
+    docs: {
+      source: {
+        type: 'dynamic',
+        excludeDecorators: true,
+      },
+    },
+    formik: {
+      initialValues: {
+        test: '',
+      },
+    },
+  }}
+/>
+
+## Date field
+
+We identify different types of date inputs, each coming with their most-appropriate UI element.
+
+**Nearby dates**
+
+Think of appointment dates, booking dates and similar. Here, the expected date is in the nearby
+future or past. A calendar component is appropriate because:
+
+- you can display occupied dates and/or date ranges
+- you can indicate the current date
+- it is not expected that the user needs to click the year/month button too many times
+
+**Known dates (currently not supported)**
+
+Known dates are exact dates that the user typically knows of the top of their head, such as birth
+dates, credit card expiry dates...
+
+Calendars are not suitable due to the usually bad default/initial value. Preferably they are able to
+enter the numeric value for day, month and year, leveraging autocomplete as well.
+
+On mobile devices, you'd typically want to use the native date widget too.
+
+### Datepicker/calendar
+
+The datepicker/calendar is suitable for nearby dates. We aim to make it accessible to assistive
+technology and keyboard-only navigation.
+
+Known issues/enhancements:
+
+- Use arrow keys to navigate inside calendar
+- Selecting a date in the next/previous month has some odd behaviour at the moment
+
+<Canvas>
+  <Story
+    name="Datepicker"
+    args={{
+      name: 'test',
+      label: 'A nearby date',
+      description: 'Yarp',
+      disabled: false,
+      isRequired: false,
+      minDate: undefined,
+      maxDate: undefined,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Limited range datepicker"
+    play={async ({canvasElement}) => {
+      const canvas = within(canvasElement);
+      // calendar is by default not visible, until you focus the field
+      await expect(await canvas.queryByRole('dialog')).toBeNull();
+      await userEvent.click(canvas.getByText('A nearby date'));
+      await expect(await canvas.findByRole('dialog')).toBeVisible();
+      // ESC key closes the dialog again
+      await userEvent.keyboard('[Escape]');
+      await expect(await canvas.queryByRole('dialog')).toBeNull();
+    }}
+    args={{
+      name: 'test',
+      label: 'A nearby date',
+      description: 'Yarp',
+      disabled: false,
+      isRequired: false,
+      minDate: subDays(new Date(), 3),
+      maxDate: addDays(new Date(), 3),
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Datepicker with disabled dates"
+    play={async ({canvasElement}) => {
+      const canvas = within(canvasElement);
+      // calendar is by default not visible, until you focus the field
+      await expect(await canvas.queryByRole('dialog')).toBeNull();
+      await userEvent.click(canvas.getByText('Today disabled'));
+      await expect(await canvas.findByRole('dialog')).toBeVisible();
+      // today should be set to disabled
+      const disabledEventButton = canvas.getByRole('button', {name: 'zaterdag 20 mei 2023'});
+      await expect(disabledEventButton).toBeVisible();
+      await expect(disabledEventButton).toHaveClass('utrecht-button--disabled');
+      await expect(disabledEventButton).toBeDisabled();
+    }}
+    parameters={{
+      formik: {
+        initialValues: {
+          test: '2023-05-31',
+        },
+      },
+    }}
+    args={{
+      name: 'test',
+      label: 'Today disabled',
+      description: 'Yarp',
+      disabled: false,
+      isRequired: false,
+      disabledDates: ['2023-05-20', new Date().toISOString(), addDays(new Date(), 3).toISOString()],
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+#### Interaction stories
+
+<Canvas>
+  <Story
+    name="Datepicker - keyboard navigation"
+    play={async ({canvasElement}) => {
+      const canvas = within(canvasElement);
+      // calendar is by default not visible, until you focus the field
+      await expect(await canvas.queryByRole('dialog')).toBeNull();
+      await userEvent.click(canvas.getByText('A nearby date'));
+      await expect(await canvas.findByRole('dialog')).toBeVisible();
+      // ESC key closes the dialog again
+      await userEvent.keyboard('[Escape]');
+      await expect(await canvas.queryByRole('dialog')).toBeNull();
+    }}
+    args={{
+      name: 'test',
+      label: 'A nearby date',
+      description: 'Yarp',
+      disabled: false,
+      isRequired: false,
+      minDate: undefined,
+      maxDate: undefined,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Datepicker - type date manually"
+    play={async ({canvasElement}) => {
+      const canvas = within(canvasElement);
+      await expect(await canvas.queryByRole('dialog')).toBeNull();
+      const textInput = canvas.getByLabelText('A nearby date');
+      await userEvent.type(textInput, '2023-05-29');
+      await expect(await canvas.queryByRole('dialog')).toBeNull();
+      await expect(textInput).toHaveDisplayValue('2023-05-29');
+      // check that the date is properly highlighted
+      await userEvent.click(textInput);
+      await expect(await canvas.findByRole('dialog')).toBeVisible();
+      const selectedEventButton = canvas.getByRole('button', {name: 'maandag 29 mei 2023'});
+      await expect(selectedEventButton).toBeVisible();
+      await expect(selectedEventButton).toHaveClass(
+        'utrecht-calendar__table-days-item-day--selected'
+      );
+    }}
+    args={{
+      name: 'test',
+      label: 'A nearby date',
+      description: 'Yarp',
+      disabled: false,
+      isRequired: false,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={DateField} />
+
+## References
+
+- https://design-system.service.gov.uk/patterns/dates/
+- https://medium.com/samsung-internet-dev/making-input-type-date-complicated-a544fd27c45a
+- https://github.com/nl-design-system/backlog/issues/189
+- https://github.com/nl-design-system/backlog/issues/188
+- https://github.com/nl-design-system/backlog/issues/35#issuecomment-1547704753

--- a/src/components/forms/DateField/DatePickerCalendar.js
+++ b/src/components/forms/DateField/DatePickerCalendar.js
@@ -1,0 +1,54 @@
+// Calendar component documentation:
+// https://nl-design-system.github.io/utrecht/storybook-react/index.html?path=/docs/react-component-calendar--docs
+import {Calendar} from '@utrecht/component-library-react';
+import {enGB, nl} from 'date-fns/locale';
+import React from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+
+// FIXME: together with src/i18n.js, see how we can make this a dynamic import without
+// breaking the bundles/cache busting mechanisms.
+const loadCalendarLocale = locale => {
+  switch (locale) {
+    case 'nl':
+      return nl;
+    default:
+      return enGB;
+  }
+};
+
+const DatePickerCalendar = props => {
+  const intl = useIntl();
+  const locale = loadCalendarLocale(intl.locale);
+  return (
+    <Calendar
+      locale={locale}
+      previousYearButtonTitle={
+        <FormattedMessage
+          description="Calendar: previous year button title"
+          defaultMessage="Previous year"
+        />
+      }
+      nextYearButtonTitle={
+        <FormattedMessage
+          description="Calendar: next year button title"
+          defaultMessage="Next year"
+        />
+      }
+      previousMonthButtonTitle={
+        <FormattedMessage
+          description="Calendar: previous month button title"
+          defaultMessage="Previous month"
+        />
+      }
+      nextMonthButtonTitle={
+        <FormattedMessage
+          description="Calendar: next month button title"
+          defaultMessage="Next month"
+        />
+      }
+      {...props}
+    />
+  );
+};
+
+export default DatePickerCalendar;

--- a/src/components/forms/DateField/index.js
+++ b/src/components/forms/DateField/index.js
@@ -1,0 +1,3 @@
+import {default as DateField} from './DateField';
+
+export default DateField;

--- a/src/components/forms/FloatingWidget.js
+++ b/src/components/forms/FloatingWidget.js
@@ -1,0 +1,149 @@
+/**
+ * Implements a form field widget that floats in a 'popout'.
+ *
+ * Focusing the form field opens the widget, while keeping focus on original form
+ * field. Keyboard tab navigation focuses the elements inside the popout in order,
+ * while any other keyboard input closes the widget (shifting to 'manual input' mode).
+ *
+ * Clicking the form field/reference (re-)opens the widget. The widget/popout can be
+ * dismissed by hitting the [ESC} key, clicking outside of it or tabbing through/out
+ * of it.
+ *
+ * You need both the hook and component for the behaviour.
+ *
+ * Note that `getReferenceProps` returns event handlers like onKeyDown - if you are
+ * overriding these events yourself, make sure you don't accidentally overwrite the
+ * floating widget handlers.
+ */
+import {
+  FloatingArrow,
+  FloatingFocusManager,
+  arrow,
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  useDismiss,
+  useFloating,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react';
+import PropTypes from 'prop-types';
+import React, {useRef, useState} from 'react';
+
+import {getBEMClassName} from 'utils';
+
+const useFloatingWidget = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const keepClosed = useRef(false);
+  const arrowRef = useRef(null);
+
+  const manageOpen = (open, options = {}) => {
+    const {keepDismissed = false} = options;
+    setIsOpen(open);
+    if (open && keepClosed.current) {
+      keepClosed.current = false;
+    }
+    if (!open && keepDismissed) {
+      keepClosed.current = true;
+    }
+  };
+
+  const {refs, floatingStyles, context} = useFloating({
+    open: isOpen,
+    onOpenChange: manageOpen,
+    middleware: [offset(10), flip(), shift(), arrow({element: arrowRef})],
+    whileElementsMounted: autoUpdate,
+  });
+
+  const dismiss = useDismiss(context);
+  const role = useRole(context);
+
+  const {getReferenceProps, getFloatingProps} = useInteractions([dismiss, role]);
+  const referenceProps = getReferenceProps();
+
+  const onClick = () => {
+    const isFocused = context.refs.reference.current === document.activeElement;
+    isFocused && !isOpen && manageOpen(true);
+  };
+
+  const onKeyDown = event => {
+    referenceProps?.onKeyDown?.(event);
+    event.key !== 'Tab' && manageOpen(false);
+  };
+
+  const onFocus = () => {
+    !isOpen && !keepClosed.current && manageOpen(true);
+    if (keepClosed.current) {
+      keepClosed.current = false;
+    }
+  };
+
+  return {
+    refs,
+    floatingStyles,
+    context,
+    getFloatingProps,
+    getReferenceProps: () => {
+      return {...referenceProps, onClick, onFocus, onKeyDown};
+    },
+    isOpen,
+    setIsOpen: manageOpen,
+    arrowRef,
+  };
+};
+
+const FloatingWidget = ({
+  isOpen,
+  context,
+  setFloating,
+  floatingStyles,
+  getFloatingProps,
+  arrowRef,
+  children,
+  ...restProps
+}) => {
+  return (
+    isOpen && (
+      <FloatingFocusManager
+        context={context}
+        modal={false}
+        order={['reference', 'content']}
+        returnFocus
+        visuallyHiddenDismiss
+      >
+        <div
+          ref={setFloating}
+          className={getBEMClassName('floating-widget')}
+          // checked with CSP - these inline styles appear to be using the CSSOM correctly
+          // and would not result in CSP violations where unsafe-inline is blocked.
+          // Ref: https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model
+          style={floatingStyles}
+          {...getFloatingProps()}
+          {...restProps}
+        >
+          <FloatingArrow
+            ref={arrowRef}
+            context={context}
+            className={getBEMClassName('floating-widget__arrow')}
+            stroke="transparent"
+            strokeWidth={1}
+          />
+          {children}
+        </div>
+      </FloatingFocusManager>
+    )
+  );
+};
+
+FloatingWidget.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  context: PropTypes.object.isRequired,
+  setFloating: PropTypes.func.isRequired,
+  floatingStyles: PropTypes.object.isRequired,
+  getFloatingProps: PropTypes.func.isRequired,
+  arrowRef: PropTypes.object.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export {useFloatingWidget, FloatingWidget};

--- a/src/components/forms/FloatingWidget.js
+++ b/src/components/forms/FloatingWidget.js
@@ -14,6 +14,14 @@
  * Note that `getReferenceProps` returns event handlers like onKeyDown - if you are
  * overriding these events yourself, make sure you don't accidentally overwrite the
  * floating widget handlers.
+ *
+ * We've done an attempt (see https://github.com/open-formulieren/open-forms-sdk/pull/432/files#r1221521810)
+ * to make the hook the *only* API by having it return the `FloatingWidget` component (
+ * as a closure) so that the additional props like refs/floatingStyles... etc. wouldn't
+ * need to be passed. This didn't work with React sort of blowing up because of too
+ * many re-renders. I suspect the refs/useRef calls with the closure component might be
+ * a problem and possibly useMemo could be a solution to this, but this is entirely
+ * guesswork and unvalidated. Making this work is left as an exercise to the reader.
  */
 import {
   FloatingArrow,

--- a/src/components/forms/FloatingWidget.stories.mdx
+++ b/src/components/forms/FloatingWidget.stories.mdx
@@ -1,11 +1,14 @@
 import {ArgsTable, Canvas, Meta, Story} from '@storybook/addon-docs';
 import {expect} from '@storybook/jest';
-import {userEvent, within} from '@storybook/testing-library';
+import {userEvent, waitFor, within} from '@storybook/testing-library';
 import {act} from '@testing-library/react';
 
 import {FloatingWidget, useFloatingWidget} from './FloatingWidget';
 
 export const waitForPosition = () => act(async () => {});
+export const waitForFocus = async element => {
+  await waitFor(() => expect(reference).toHaveFocus());
+};
 
 <Meta title="Private API / FloatingWidget" component={FloatingWidget} />
 
@@ -137,7 +140,7 @@ export const FloatingWidgetExample = () => {
       await expect(await canvas.queryByRole('dialog')).toBeNull();
       await userEvent.click(canvas.getByText('Reference'));
       const reference = canvas.getByTestId('reference');
-      await expect(reference).toHaveFocus();
+      await waitForFocus(reference);
       await expect(canvas.getByRole('dialog')).toBeVisible();
     }}
   >
@@ -169,13 +172,13 @@ export const FloatingWidgetExample = () => {
       const canvas = within(canvasElement);
       const reference = canvas.getByTestId('reference');
       await userEvent.click(reference);
-      await expect(reference).toHaveFocus();
+      await waitForFocus(reference);
       await expect(canvas.getByRole('dialog')).toBeVisible();
       await userEvent.keyboard('[Escape]');
       await expect(await canvas.queryByRole('dialog')).toBeNull();
-      await expect(reference).toHaveFocus();
+      await waitForFocus(reference);
       await userEvent.click(reference);
-      await expect(reference).toHaveFocus();
+      await waitForFocus(reference);
       await expect(canvas.getByRole('dialog')).toBeVisible();
     }}
   >
@@ -218,7 +221,7 @@ export const FloatingWidgetExample = () => {
       await userEvent.click(button);
       await waitForPosition();
       await expect(await canvas.queryByRole('dialog')).toBeNull();
-      await expect(reference).toHaveFocus();
+      await waitForFocus(reference);
     }}
   >
     <FloatingWidgetExample />

--- a/src/components/forms/FloatingWidget.stories.mdx
+++ b/src/components/forms/FloatingWidget.stories.mdx
@@ -1,0 +1,249 @@
+import {ArgsTable, Canvas, Meta, Story} from '@storybook/addon-docs';
+import {expect} from '@storybook/jest';
+import {userEvent, within} from '@storybook/testing-library';
+import {act} from '@testing-library/react';
+
+import {FloatingWidget, useFloatingWidget} from './FloatingWidget';
+
+export const waitForPosition = () => act(async () => {});
+
+<Meta title="Private API / FloatingWidget" component={FloatingWidget} />
+
+Use the `FloatingWidget` component and `useFloatingWidget` hook when you want to provide a form
+control/widget in a widget.
+
+The widget will position itself to the form field with the appropriate accessible attributes set.
+
+## API
+
+This component requires both the `FloatingWidget` wrapper component and `useFloatingWidget` hook to
+manage the state, position and attributes.
+
+### Example
+
+```jsx
+const FormField = () => {
+  const {
+    refs,
+    floatingStyles,
+    context,
+    getFloatingProps,
+    getReferenceProps,
+    isOpen,
+    setIsOpen,
+    arrowRef,
+  } = useFloatingWidget();
+  return (
+    <div>
+      <input type="text" name="reference" ref={refs.setReference} {...getReferenceProps()} />
+      <FloatingWidget
+        isOpen={isOpen}
+        context={context}
+        setFloating={refs.setFloating}
+        floatingStyles={floatingStyles}
+        getFloatingProps={getFloatingProps}
+        arrowRef={arrowRef}
+      >
+        <p>Floating widget content</p>
+        <p>
+          <input name="widgetInput" />
+          <button onClick={() => setIsOpen(false, {keepDismissed: true})}>close</button>
+        </p>
+      </FloatingWidget>
+    </div>
+  );
+};
+```
+
+### FloatingWidget props
+
+<ArgsTable of={FloatingWidget} />
+
+## Stories for interaction tests
+
+export const FloatingWidgetExample = () => {
+  const {
+    refs,
+    floatingStyles,
+    context,
+    getFloatingProps,
+    getReferenceProps,
+    isOpen,
+    setIsOpen,
+    arrowRef,
+  } = useFloatingWidget();
+  return (
+    <>
+      <div>
+        <label htmlFor="reference">Reference</label>
+        <input
+          name="reference"
+          type="text"
+          id="reference"
+          defaultValue=""
+          ref={refs.setReference}
+          data-testid="reference"
+          {...getReferenceProps()}
+        />
+        <FloatingWidget
+          isOpen={isOpen}
+          context={context}
+          setFloating={refs.setFloating}
+          floatingStyles={floatingStyles}
+          getFloatingProps={getFloatingProps}
+          arrowRef={arrowRef}
+          data-testid="floating-widget"
+        >
+          <div style={{padding: '1em'}}>
+            <p>Floating widget content</p>
+            <p>
+              <input name="widgetInput" defaultValue="" data-testid="widget-input" />
+              <button
+                onClick={() => {
+                  setIsOpen(false, {keepDismissed: true});
+                }}
+              >
+                close
+              </button>
+            </p>
+          </div>
+        </FloatingWidget>
+      </div>
+      <div>
+        <label htmlFor="other-input">Other input</label>
+        <input
+          name="otherInput"
+          type="text"
+          id="other-input"
+          defaultValue=""
+          data-testid="other-input"
+        />
+      </div>
+    </>
+  );
+};
+
+<Canvas>
+  <Story name="Default">
+    <FloatingWidgetExample />
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Focus reference input"
+    play={async ({canvasElement}) => {
+      const canvas = within(canvasElement);
+      await expect(await canvas.queryByRole('dialog')).toBeNull();
+      await userEvent.click(canvas.getByText('Reference'));
+      const reference = canvas.getByTestId('reference');
+      await expect(reference).toHaveFocus();
+      await expect(canvas.getByRole('dialog')).toBeVisible();
+    }}
+  >
+    <FloatingWidgetExample />
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Type in reference input closes widget"
+    play={async ({canvasElement}) => {
+      const canvas = within(canvasElement);
+      await expect(await canvas.queryByRole('dialog')).toBeNull();
+      const reference = canvas.getByTestId('reference');
+      await reference.focus();
+      await expect(canvas.getByRole('dialog')).toBeVisible();
+      await userEvent.type(reference, 'Some input');
+      await expect(await canvas.queryByRole('dialog')).toBeNull();
+    }}
+  >
+    <FloatingWidgetExample />
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Dismiss widget and re-open with click"
+    play={async ({canvasElement}) => {
+      const canvas = within(canvasElement);
+      const reference = canvas.getByTestId('reference');
+      await userEvent.click(reference);
+      await expect(reference).toHaveFocus();
+      await expect(canvas.getByRole('dialog')).toBeVisible();
+      await userEvent.keyboard('[Escape]');
+      await expect(await canvas.queryByRole('dialog')).toBeNull();
+      await expect(reference).toHaveFocus();
+      await userEvent.click(reference);
+      await expect(reference).toHaveFocus();
+      await expect(canvas.getByRole('dialog')).toBeVisible();
+    }}
+  >
+    <FloatingWidgetExample />
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Tab navigate to widget input"
+    play={async ({canvasElement}) => {
+      const canvas = within(canvasElement);
+      const reference = canvas.getByTestId('reference');
+      await userEvent.click(reference);
+      await waitForPosition();
+      await expect(canvas.getByRole('dialog')).toBeVisible();
+      const widgetInput = canvas.getByTestId('widget-input');
+      await expect(widgetInput).not.toHaveFocus();
+      await userEvent.tab();
+      await waitForPosition();
+      await expect(canvas.getByRole('dialog')).toBeVisible();
+      await expect(widgetInput).toHaveFocus();
+    }}
+  >
+    <FloatingWidgetExample />
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Submit widget and close widget"
+    play={async ({canvasElement}) => {
+      const canvas = within(canvasElement);
+      const reference = canvas.getByTestId('reference');
+      await userEvent.click(reference);
+      await waitForPosition();
+      await expect(canvas.getByRole('dialog')).toBeVisible();
+      const button = canvas.getByRole('button', {name: 'close'});
+      await expect(button).toBeVisible();
+      await userEvent.click(button);
+      await waitForPosition();
+      await expect(await canvas.queryByRole('dialog')).toBeNull();
+      await expect(reference).toHaveFocus();
+    }}
+  >
+    <FloatingWidgetExample />
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Focus other input closes widget"
+    play={async ({canvasElement}) => {
+      const canvas = within(canvasElement);
+      const reference = canvas.getByTestId('reference');
+      await userEvent.click(reference);
+      await waitForPosition();
+      await expect(canvas.getByRole('dialog')).toBeVisible();
+      await userEvent.tab();
+      await expect(canvas.getByTestId('widget-input')).toHaveFocus();
+      await userEvent.tab();
+      await expect(canvas.getByRole('button')).toHaveFocus();
+      await userEvent.tab();
+      await waitForPosition();
+      await expect(canvas.getByTestId('other-input')).toHaveFocus();
+      await expect(await canvas.queryByRole('dialog')).toBeNull();
+    }}
+  >
+    <FloatingWidgetExample />
+  </Story>
+</Canvas>

--- a/src/components/forms/index.js
+++ b/src/components/forms/index.js
@@ -1,8 +1,10 @@
-import {default as EmailField} from './EmailField';
-import {default as NumberField} from './NumberField';
-import {default as TextField} from './TextField';
-
-export {default as Label} from './Label';
+// high-level
+export {default as EmailField} from './EmailField';
+export {default as NumberField} from './NumberField';
 export {SelectField, AsyncSelectField} from './SelectField';
+export {default as TextField} from './TextField';
+
+// helpers
+export * from './FloatingWidget';
+export {default as Label} from './Label';
 export {default as ValidationErrors} from './ValidationErrors';
-export {TextField, EmailField, NumberField};

--- a/src/components/forms/index.js
+++ b/src/components/forms/index.js
@@ -1,4 +1,5 @@
 // high-level
+export {default as DateField} from './DateField';
 export {default as EmailField} from './EmailField';
 export {default as NumberField} from './NumberField';
 export {SelectField, AsyncSelectField} from './SelectField';

--- a/src/formio/components/FileField.stories.mdx
+++ b/src/formio/components/FileField.stories.mdx
@@ -3,7 +3,7 @@ import {expect} from '@storybook/jest';
 import {userEvent, within} from '@storybook/testing-library';
 import {getWorker} from 'msw-storybook-addon';
 
-import {FileField} from './FileField';
+import FileField from './FileField';
 import {
   UPLOAD_URL,
   mockFileUploadDelete,

--- a/src/scss/components/_date-picker.scss
+++ b/src/scss/components/_date-picker.scss
@@ -1,0 +1,62 @@
+@use 'microscope-sass/lib/bem';
+@use '../mixins/prefix';
+
+@import '@utrecht/components/dist/calendar/css/index.css';
+
+.#{prefix.prefix('datepicker')} {
+  padding: 0;
+  border: 0;
+  border-radius: var(--of-datepicker-border-radius, 0);
+  box-sizing: border-box;
+  background: var(--of-datepicker-background, var(--of-color-bg));
+  box-shadow: var(
+    --of-datepicker-box-shadow,
+    1px 0 0 #e6e6e6,
+    -1px 0 0 #e6e6e6,
+    0 1px 0 #e6e6e6,
+    0 -1px 0 #e6e6e6,
+    0 3px 13px rgba(0, 0, 0, 0.08)
+  );
+
+  @include bem.element('arrow') {
+    fill: var(--of-color-bg, #fff);
+
+    path[clip-path] {
+      stroke: var(--of-datepicker-arrow-border-color, #e6e6e6);
+      stroke-width: var(--of-datepicker-arrow-stroke-width, 3);
+    }
+  }
+}
+
+.#{prefix.prefix('datepicker-textbox')} {
+  position: relative;
+
+  .utrecht-textbox {
+    padding-right: 3em;
+  }
+
+  @include bem.element('calendar-toggle') {
+    position: absolute;
+    padding: 0.5em;
+    font-size: 150%;
+    right: 0;
+    bottom: 0;
+    top: 0;
+    display: flex;
+    align-items: center;
+    color: var(--of-color-fg-muted);
+  }
+}
+
+.openforms-theme .utrecht-calendar {
+  .utrecht-calendar {
+    &__table-days-item-day {
+      &--selected {
+        text-decoration: var(
+          --of-datepicker-table-days-item-day-selected-text-decoration,
+          underline
+        );
+      }
+    }
+  }
+}

--- a/src/scss/components/_floating-widget.scss
+++ b/src/scss/components/_floating-widget.scss
@@ -1,0 +1,27 @@
+@use 'microscope-sass/lib/bem';
+@use '../mixins/prefix';
+
+.#{prefix.prefix('floating-widget')} {
+  padding: 0;
+  border: 0;
+  border-radius: var(--of-floating-widget-border-radius, 0);
+  box-sizing: border-box;
+  background: var(--of-floating-widget-background, var(--of-color-bg));
+  box-shadow: var(
+    --of-floating-widget-box-shadow,
+    1px 0 0 #e6e6e6,
+    -1px 0 0 #e6e6e6,
+    0 1px 0 #e6e6e6,
+    0 -1px 0 #e6e6e6,
+    0 3px 13px rgba(0, 0, 0, 0.08)
+  );
+
+  @include bem.element('arrow') {
+    fill: var(--of-color-bg, #fff);
+
+    path[clip-path] {
+      stroke: var(--of-floating-widget-arrow-border-color, #e6e6e6);
+      stroke-width: var(--of-floating-widget-arrow-stroke-width, 3);
+    }
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -59,3 +59,4 @@
 @import './scss/components/login-options';
 @import './scss/components/login-button';
 @import './scss/components/login-button-logo';
+@import './scss/components/floating-widget';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -60,3 +60,4 @@
 @import './scss/components/login-button';
 @import './scss/components/login-button-logo';
 @import './scss/components/floating-widget';
+@import './scss/components/date-picker';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5524,10 +5524,10 @@
   resolved "https://registry.yarnpkg.com/@utrecht/component-library-css/-/component-library-css-1.0.0-alpha.417.tgz#cc75f326af08a6c501f7dcfd3fdce425295b0093"
   integrity sha512-5MS5WmvBDd69yQUlWg97ynsPPfXbur49STcUP/UTCaQrWzB5xUu/NhbaWFdVEW2PqGh2/TOT4tE/ziaeY4Aksw==
 
-"@utrecht/component-library-react@^1.0.0-alpha.321":
-  version "1.0.0-alpha.321"
-  resolved "https://registry.yarnpkg.com/@utrecht/component-library-react/-/component-library-react-1.0.0-alpha.321.tgz#0b531f07bd0bde988ba505b5857e27cdc5a23c1e"
-  integrity sha512-f63QXwlrSI2CS+FeWs8RtrScjW6/PXisPLQYcvINLdh76Uo4MyrnjS5kNHxo/wxVv+y19h2GwmbaDDX7oxZ3vQ==
+"@utrecht/component-library-react@^1.0.0-alpha.334":
+  version "1.0.0-alpha.334"
+  resolved "https://registry.yarnpkg.com/@utrecht/component-library-react/-/component-library-react-1.0.0-alpha.334.tgz#bd5f20831994c47e3ffcf7e72977c6ec096a916b"
+  integrity sha512-F6uIYgRr1+lUdM83n7RX7swye0q0NrHW/594nohskfHH5fkQZKOrgxcGLICRwvcWvKphsf6v4uPC4hmIAtnXBQ==
   dependencies:
     clsx "1.2.1"
     date-fns "2.30.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2667,6 +2667,29 @@
   dependencies:
     "@floating-ui/core" "^1.2.6"
 
+"@floating-ui/dom@^1.2.7":
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.2.9.tgz#b9ed1c15d30963419a6736f1b7feb350dd49c603"
+  integrity sha512-sosQxsqgxMNkV3C+3UqTS6LxP7isRLwX8WMepp843Rb3/b0Wz8+MdUkxJksByip3C2WwLugLHN1b4ibn//zKwQ==
+  dependencies:
+    "@floating-ui/core" "^1.2.6"
+
+"@floating-ui/react-dom@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.0.tgz#7514baac526c818892bbcc84e1c3115008c029f9"
+  integrity sha512-Ke0oU3SeuABC2C4OFu2mSAwHIP5WUiV98O9YWoHV4Q5aT6E9k06DV0Khi5uYspR8xmmBk08t8ZDcz3TR3ARkEg==
+  dependencies:
+    "@floating-ui/dom" "^1.2.7"
+
+"@floating-ui/react@^0.24.2":
+  version "0.24.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.24.2.tgz#1f2e596da122341a3fa65667a6f26ed126d32cc0"
+  integrity sha512-8sdLmcC85J6M2H0AL8yOQuiWD4T0gNMSLpuJjmXyEA6ndfmxXR0hwKFkczB4xRNFhKbwoQeuh8z561HE2vOdZw==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.0"
+    aria-hidden "^1.1.3"
+    tabbable "^6.0.1"
+
 "@formatjs/cli@^4.2.33":
   version "4.2.33"
   resolved "https://registry.npmjs.org/@formatjs/cli/-/cli-4.2.33.tgz"
@@ -6173,6 +6196,13 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+aria-hidden@^1.1.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.3.tgz#14aeb7fb692bbb72d69bebfa47279c1fd725e954"
+  integrity sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==
+  dependencies:
+    tslib "^2.0.0"
 
 aria-query@^4.2.2:
   version "4.2.2"
@@ -16998,6 +17028,11 @@ synchronous-promise@^2.0.15:
   version "2.0.15"
   resolved "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.15.tgz"
   integrity sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==
+
+tabbable@^6.0.1:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.1.2.tgz#b0d3ca81d582d48a80f71b267d1434b1469a3703"
+  integrity sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ==
 
 tailwindcss@^3.0.2:
   version "3.0.24"


### PR DESCRIPTION
Closes open-formulieren/open-forms#3060
~~Depends on open-formulieren/design-tokens#21~~
~~Depends on open-formulieren/design-tokens#22~~

**Notes**

* Field allows manual keyboard input in ISO 8601 format
* Date is stored in formik state (as string)
* Focusing the field opens the datepicker
* Supports specifying disabled dates, minimum and maximum date (all optional)
* Design token values in our own theme added to match existing look and feel
* Added documentation on what this component can and can not do
* Scoped to the needs of the appointments rework, see #433 for broader usage

**TODO**

- [x] clean up commit history