### PR TITLE
[OF#3096] Blocked form because of open editgrid row

### DIFF
--- a/src/formio/components/EditGrid.js
+++ b/src/formio/components/EditGrid.js
@@ -128,6 +128,55 @@ class EditGrid extends FormioEditGrid {
     return !!valid;
   }
 
+  /**
+   * Copied from Formio https://github.com/formio/formio.js/blob/v4.13.13/src/components/editgrid/EditGrid.js#L969
+   * The call to super was moved AFTER the checks of whether the rows are invalid or if there are open (unsaved rows).
+   *
+   * See: open-formulieren/open-forms#3096
+   */
+  checkComponentValidity(data, dirty, row, options) {
+    if (this.shouldSkipValidation(data, dirty, row)) {
+      return true;
+    }
+
+    let rowsValid = true;
+    let rowsEditing = false;
+
+    this.editRows.forEach((editRow, index) => {
+      // Trigger all errors on the row.
+      const rowValid = this.validateRow(editRow, editRow.alerts || dirty);
+
+      rowsValid &= rowValid;
+
+      if (this.rowRefs) {
+        const rowContainer = this.rowRefs[index];
+
+        if (rowContainer) {
+          const errorContainer = rowContainer.querySelector('.editgrid-row-error');
+
+          if (!rowValid && errorContainer) {
+            errorContainer.textContent = this.t('invalidRowError');
+          }
+        }
+      }
+      // If this is a dirty check, and any rows are still editing, we need to throw validation error.
+      rowsEditing |= dirty && this.isOpen(editRow);
+    });
+
+    if (!rowsValid) {
+      this.setCustomValidity(this.t('invalidRowsError'), dirty);
+      return false;
+    } else if (rowsEditing && this.saveEditMode) {
+      this.setCustomValidity(this.t('unsavedRowsError'), dirty);
+      return false;
+    }
+
+    const message = this.invalid || this.invalidMessage(data, dirty);
+    this.setCustomValidity(message, dirty);
+
+    return super.checkComponentValidity(data, dirty, row, options);
+  }
+
   cancelRow(rowIndex) {
     if (this.options.readOnly) {
       return;

--- a/src/jstests/formio/components/editgrid.spec.js
+++ b/src/jstests/formio/components/editgrid.spec.js
@@ -1,0 +1,39 @@
+import _ from 'lodash';
+import {Formio} from 'react-formio';
+
+import {BASE_URL} from 'api-mocks';
+import OpenFormsModule from 'formio/module';
+
+import {editgridForm} from './fixtures/editgrid';
+
+// Use our custom components
+Formio.use(OpenFormsModule);
+
+describe('EditGrid Component', () => {
+  test('Unsaved row raises error', done => {
+    let formJSON = _.cloneDeep(editgridForm);
+    const data = {repeatingGroup: []};
+
+    const element = document.createElement('div');
+
+    let formInstance;
+
+    Formio.createForm(element, formJSON, {baseUrl: BASE_URL})
+      .then(form => {
+        form.setPristine(false);
+        const componentRepeatingGroup = form.getComponent('repeatingGroup');
+        componentRepeatingGroup.addRow();
+
+        formInstance = form;
+
+        return form.checkAsyncValidity(data, true, data);
+      })
+      .then(isValid => {
+        setTimeout(() => {
+          expect(formInstance.errors.length).toBeGreaterThan(0);
+          done();
+        }, 300);
+      })
+      .catch(done);
+  });
+});

--- a/src/jstests/formio/components/fixtures/editgrid.js
+++ b/src/jstests/formio/components/fixtures/editgrid.js
@@ -1,0 +1,23 @@
+const editgridForm = {
+  type: 'form',
+  components: [
+    {
+      key: 'repeatingGroup',
+      type: 'editgrid',
+      components: [
+        {
+          key: 'textField',
+          type: 'textfield',
+          input: true,
+          label: 'TextField',
+        },
+      ],
+    },
+  ],
+  title: 'Test editgrid form',
+  display: 'Test editgrid form',
+  name: 'testEditgridForm',
+  path: 'testEditgridForm',
+};
+
+export {editgridForm};


### PR DESCRIPTION
Fixes https://github.com/open-formulieren/open-forms/issues/3096

### The problem

- The function `checkComponentValidity` is called to validate the editGrid (https://github.com/formio/formio.js/blob/v4.13.13/src/components/editgrid/EditGrid.js#L969). This makes a call to super.
- The `super.checkComponentValidity` checks the editGrid 'as a whole': it checks the 'required' validator, the max length validator... If the component as a whole is valid, then it schedules a callback to `setComponentValidity`, which will clear errors on the component.
- The `checkComponentValidity` of editGrid now checks if each row is valid and if there are any open/unsaved rows. Since it is the case, it sets the component validity (note: it does it syncronously, it doesn't schedule a callback like the super.
- The callback of the super executes. This clears the error on the component (but it must miss something somewhere because the form submission is blocked, but no error is visible).

### Solution

Moved the super call AFTER the row checks. If the rows are invalid/unsaved, then the function returns and no super call is done.

The repeating group doesn't deal with async validation, so this could be a problem at some point :shrug: 