### PR TITLE
:sparkles: [#2175] added configureable zoom and start location

### DIFF
--- a/src/components/Map/Map.stories.js
+++ b/src/components/Map/Map.stories.js
@@ -12,6 +12,8 @@ export default {
   decorators: [withMapLayout],
   args: {
     markerCoordinates: [52.1326332, 5.291266],
+    defaultCenter: [52.1326332, 5.291266],
+    defaultZoomLevel: 12,
     disabled: true, // TODO: ideally this would be false but firefox has an infinite loop with onMarkerSet.
   },
   parameters: {
@@ -19,4 +21,12 @@ export default {
   },
 };
 
-export const Map = {};
+export const Map = {
+  args: {
+    component: {
+      lat: 52.1326332,
+      lng: 5.291266,
+      defaultZoom: 12,
+    },
+  },
+};

--- a/src/components/Map/Map.stories.js
+++ b/src/components/Map/Map.stories.js
@@ -21,12 +21,4 @@ export default {
   },
 };
 
-export const Map = {
-  args: {
-    component: {
-      lat: 52.1326332,
-      lng: 5.291266,
-      defaultZoom: 12,
-    },
-  },
-};
+export const Map = {};

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -4,7 +4,7 @@ import React, {useEffect} from 'react';
 import {MapContainer, Marker, TileLayer, useMap, useMapEvent} from 'react-leaflet';
 import {useGeolocation} from 'react-use';
 
-import {DEFAULT_LAT_LON, DEFAULT_ZOOM, MAP_DEFAULTS, TILE_LAYERS} from 'map/constants';
+import {DEFAULT_LAT_LNG, DEFAULT_ZOOM, MAP_DEFAULTS, TILE_LAYERS} from 'map/constants';
 import {getBEMClassName} from 'utils';
 
 const useDefaultCoordinates = () => {
@@ -27,8 +27,8 @@ const useDefaultCoordinates = () => {
 const LeaftletMap = ({
   markerCoordinates,
   onMarkerSet,
-  defaultCenter = DEFAULT_LAT_LON,
-  defaultZoomLevel = MAP_DEFAULTS.zoom,
+  defaultCenter = DEFAULT_LAT_LNG,
+  defaultZoomLevel = DEFAULT_ZOOM,
   disabled = false,
 }) => {
   const defaultCoordinates = useDefaultCoordinates();
@@ -45,7 +45,7 @@ const LeaftletMap = ({
 
   return (
     <MapContainer
-      center={MAP_DEFAULTS.center}
+      center={defaultCenter}
       zoom={defaultZoomLevel}
       continuousWorld
       crs={MAP_DEFAULTS.crs}
@@ -55,7 +55,7 @@ const LeaftletMap = ({
       <TileLayer url={TILE_LAYERS.url} {...TILE_LAYERS.options} />
       {coordinates ? (
         <>
-          <MapView coordinates={defaultCenter} zoomLevel={defaultZoomLevel} />
+          <MapView coordinates={coordinates} />
           <MarkerWrapper position={coordinates} onMarkerSet={onWrapperMarkerSet} />
         </>
       ) : null}

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -17,14 +17,20 @@ const useDefaultCoordinates = () => {
   // GeolocationPositionError:
   // https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError
   if (error) {
-    return DEFAULT_LAT_LON;
+    return null;
   }
-  if (!navigator.geolocation) return DEFAULT_LAT_LON;
+  if (!navigator.geolocation) return null;
   if (loading) return null;
   return [latitude, longitude];
 };
 
-const LeaftletMap = ({markerCoordinates, onMarkerSet, zoomLevel, disabled = false}) => {
+const LeaftletMap = ({
+  markerCoordinates,
+  onMarkerSet,
+  defaultCenter = DEFAULT_LAT_LON,
+  defaultZoomLevel = MAP_DEFAULTS.zoom,
+  disabled = false,
+}) => {
   const defaultCoordinates = useDefaultCoordinates();
   const coordinates = markerCoordinates || defaultCoordinates;
 
@@ -40,7 +46,7 @@ const LeaftletMap = ({markerCoordinates, onMarkerSet, zoomLevel, disabled = fals
   return (
     <MapContainer
       center={MAP_DEFAULTS.center}
-      zoom={zoomLevel}
+      zoom={defaultZoomLevel}
       continuousWorld
       crs={MAP_DEFAULTS.crs}
       attributionControl
@@ -49,7 +55,7 @@ const LeaftletMap = ({markerCoordinates, onMarkerSet, zoomLevel, disabled = fals
       <TileLayer url={TILE_LAYERS.url} {...TILE_LAYERS.options} />
       {coordinates ? (
         <>
-          <MapView coordinates={coordinates} zoomLevel={zoomLevel} />
+          <MapView coordinates={defaultCenter} zoomLevel={defaultZoomLevel} />
           <MarkerWrapper position={coordinates} onMarkerSet={onWrapperMarkerSet} />
         </>
       ) : null}

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -24,7 +24,7 @@ const useDefaultCoordinates = () => {
   return [latitude, longitude];
 };
 
-const LeaftletMap = ({markerCoordinates, onMarkerSet, disabled = false}) => {
+const LeaftletMap = ({markerCoordinates, onMarkerSet, zoomLevel, disabled = false}) => {
   const defaultCoordinates = useDefaultCoordinates();
   const coordinates = markerCoordinates || defaultCoordinates;
 
@@ -40,7 +40,7 @@ const LeaftletMap = ({markerCoordinates, onMarkerSet, disabled = false}) => {
   return (
     <MapContainer
       center={MAP_DEFAULTS.center}
-      zoom={MAP_DEFAULTS.zoom}
+      zoom={zoomLevel}
       continuousWorld
       crs={MAP_DEFAULTS.crs}
       attributionControl
@@ -49,7 +49,7 @@ const LeaftletMap = ({markerCoordinates, onMarkerSet, disabled = false}) => {
       <TileLayer url={TILE_LAYERS.url} {...TILE_LAYERS.options} />
       {coordinates ? (
         <>
-          <MapView coordinates={coordinates} />
+          <MapView coordinates={coordinates} zoomLevel={zoomLevel} />
           <MarkerWrapper position={coordinates} onMarkerSet={onWrapperMarkerSet} />
         </>
       ) : null}

--- a/src/formio/components/Map.js
+++ b/src/formio/components/Map.js
@@ -6,6 +6,7 @@ import {createRoot} from 'react-dom/client';
 import {Formio} from 'react-formio';
 
 import LeafletMap from 'components/Map';
+import {DEFAULT_LAT_LON, MAP_DEFAULTS} from 'map/constants';
 
 const Field = Formio.Components.components.field;
 
@@ -90,16 +91,26 @@ export default class Map extends Field {
     this.setValue(newLatLng, {modified: true});
   }
 
+  setAndReturnCoordinates(coordinates) {
+    this.onMarkerSet(coordinates);
+    return coordinates;
+  }
+
   renderReact() {
-    const markerCoordinates = this.getValue();
+    const startingPop = [this.component.lat, this.component.lng] || DEFAULT_LAT_LON;
+    const markerCoordinates =
+      this.getValue().length === 2 ? this.getValue() : this.setAndReturnCoordinates(startingPop);
+
     const container = this.refs.mapContainer;
+    const zoom = Number(this.component.defaultZoom);
     // no container node ready (yet), defer to next render cycle
     if (!container) return;
 
     this.reactRoot.render(
       <LeafletMap
-        markerCoordinates={markerCoordinates || null}
+        markerCoordinates={markerCoordinates}
         onMarkerSet={this.onMarkerSet.bind(this)}
+        zoomLevel={zoom || MAP_DEFAULTS.zoom}
       />
     );
   }

--- a/src/formio/components/Map.js
+++ b/src/formio/components/Map.js
@@ -91,15 +91,12 @@ export default class Map extends Field {
     this.setValue(newLatLng, {modified: true});
   }
 
-  setAndReturnCoordinates(coordinates) {
-    this.onMarkerSet(coordinates);
-    return coordinates;
-  }
-
   renderReact() {
-    const startingPop = [this.component.lat, this.component.lng] || DEFAULT_LAT_LON;
-    const markerCoordinates =
-      this.getValue().length === 2 ? this.getValue() : this.setAndReturnCoordinates(startingPop);
+    const defaultCenter =
+      this.component.initialCenter.lat && this.component.initialCenter.lng
+        ? [this.component.initialCenter.lat, this.component.initialCenter.lng]
+        : DEFAULT_LAT_LON;
+    const markerCoordinates = this.getValue();
 
     const container = this.refs.mapContainer;
     const zoom = Number(this.component.defaultZoom);
@@ -108,8 +105,9 @@ export default class Map extends Field {
 
     this.reactRoot.render(
       <LeafletMap
-        markerCoordinates={markerCoordinates}
+        markerCoordinates={markerCoordinates || null}
         onMarkerSet={this.onMarkerSet.bind(this)}
+        defaultCenter={defaultCenter}
         zoomLevel={zoom || MAP_DEFAULTS.zoom}
       />
     );

--- a/src/formio/components/Map.js
+++ b/src/formio/components/Map.js
@@ -6,7 +6,7 @@ import {createRoot} from 'react-dom/client';
 import {Formio} from 'react-formio';
 
 import LeafletMap from 'components/Map';
-import {DEFAULT_LAT_LON, MAP_DEFAULTS} from 'map/constants';
+import {DEFAULT_LAT_LNG, MAP_DEFAULTS} from 'map/constants';
 
 const Field = Formio.Components.components.field;
 
@@ -92,14 +92,14 @@ export default class Map extends Field {
   }
 
   renderReact() {
-    const defaultCenter =
-      this.component.initialCenter.lat && this.component.initialCenter.lng
-        ? [this.component.initialCenter.lat, this.component.initialCenter.lng]
-        : DEFAULT_LAT_LON;
+    const [defaultLat, defaultLon] = DEFAULT_LAT_LNG;
+    const {lat = defaultLat, lng = defaultLon} = this.component?.initialCenter || {};
+    const defaultCenter = [lat, lng];
+
     const markerCoordinates = this.getValue();
 
     const container = this.refs.mapContainer;
-    const zoom = Number(this.component.defaultZoom);
+    const zoom = this.component.defaultZoom;
     // no container node ready (yet), defer to next render cycle
     if (!container) return;
 
@@ -108,7 +108,7 @@ export default class Map extends Field {
         markerCoordinates={markerCoordinates || null}
         onMarkerSet={this.onMarkerSet.bind(this)}
         defaultCenter={defaultCenter}
-        zoomLevel={zoom || MAP_DEFAULTS.zoom}
+        defaultZoomLevel={zoom || MAP_DEFAULTS.zoom}
       />
     );
   }

--- a/src/map/constants.js
+++ b/src/map/constants.js
@@ -18,15 +18,15 @@ const TILE_LAYERS = {
 };
 
 // Roughly the center of the Netherlands
-const DEFAULT_LAT_LON = [52.1326332, 5.291266];
+const DEFAULT_LAT_LNG = [52.1326332, 5.291266];
 const DEFAULT_ZOOM = 13;
 
 const MAP_DEFAULTS = {
   continuousWorld: true,
   crs: RD_CRS,
   attributionControl: true,
-  center: DEFAULT_LAT_LON,
+  center: DEFAULT_LAT_LNG,
   zoom: DEFAULT_ZOOM,
 };
 
-export {TILES, ATTRIBUTION, TILE_LAYERS, DEFAULT_LAT_LON, DEFAULT_ZOOM, MAP_DEFAULTS};
+export {TILES, ATTRIBUTION, TILE_LAYERS, DEFAULT_LAT_LNG, DEFAULT_ZOOM, MAP_DEFAULTS};


### PR DESCRIPTION
Fixes open-formulieren/open-forms#2175

- retrieved default zoom and location from configuration
- set starting location as configured latitude and longitude 
- set starting zoomlevel to be either map default or the configured zoomlevel