### PR TITLE
Hook up appointment form to main router

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,6 +1,6 @@
 import React, {useContext} from 'react';
 import ReactDOM from 'react-dom';
-import {Route, Routes} from 'react-router-dom';
+import {Outlet} from 'react-router-dom';
 
 import {ConfigContext} from 'Context';
 import AppDebug from 'components/AppDebug';
@@ -14,6 +14,25 @@ import Types from 'types';
 import {DEBUG} from 'utils';
 
 import AppDisplay from './AppDisplay';
+
+export const getRoutes = (form, noDebug = false) => {
+  const routes = [
+    {
+      path: 'afspraak-annuleren',
+      element: <ManageAppointment />,
+    },
+    {
+      path: 'cosign/*',
+      element: <Cosign form={form} noDebug={noDebug} />,
+    },
+    // All the rest goes to the formio-based form flow
+    {
+      path: '*',
+      element: <Form form={form} noDebug={noDebug} />,
+    },
+  ];
+  return routes;
+};
 
 const LanguageSwitcher = () => {
   const {languageSelectorTarget: target} = useContext(I18NContext);
@@ -39,20 +58,14 @@ const App = ({...props}) => {
   const AppDisplayComponent = config?.displayComponents?.app ?? AppDisplay;
 
   const languageSwitcher = translationEnabled ? <LanguageSwitcher /> : null;
-  const router = (
-    <Routes>
-      {/* Anything dealing with appointments gets routed to its own sub-router */}
-      <Route path="afspraak-annuleren/*" element={<ManageAppointment />} />
-      <Route path="cosign/*" element={<Cosign {...props} />} />
-
-      {/* All the rest goes to the actual form flow */}
-      <Route path="*" element={<Form {...props} />} />
-    </Routes>
-  );
   const appDebug = DEBUG && !noDebug ? <AppDebug /> : null;
 
   return (
-    <AppDisplayComponent router={router} languageSwitcher={languageSwitcher} appDebug={appDebug} />
+    <AppDisplayComponent
+      router={<Outlet />}
+      languageSwitcher={languageSwitcher}
+      appDebug={appDebug}
+    />
   );
 };
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,6 +1,6 @@
 import React, {useContext} from 'react';
 import ReactDOM from 'react-dom';
-import {Outlet} from 'react-router-dom';
+import {Navigate, Outlet, useMatch} from 'react-router-dom';
 
 import {ConfigContext} from 'Context';
 import AppDebug from 'components/AppDebug';
@@ -56,8 +56,10 @@ Top level router - routing between an actual form or supporting screens.
  */
 const App = ({...props}) => {
   const config = useContext(ConfigContext);
+  const appointmentMatch = useMatch('afspraak-maken/*');
+
   const {
-    form: {translationEnabled},
+    form: {translationEnabled, appointmentEnabled},
     noDebug = false,
   } = props;
 
@@ -65,6 +67,10 @@ const App = ({...props}) => {
 
   const languageSwitcher = translationEnabled ? <LanguageSwitcher /> : null;
   const appDebug = DEBUG && !noDebug ? <AppDebug /> : null;
+
+  if (appointmentEnabled && !appointmentMatch) {
+    return <Navigate replace to="../afspraak-maken" />;
+  }
 
   return (
     <AppDisplayComponent

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -8,6 +8,7 @@ import {Cosign} from 'components/CoSign';
 import Form from 'components/Form';
 import LanguageSelection from 'components/LanguageSelection';
 import {LayoutRow} from 'components/Layout';
+import {CreateAppointment, appointmentRoutes} from 'components/appointments';
 import ManageAppointment from 'components/appointments/ManageAppointment';
 import {I18NContext} from 'i18n';
 import Types from 'types';
@@ -20,6 +21,11 @@ export const getRoutes = (form, noDebug = false) => {
     {
       path: 'afspraak-annuleren',
       element: <ManageAppointment />,
+    },
+    {
+      path: 'afspraak-maken/*',
+      element: <CreateAppointment form={form} />,
+      children: appointmentRoutes,
     },
     {
       path: 'cosign/*',

--- a/src/components/App.stories.js
+++ b/src/components/App.stories.js
@@ -1,16 +1,18 @@
 import {expect} from '@storybook/jest';
 import {waitForElementToBeRemoved, within} from '@storybook/testing-library';
+import {Outlet} from 'react-router-dom';
+import {RouterProvider, createMemoryRouter} from 'react-router-dom';
 
 import {buildForm} from 'api-mocks';
 import {mockLanguageChoicePut, mockLanguageInfoGet} from 'components/LanguageSelection/mocks';
-import {ConfigDecorator, DeprecatedRouterDecorator} from 'story-utils/decorators';
+import {ConfigDecorator} from 'story-utils/decorators';
 
-import App from './App';
+import App, {getRoutes} from './App';
 
 export default {
   title: 'Private API / App',
   component: App,
-  decorators: [ConfigDecorator, DeprecatedRouterDecorator],
+  decorators: [ConfigDecorator],
   args: {
     'form.translationEnabled': true,
   },
@@ -30,12 +32,27 @@ export default {
   },
 };
 
+const Wrapper = ({form}) => {
+  const routes = [
+    {
+      path: '*',
+      element: <App form={form} noDebug />,
+      children: getRoutes(form, true),
+    },
+  ];
+  const router = createMemoryRouter(routes, {
+    initialEntries: ['/'],
+    initialIndex: 0,
+  });
+  return <RouterProvider router={router} />;
+};
+
 const render = args => {
   const form = buildForm({
     translationEnabled: args['form.translationEnabled'],
     explanationTemplate: '<p>Toelichtingssjabloon...</p>',
   });
-  return <App form={form} noDebug />;
+  return <Wrapper form={form} />;
 };
 
 export const Default = {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -289,12 +289,6 @@ const Form = ({form}) => {
     );
   }
 
-  // redirect to the appointment form
-  // use redirect instead of history to replace the location
-  if (form.appointmentEnabled) {
-    return <Navigate replace to="/appointment" />;
-  }
-
   if (loading || shouldAutomaticallyRedirect) {
     return (
       <LayoutColumn>

--- a/src/components/appointments/ChooseProductStep.js
+++ b/src/components/appointments/ChooseProductStep.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 
 import Button from 'components/Button';
-import Card, {CardTitle} from 'components/Card';
+import {CardTitle} from 'components/Card';
 import FAIcon from 'components/FAIcon';
 import {Toolbar, ToolbarList} from 'components/Toolbar';
 import useTitle from 'hooks/useTitle';

--- a/src/components/appointments/LocationSelect.js
+++ b/src/components/appointments/LocationSelect.js
@@ -22,6 +22,7 @@ const LocationSelect = () => {
   const getOptions = useCallback(
     async () => await getLocations(baseUrl, productIds),
     // about JSON.stringify: https://github.com/facebook/react/issues/14476#issuecomment-471199055
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [baseUrl, JSON.stringify(productIds)]
   );
   return (

--- a/src/components/appointments/TimeSelect.js
+++ b/src/components/appointments/TimeSelect.js
@@ -47,6 +47,7 @@ const TimeSelect = () => {
         });
     },
     // about JSON.stringify: https://github.com/facebook/react/issues/14476#issuecomment-471199055
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [baseUrl, calendarLocale, JSON.stringify(values)]
   );
 

--- a/src/components/appointments/index.js
+++ b/src/components/appointments/index.js
@@ -1,0 +1,1 @@
+export {default as CreateAppointment, routes as appointmentRoutes} from './CreateAppointment';

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -9,7 +9,7 @@ import {RouterProvider, createBrowserRouter, createHashRouter} from 'react-route
 
 import {ConfigContext} from 'Context';
 import {get} from 'api';
-import App from 'components/App';
+import App, {getRoutes} from 'components/App';
 import {AddFetchAuth} from 'formio/plugins';
 import {CSPNonce} from 'headers';
 import {I18NErrorBoundary, I18NManager} from 'i18n';
@@ -114,6 +114,7 @@ class OpenForm {
         {
           path: '*',
           element: <App form={this.formObject} />,
+          children: getRoutes(this.formObject),
         },
       ],
       {basename: this.basePath}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2461,7 +2461,7 @@
   resolved "https://registry.yarnpkg.com/@nl-design-system-unstable/amsterdam-design-tokens/-/amsterdam-design-tokens-1.0.0-alpha.107.tgz#5b0dbff57fb9b1611dd394c2cb3e48b8d7587137"
   integrity sha512-YTixMpGLuS9gluB73OSsFfPaiDapQI0frjgxpWtqsSpeslnwkzPhYzbEppY81nkIXrwIpScioz1/CDwBjmh9Gw==
 
-"@nl-design-system-unstable/rotterdam-design-tokens@^1.0.0-alpha.100":
+"@nl-design-system-unstable/rotterdam-design-tokens@1.0.0-alpha.100":
   version "1.0.0-alpha.100"
   resolved "https://registry.yarnpkg.com/@nl-design-system-unstable/rotterdam-design-tokens/-/rotterdam-design-tokens-1.0.0-alpha.100.tgz#db1b00b7abd50c32cbc3385c87bebac7382f1dcb"
   integrity sha512-ciaFKCMD2SBZBnxq2YS5PUSJssQRIvWyosbupxlXDHsWBNR0JotnD5J1KnXnMTQuqTi79c5YJxgKTy8EBQSw4g==


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#3067

This wires up the appointment create form into the main app. For that, I broke up the main router into a native javascript array instead of JSX, which is the recommended way now in React Router - see the individual commits.

**Note** the product list API endpoint gives HTTP 403 errors if you don't have any form session/submission - that will be tackled in a separate PR.

In the future, this would be a good candidate for bundle splitting.