### PR TITLE
Implement appointment time field

### DIFF
--- a/src/components/appointments/TimeSelect.js
+++ b/src/components/appointments/TimeSelect.js
@@ -1,0 +1,75 @@
+import {format, parseISO} from 'date-fns';
+import {useFormikContext} from 'formik';
+import React, {useCallback, useContext} from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import {ConfigContext} from 'Context';
+import {get} from 'api';
+import {AsyncSelectField} from 'components/forms';
+import {useCalendarLocale} from 'components/forms/DateField';
+
+const getDatetimes = async (baseUrl, productIds, locationId, date) => {
+  if (!productIds.length || !locationId || !date) return [];
+  const multiParams = productIds.map(id => ({product_id: id}));
+  const datetimesList = await get(
+    `${baseUrl}appointments/times`,
+    {location_id: locationId, date: date},
+    multiParams
+  );
+
+  return datetimesList.map(item => item.time);
+};
+
+const TimeSelect = () => {
+  const {baseUrl} = useContext(ConfigContext);
+  const {values} = useFormikContext();
+  const calendarLocale = useCalendarLocale();
+
+  const getOptions = useCallback(
+    async () => {
+      const productIds = (values.products || []).map(prod => prod.product);
+      const results = await getDatetimes(baseUrl, productIds, values.location, values.date);
+      // Array.prototype.toSorted is too new, jest tests can't handle it yet
+      return results
+        .map(datetime => {
+          const parsed = parseISO(datetime);
+          return {
+            parsed,
+            value: datetime,
+            // p: long localized time, without seconds
+            label: format(parsed, 'p', {locale: calendarLocale}),
+          };
+        })
+        .sort((a, b) => {
+          if (a.parsed < b.parsed) return -1;
+          if (a.parsed > b.parsed) return 1;
+          return 0;
+        });
+    },
+    // about JSON.stringify: https://github.com/facebook/react/issues/14476#issuecomment-471199055
+    [baseUrl, calendarLocale, JSON.stringify(values)]
+  );
+
+  return (
+    <AsyncSelectField
+      name="datetime"
+      isRequired
+      disabled={!values.products || !values.products.length || !values.location || !values.date}
+      label={
+        <FormattedMessage description="Appoinments: time select label" defaultMessage="Time" />
+      }
+      description={
+        <FormattedMessage
+          description="Appoinments: time select help text"
+          defaultMessage="Times are in your local time"
+        />
+      }
+      getOptions={getOptions}
+      autoSelectOnlyOption
+    />
+  );
+};
+
+TimeSelect.propTypes = {};
+
+export default TimeSelect;

--- a/src/components/appointments/TimeSelect.stories.mdx
+++ b/src/components/appointments/TimeSelect.stories.mdx
@@ -76,6 +76,9 @@ end-user, the times are displayed in their local timezone, configured on their O
   <Story
     name="Times are localized"
     height="280px"
+    parameters={{
+      chromatic: {disableSnapshot: true},
+    }}
     play={async ({canvasElement}) => {
       const canvas = within(canvasElement);
       const dropdown = canvas.getByLabelText('Time');

--- a/src/components/appointments/TimeSelect.stories.mdx
+++ b/src/components/appointments/TimeSelect.stories.mdx
@@ -1,0 +1,96 @@
+import {Canvas, Meta, Story} from '@storybook/addon-docs';
+import {expect} from '@storybook/jest';
+import {userEvent, waitFor, within} from '@storybook/testing-library';
+import {addDays, formatISO} from 'date-fns';
+
+import {ConfigDecorator, FormikDecorator} from 'story-utils/decorators';
+
+import TimeSelect from './TimeSelect';
+import {mockAppointmentTimesGet} from './mocks';
+
+export const tomorrow = formatISO(addDays(new Date(), 1), {representation: 'date'});
+
+<Meta
+  title="Private API / Appointments / TimeSelect"
+  decorators={[FormikDecorator, ConfigDecorator]}
+  component={TimeSelect}
+  parameters={{
+    formik: {
+      initialValues: {
+        products: [{product: 'e8e045ab', amount: 1}],
+        location: '1396f17c',
+        date: tomorrow,
+        datetime: '',
+      },
+    },
+    msw: {
+      handlers: [mockAppointmentTimesGet],
+    },
+  }}
+/>
+
+## Select an available time
+
+Given the location, products and date, the API endpoint returns a set of available appointment
+times. These are displayed to the user as a time, but the value stored and submitted is a full
+ISO-8601 datetime string.
+
+<Canvas>
+  <Story name="Default" height="280px">
+    <TimeSelect />
+  </Story>
+</Canvas>
+
+## Interactions
+
+The time field is only enabled when one or more products, a location and a date have been selected.
+
+<Canvas>
+  <Story
+    name="No date selected -> disabled"
+    parameters={{
+      formik: {
+        initialValues: {
+          products: [{product: 'e8e045ab', amount: 1}],
+          location: '1396f17c',
+          date: '',
+          datetime: '',
+        },
+      },
+    }}
+    play={async ({canvasElement}) => {
+      const canvas = within(canvasElement);
+      const dropdown = canvas.getByLabelText('Time');
+      await expect(dropdown.role).toBe('combobox');
+      await expect(dropdown).toBeDisabled();
+    }}
+  >
+    <TimeSelect />
+  </Story>
+</Canvas>
+
+The times received from the backend are typically in UTC or otherwise timezone-aware. For the
+end-user, the times are displayed in their local timezone, configured on their OS/browser.
+
+<Canvas>
+  <Story
+    name="Times are localized"
+    height="280px"
+    play={async ({canvasElement}) => {
+      const canvas = within(canvasElement);
+      const dropdown = canvas.getByLabelText('Time');
+      await dropdown.focus();
+      await userEvent.keyboard('[ArrowDown]');
+      await waitFor(async () => {
+        // see mocks.js for the returned times
+        await expect(canvas.getByText('08:00')).toBeVisible();
+        await expect(canvas.getByText('08:10')).toBeVisible();
+        await expect(canvas.getByText('10:00')).toBeVisible();
+        await expect(canvas.getByText('10:30')).toBeVisible();
+        await expect(canvas.getByText('14:30')).toBeVisible();
+      });
+    }}
+  >
+    <TimeSelect />
+  </Story>
+</Canvas>

--- a/src/components/appointments/mocks.js
+++ b/src/components/appointments/mocks.js
@@ -40,13 +40,6 @@ const DATES = [
   },
 ];
 
-const DEFAULT_TIMES = [
-  {time: '2021-08-19T10:00:00+02:00'},
-  {time: '2021-08-19T10:30:00+02:00'},
-  {time: '2021-08-20T08:00:00+02:00'},
-  {time: '2021-08-20T08:10:00+02:00'},
-];
-
 export const mockAppointmentProductsGet = rest.get(
   `${BASE_URL}appointments/products`,
   (req, res, ctx) => {
@@ -92,9 +85,15 @@ export const mockAppointmentTimesGet = rest.get(
   `${BASE_URL}appointments/times`,
   (req, res, ctx) => {
     const date = req.url.searchParams.get('date');
-    const times = DEFAULT_TIMES.filter(
-      t => new Date(t.time).toDateString() === new Date(date).toDateString()
-    );
+    // ensure we can handle datetimes with timezone information in varying formats.
+    // Ideally, the API returns UTC, but the UI needs to display localized times.
+    const times = [
+      `${date}T08:00:00Z`,
+      `${date}T08:30:00Z`,
+      `${date}T06:00:00Z`,
+      `${date}T06:10:00Z`,
+      `${date}T14:30:00+02:00`,
+    ].map(datetime => ({time: datetime}));
     return res(ctx.json(times));
   }
 );


### PR DESCRIPTION
(Partially) closes open-formulieren/open-forms#3065

Depends on #450 

Implements the time field for the appointment time, based on select products, location and date. Times are displayed in the browser/OS timezone.

I've reached out to Chromatic support to ask if we can set the timezone for the play functions, but in the worst case we can disable this particular story completely.