### PR TITLE
Ensure submission exists

### DIFF
--- a/.storybook/decorators.js
+++ b/.storybook/decorators.js
@@ -1,0 +1,12 @@
+import {SESSION_STORAGE_KEY} from 'hooks/useGetOrCreateSubmission';
+
+/**
+ * Storybook does not have a before/after cleanup cycle, and localStorage would in
+ * these situations break story/test isolation.
+ *
+ * This decorator is applied to every story to reset the storage state.
+ */
+export const withClearSessionStorage = Story => {
+  window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
+  return <Story />;
+};

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -17,6 +17,7 @@ import 'styles.scss';
 import OpenFormsModule from 'formio/module';
 import OFLibrary from 'formio/templates';
 
+import {withClearSessionStorage} from './decorators';
 import {reactIntl} from './reactIntl.js';
 
 initialize({
@@ -32,7 +33,7 @@ Formio.use(OpenFormsModule);
 Templates.current = OFLibrary;
 
 export default {
-  decorators: [mswDecorator],
+  decorators: [mswDecorator, withClearSessionStorage],
   globals: {
     locale: reactIntl.defaultLocale,
     locales: {

--- a/src/api-mocks/submissions.js
+++ b/src/api-mocks/submissions.js
@@ -1,3 +1,5 @@
+import {rest} from 'msw';
+
 import {BASE_URL, getDefaultFactory} from './base';
 
 // FIXME - this is incomplete, the prop types aren't detailed enough.
@@ -28,3 +30,8 @@ const SUBMISSION_DETAILS = {
  * @return {Object}           A submission object.
  */
 export const buildSubmission = getDefaultFactory(SUBMISSION_DETAILS);
+
+export const mockSubmissionPost = (submission = buildSubmission()) =>
+  rest.post(`${BASE_URL}submissions`, (req, res, ctx) => {
+    return res(ctx.status(201), ctx.json(submission));
+  });

--- a/src/components/appointments/CreateAppointment.js
+++ b/src/components/appointments/CreateAppointment.js
@@ -9,7 +9,9 @@ import {ConfigContext} from 'Context';
 import Card from 'components/Card';
 import ErrorBoundary from 'components/ErrorBoundary';
 import FormDisplay from 'components/FormDisplay';
+import Loader from 'components/Loader';
 import ProgressIndicatorDisplay from 'components/ProgressIndicator/ProgressIndicatorDisplay';
+import useGetOrCreateSubmission from 'hooks/useGetOrCreateSubmission';
 import Types from 'types';
 
 import ChooseProductStep from './ChooseProductStep';
@@ -150,6 +152,9 @@ const CreateAppointment = ({form}) => {
     phoneNumber: '',
   });
 
+  const {isLoading, error, submission, removeSubmissionFromStorage} = useGetOrCreateSubmission();
+  if (error) throw error;
+
   const currentStep =
     APPOINTMENT_STEP_PATHS.find(step => checkMatchesPath(currentPathname, step)) ||
     APPOINTMENT_STEP_PATHS[0];
@@ -171,8 +176,8 @@ const CreateAppointment = ({form}) => {
             case APPOINTMENT_STEP_PATHS.at(-1): {
               console.log(values);
               // TODO: post to API endpoint, handle validation errors
-              // TODO: clear session storage key
               window.sessionStorage.clearItem(storageKey);
+              removeSubmissionFromStorage();
               setSubmitting(false);
               break;
             }
@@ -196,7 +201,7 @@ const CreateAppointment = ({form}) => {
             router={
               <Card title={form.name} titleComponent="h1" modifiers={['mobile-header-hidden']}>
                 <ErrorBoundary>
-                  <Outlet />
+                  {isLoading ? <Loader modifiers={['centered']} /> : <Outlet />}
                 </ErrorBoundary>
               </Card>
             }

--- a/src/components/appointments/CreateAppointment.js
+++ b/src/components/appointments/CreateAppointment.js
@@ -152,7 +152,7 @@ const CreateAppointment = ({form}) => {
     phoneNumber: '',
   });
 
-  const {isLoading, error, submission, removeSubmissionFromStorage} = useGetOrCreateSubmission();
+  const {isLoading, error, removeSubmissionFromStorage} = useGetOrCreateSubmission(form);
   if (error) throw error;
 
   const currentStep =

--- a/src/components/appointments/CreateAppointment.stories.js
+++ b/src/components/appointments/CreateAppointment.stories.js
@@ -5,7 +5,6 @@ import {RouterProvider, createMemoryRouter} from 'react-router-dom';
 
 import {buildForm} from 'api-mocks';
 import {mockSubmissionPost} from 'api-mocks/submissions';
-import {SESSION_STORAGE_KEY} from 'hooks/useGetOrCreateSubmission';
 import {ConfigDecorator, LayoutDecorator} from 'story-utils/decorators';
 
 import CreateAppointment, {routes as childRoutes} from './CreateAppointment';
@@ -17,15 +16,10 @@ import {
   mockAppointmentTimesGet,
 } from './mocks';
 
-const withClearSessionStorage = Story => {
-  window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
-  return <Story />;
-};
-
 export default {
   title: 'Private API / Appointments / CreateForm',
   component: CreateAppointment,
-  decorators: [withClearSessionStorage, ConfigDecorator, LayoutDecorator],
+  decorators: [ConfigDecorator, LayoutDecorator],
   parameters: {
     msw: {
       handlers: [

--- a/src/components/appointments/CreateAppointment.stories.js
+++ b/src/components/appointments/CreateAppointment.stories.js
@@ -5,6 +5,7 @@ import {RouterProvider, createMemoryRouter} from 'react-router-dom';
 
 import {buildForm} from 'api-mocks';
 import {mockSubmissionPost} from 'api-mocks/submissions';
+import {SESSION_STORAGE_KEY} from 'hooks/useGetOrCreateSubmission';
 import {ConfigDecorator, LayoutDecorator} from 'story-utils/decorators';
 
 import CreateAppointment, {routes as childRoutes} from './CreateAppointment';
@@ -16,10 +17,15 @@ import {
   mockAppointmentTimesGet,
 } from './mocks';
 
+const withClearSessionStorage = Story => {
+  window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
+  return <Story />;
+};
+
 export default {
   title: 'Private API / Appointments / CreateForm',
   component: CreateAppointment,
-  decorators: [ConfigDecorator, LayoutDecorator],
+  decorators: [withClearSessionStorage, ConfigDecorator, LayoutDecorator],
   parameters: {
     msw: {
       handlers: [

--- a/src/components/appointments/CreateAppointment.stories.js
+++ b/src/components/appointments/CreateAppointment.stories.js
@@ -4,6 +4,7 @@ import {addDays, formatISO} from 'date-fns';
 import {RouterProvider, createMemoryRouter} from 'react-router-dom';
 
 import {buildForm} from 'api-mocks';
+import {mockSubmissionPost} from 'api-mocks/submissions';
 import {ConfigDecorator, LayoutDecorator} from 'story-utils/decorators';
 
 import CreateAppointment, {routes as childRoutes} from './CreateAppointment';
@@ -22,6 +23,7 @@ export default {
   parameters: {
     msw: {
       handlers: [
+        mockSubmissionPost(),
         mockAppointmentProductsGet,
         mockAppointmentLocationsGet,
         mockAppointmentDatesGet,

--- a/src/data/submissions.js
+++ b/src/data/submissions.js
@@ -1,0 +1,16 @@
+import {post} from 'api';
+
+/**
+ * Create a submission instance from a given form instance
+ * @param  {String} baseUrl The Open Forms backend baseUrl of the API (e.g. https://example.com/api/v2/)
+ * @param  {Object} form   The relevant Open Forms form instance.
+ * @return {Object}        The Submission instance.
+ */
+export const createSubmission = async (baseUrl, form) => {
+  const createData = {
+    form: form.url,
+    formUrl: window.location.toString(),
+  };
+  const submissionResponse = await post(`${baseUrl}submissions`, createData);
+  return submissionResponse.data;
+};

--- a/src/hooks/useGetOrCreateSubmission.js
+++ b/src/hooks/useGetOrCreateSubmission.js
@@ -1,20 +1,20 @@
+import {createSubmission} from 'data/submissions';
 import {useContext} from 'react';
 import {useAsync, useSessionStorage} from 'react-use';
 
 import {ConfigContext} from 'Context';
-import {post} from 'api';
 
-const SESSION_STORAGE_KEY = 'appointment|submission';
+export const SESSION_STORAGE_KEY = 'appointment|submission';
 
-const useGetOrCreateSubmission = () => {
+const useGetOrCreateSubmission = form => {
   const {baseUrl} = useContext(ConfigContext);
   const [submission, setSubmission] = useSessionStorage(SESSION_STORAGE_KEY, null);
 
   const {loading, error} = useAsync(async () => {
     if (submission !== null) return;
-    const response = await post(`${baseUrl}submissions`);
+    const response = await createSubmission(baseUrl, form);
     setSubmission(response.data);
-  }, [baseUrl, submission]);
+  }, [baseUrl, form, submission]);
 
   return {
     isLoading: loading,

--- a/src/hooks/useGetOrCreateSubmission.js
+++ b/src/hooks/useGetOrCreateSubmission.js
@@ -1,0 +1,27 @@
+import {useContext} from 'react';
+import {useAsync, useSessionStorage} from 'react-use';
+
+import {ConfigContext} from 'Context';
+import {post} from 'api';
+
+const SESSION_STORAGE_KEY = 'appointment|submission';
+
+const useGetOrCreateSubmission = () => {
+  const {baseUrl} = useContext(ConfigContext);
+  const [submission, setSubmission] = useSessionStorage(SESSION_STORAGE_KEY, null);
+
+  const {loading, error} = useAsync(async () => {
+    if (submission !== null) return;
+    const response = await post(`${baseUrl}submissions`);
+    setSubmission(response.data);
+  }, [baseUrl, submission]);
+
+  return {
+    isLoading: loading,
+    error,
+    submission,
+    removeSubmissionFromStorage: () => window.sessionStorage.removeItem(SESSION_STORAGE_KEY),
+  };
+};
+
+export default useGetOrCreateSubmission;


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#3067

This hook ensures that a submission is created in the backend (and when done so, stores it in the browser session storage).

This is required for the backend permission checks, which require having a valid submission in the session.

The loader UI is displayed when the submission is being created, which prevents any other components from retrieving data from
the backend until a submission is available.