### PR TITLE
Refactor form 'prop' and (nested) routes

### DIFF
--- a/src/Context.js
+++ b/src/Context.js
@@ -1,5 +1,25 @@
 import React from 'react';
 
+const FormContext = React.createContext({
+  uuid: '',
+  name: '',
+  slug: '',
+  url: '',
+  loginRequired: false,
+  loginOptions: [],
+  maintenanceMode: false,
+  showProgressIndicator: true,
+  submissionAllowed: 'yes',
+  literals: {
+    beginText: {value: '', resolved: 'Begin'},
+    changeText: {value: '', resolved: 'Change'},
+    confirmText: {value: '', resolved: 'Confirm'},
+    previousText: {value: '', resolved: 'Previous'},
+  },
+  steps: [],
+});
+FormContext.displayName = 'FormContext';
+
 const ConfigContext = React.createContext({
   baseUrl: '',
   basePath: '',
@@ -20,4 +40,4 @@ FormioTranslations.displayName = 'FormioTranslations';
 const SubmissionContext = React.createContext({submission: null});
 SubmissionContext.displayName = 'SubmissionContext';
 
-export {ConfigContext, FormioTranslations, SubmissionContext};
+export {FormContext, ConfigContext, FormioTranslations, SubmissionContext};

--- a/src/api-mocks/submissions.js
+++ b/src/api-mocks/submissions.js
@@ -35,3 +35,23 @@ export const mockSubmissionPost = (submission = buildSubmission()) =>
   rest.post(`${BASE_URL}submissions`, (req, res, ctx) => {
     return res(ctx.status(201), ctx.json(submission));
   });
+
+/**
+ * Simulate a succesful backend processing status without payment.
+ */
+export const mockSubmissionProcessingStatusGet = rest.get(
+  `${BASE_URL}submissions/:uuid/:token/status`,
+  (req, res, ctx) =>
+    res(
+      ctx.json({
+        status: 'done',
+        result: 'success',
+        errorMessage: '',
+        publicReference: 'OF-L337',
+        confirmationPageContent: `<p>Thank you for doing <span style="font-style: italic;">the thing</span>.`,
+        reportDownloadUrl: '#',
+        paymentUrl: '',
+        mainWebsiteUrl: '#',
+      })
+    )
+);

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 import ReactDOM from 'react-dom';
 import {Navigate, Outlet, useMatch} from 'react-router-dom';
@@ -10,35 +11,32 @@ import LanguageSelection from 'components/LanguageSelection';
 import {LayoutRow} from 'components/Layout';
 import {CreateAppointment, appointmentRoutes} from 'components/appointments';
 import ManageAppointment from 'components/appointments/ManageAppointment';
+import useFormContext from 'hooks/useFormContext';
 import {I18NContext} from 'i18n';
-import Types from 'types';
 import {DEBUG} from 'utils';
 
 import AppDisplay from './AppDisplay';
 
-export const getRoutes = (form, noDebug = false) => {
-  const routes = [
-    {
-      path: 'afspraak-annuleren',
-      element: <ManageAppointment />,
-    },
-    {
-      path: 'afspraak-maken/*',
-      element: <CreateAppointment form={form} />,
-      children: appointmentRoutes,
-    },
-    {
-      path: 'cosign/*',
-      element: <Cosign form={form} noDebug={noDebug} />,
-    },
-    // All the rest goes to the formio-based form flow
-    {
-      path: '*',
-      element: <Form form={form} noDebug={noDebug} />,
-    },
-  ];
-  return routes;
-};
+export const routes = [
+  {
+    path: 'afspraak-annuleren',
+    element: <ManageAppointment />,
+  },
+  {
+    path: 'afspraak-maken/*',
+    element: <CreateAppointment />,
+    children: appointmentRoutes,
+  },
+  {
+    path: 'cosign/*',
+    element: <Cosign />,
+  },
+  // All the rest goes to the formio-based form flow
+  {
+    path: '*',
+    element: <Form />,
+  },
+];
 
 const LanguageSwitcher = () => {
   const {languageSelectorTarget: target} = useContext(I18NContext);
@@ -54,23 +52,18 @@ const LanguageSwitcher = () => {
 /*
 Top level router - routing between an actual form or supporting screens.
  */
-const App = ({...props}) => {
+const App = ({noDebug = false}) => {
+  const form = useFormContext();
   const config = useContext(ConfigContext);
   const appointmentMatch = useMatch('afspraak-maken/*');
 
-  const {
-    form: {
-      translationEnabled,
-      appointmentOptions: {isAppointment},
-    },
-    noDebug = false,
-  } = props;
-
   const AppDisplayComponent = config?.displayComponents?.app ?? AppDisplay;
 
+  const {translationEnabled} = form;
   const languageSwitcher = translationEnabled ? <LanguageSwitcher /> : null;
   const appDebug = DEBUG && !noDebug ? <AppDebug /> : null;
 
+  const isAppointment = form.appointmentOptions?.isAppointment ?? false;
   if (isAppointment && !appointmentMatch) {
     return <Navigate replace to="../afspraak-maken" />;
   }
@@ -85,7 +78,7 @@ const App = ({...props}) => {
 };
 
 App.propTypes = {
-  form: Types.Form,
+  noDebug: PropTypes.bool,
 };
 
 export default App;

--- a/src/components/App.stories.js
+++ b/src/components/App.stories.js
@@ -1,13 +1,13 @@
 import {expect} from '@storybook/jest';
 import {waitForElementToBeRemoved, within} from '@storybook/testing-library';
-import {Outlet} from 'react-router-dom';
 import {RouterProvider, createMemoryRouter} from 'react-router-dom';
 
+import {FormContext} from 'Context';
 import {buildForm} from 'api-mocks';
 import {mockLanguageChoicePut, mockLanguageInfoGet} from 'components/LanguageSelection/mocks';
 import {ConfigDecorator} from 'story-utils/decorators';
 
-import App, {getRoutes} from './App';
+import App, {routes as nestedRoutes} from './App';
 
 export default {
   title: 'Private API / App',
@@ -18,6 +18,7 @@ export default {
   },
   argTypes: {
     form: {table: {disable: true}},
+    noDebug: {table: {disable: true}},
   },
   parameters: {
     msw: {
@@ -36,15 +37,19 @@ const Wrapper = ({form}) => {
   const routes = [
     {
       path: '*',
-      element: <App form={form} noDebug />,
-      children: getRoutes(form, true),
+      element: <App noDebug />,
+      children: nestedRoutes,
     },
   ];
   const router = createMemoryRouter(routes, {
     initialEntries: ['/'],
     initialIndex: 0,
   });
-  return <RouterProvider router={router} />;
+  return (
+    <FormContext.Provider value={form}>
+      <RouterProvider router={router} />
+    </FormContext.Provider>
+  );
 };
 
 const render = args => {

--- a/src/components/CoSign/Cosign.js
+++ b/src/components/CoSign/Cosign.js
@@ -6,6 +6,7 @@ import {ConfigContext} from 'Context';
 import {destroy} from 'api';
 import ErrorBoundary from 'components/ErrorBoundary';
 import {CosignSummary} from 'components/Summary';
+import useFormContext from 'hooks/useFormContext';
 
 import CosignDone from './CosignDone';
 
@@ -48,7 +49,8 @@ const reducer = (draft, action) => {
   }
 };
 
-const Cosign = ({...props}) => {
+const Cosign = () => {
+  const form = useFormContext();
   const [state, dispatch] = useImmerReducer(reducer, initialState);
   const navigate = useNavigate();
   const config = useContext(ConfigContext);
@@ -79,6 +81,7 @@ const Cosign = ({...props}) => {
           path="check"
           element={
             <CosignSummary
+              form={form}
               submission={state.submission}
               summaryData={state.summaryData}
               privacyInfo={state.privacyInfo}
@@ -92,7 +95,6 @@ const Cosign = ({...props}) => {
               onCosignComplete={onCosignComplete}
               onDestroySession={onDestroySession}
               onPrivacyCheckboxChange={() => dispatch({type: 'TOGGLE_PRIVACY_CHECKBOX'})}
-              {...props}
             />
           }
         />

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -22,11 +22,11 @@ import {START_FORM_QUERY_PARAM} from 'components/constants';
 import {findNextApplicableStep} from 'components/utils';
 import {createSubmission, flagActiveSubmission, flagNoActiveSubmission} from 'data/submissions';
 import useAutomaticRedirect from 'hooks/useAutomaticRedirect';
+import useFormContext from 'hooks/useFormContext';
 import usePageViews from 'hooks/usePageViews';
 import useQuery from 'hooks/useQuery';
 import useRecycleSubmission from 'hooks/useRecycleSubmission';
 import useSessionTimeout from 'hooks/useSessionTimeout';
-import Types from 'types';
 
 const initialState = {
   submission: null,
@@ -90,7 +90,8 @@ const reducer = (draft, action) => {
  * @param  {Object} options.form The form definition from the Open Forms API
  * @return {JSX}
  */
-const Form = ({form}) => {
+const Form = () => {
+  const form = useFormContext();
   const navigate = useNavigate();
   const shouldAutomaticallyRedirect = useAutomaticRedirect(form);
   const queryParams = useQuery();
@@ -377,8 +378,6 @@ const Form = ({form}) => {
   );
 };
 
-Form.propTypes = {
-  form: Types.Form.isRequired,
-};
+Form.propTypes = {};
 
 export default Form;

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -323,7 +323,7 @@ const Form = ({form}) => {
               onFailure={onProcessingFailure}
               onConfirmed={() => dispatch({type: 'PROCESSING_SUCCEEDED'})}
               component={SubmissionConfirmation}
-              form={form}
+              donwloadPDFText={form.submissionReportDownloadLinkTitle}
             />
           </ErrorBoundary>
         }

--- a/src/components/SubmissionConfirmation.js
+++ b/src/components/SubmissionConfirmation.js
@@ -100,6 +100,9 @@ const SubmissionConfirmation = ({statusUrl, onFailure, onConfirmed, form}) => {
     }
   });
 
+  // FIXME: https://github.com/open-formulieren/open-forms/issues/3255
+  // errors (bad gateway 502, for example) appear to result in infinite loading
+  // spinners
   if (error) {
     console.error(error);
   }

--- a/src/components/SubmissionConfirmation.js
+++ b/src/components/SubmissionConfirmation.js
@@ -15,7 +15,6 @@ import PaymentForm from 'components/PaymentForm';
 import {Toolbar, ToolbarList} from 'components/Toolbar';
 import usePoll from 'hooks/usePoll';
 import useTitle from 'hooks/useTitle';
-import Types from 'types';
 
 const RESULT_FAILED = 'failed';
 const RESULT_SUCCESS = 'success';
@@ -68,7 +67,7 @@ StartPayment.propTypes = {
  * @param {Function} onFailure Callback to invoke if the background processing result is failure.
  * @param {Function} onConfirmed Callback to invoke if the background processing result is success.
  */
-const SubmissionConfirmation = ({statusUrl, onFailure, onConfirmed, form}) => {
+const SubmissionConfirmation = ({statusUrl, onFailure, onConfirmed, donwloadPDFText}) => {
   const intl = useIntl();
   const pageTitle = intl.formatMessage({
     description: 'Confirmation page title',
@@ -145,7 +144,7 @@ const SubmissionConfirmation = ({statusUrl, onFailure, onConfirmed, form}) => {
   const showBackToMainWebsite = mainWebsiteUrl && !paymentUrl;
 
   // Fall back to the literal message in code for backwards compatibility.
-  const linkTitle = form.submissionReportDownloadLinkTitle || (
+  const linkTitle = donwloadPDFText || (
     <FormattedMessage description="Download report PDF link title" defaultMessage="Download PDF" />
   );
 
@@ -198,7 +197,7 @@ SubmissionConfirmation.propTypes = {
   statusUrl: PropTypes.string.isRequired,
   onFailure: PropTypes.func,
   onConfirmed: PropTypes.func,
-  form: Types.Form.isRequired,
+  donwloadPDFText: PropTypes.node,
 };
 
 export default SubmissionConfirmation;

--- a/src/components/SubmissionConfirmation.stories.js
+++ b/src/components/SubmissionConfirmation.stories.js
@@ -1,3 +1,6 @@
+import {expect} from '@storybook/jest';
+import {waitFor, within} from '@storybook/testing-library';
+
 import {BASE_URL} from 'api-mocks';
 import {buildForm} from 'api-mocks';
 import {mockSubmissionProcessingStatusGet} from 'api-mocks/submissions';
@@ -11,11 +14,10 @@ export default {
   decorators: [LayoutDecorator, withCard],
   args: {
     statusUrl: `${BASE_URL}submissions/4b0e86a8-dc5f-41cc-b812-c89857b9355b/-token-/status`,
-    form: buildForm({submissionReportDownloadLinkTitle: 'Download your details as PDF'}),
+    donwloadPDFText: 'Download your details as PDF',
   },
   argTypes: {
     statusUrl: {control: false},
-    form: {control: false},
   },
   parameters: {
     msw: {
@@ -24,4 +26,20 @@ export default {
   },
 };
 
-export const Success = {};
+export const Success = {
+  play: async ({canvasElement, args}) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(
+      async () => {
+        expect(canvas.getByRole('button', {name: 'Terug naar de website'})).toBeVisible();
+      },
+      {
+        timeout: 2000,
+        interval: 100,
+      }
+    );
+    expect(canvas.getByText(/OF-L337/)).toBeVisible();
+    expect(args.onConfirmed).toBeCalledTimes(1);
+  },
+};

--- a/src/components/SubmissionConfirmation.stories.js
+++ b/src/components/SubmissionConfirmation.stories.js
@@ -1,0 +1,27 @@
+import {BASE_URL} from 'api-mocks';
+import {buildForm} from 'api-mocks';
+import {mockSubmissionProcessingStatusGet} from 'api-mocks/submissions';
+import {LayoutDecorator, withCard} from 'story-utils/decorators';
+
+import SubmissionConfirmation from './SubmissionConfirmation';
+
+export default {
+  title: 'Private API / SubmissionConfirmation',
+  component: SubmissionConfirmation,
+  decorators: [LayoutDecorator, withCard],
+  args: {
+    statusUrl: `${BASE_URL}submissions/4b0e86a8-dc5f-41cc-b812-c89857b9355b/-token-/status`,
+    form: buildForm({submissionReportDownloadLinkTitle: 'Download your details as PDF'}),
+  },
+  argTypes: {
+    statusUrl: {control: false},
+    form: {control: false},
+  },
+  parameters: {
+    msw: {
+      handlers: [mockSubmissionProcessingStatusGet],
+    },
+  },
+};
+
+export const Success = {};

--- a/src/components/appointments/CreateAppointment/CreateAppointment.js
+++ b/src/components/appointments/CreateAppointment/CreateAppointment.js
@@ -9,9 +9,9 @@ import {LiteralsProvider} from 'components/Literal';
 import Loader from 'components/Loader';
 import {RequireSession} from 'components/Sessions';
 import {flagNoActiveSubmission} from 'data/submissions';
+import useFormContext from 'hooks/useFormContext';
 import useGetOrCreateSubmission from 'hooks/useGetOrCreateSubmission';
 import useSessionTimeout from 'hooks/useSessionTimeout';
-import Types from 'types';
 
 import {AppointmentConfigContext} from '../Context';
 import AppointmentProgress from './AppointmentProgress';
@@ -24,7 +24,8 @@ import {APPOINTMENT_STEP_PATHS, checkMatchesPath} from './routes';
 // removeSubmissionFromStorage();
 // resetSession();
 
-const CreateAppointment = ({form}) => {
+const CreateAppointment = () => {
+  const form = useFormContext();
   const {isLoading, error, submission, removeSubmissionFromStorage} =
     useGetOrCreateSubmission(form);
   if (error) throw error;
@@ -75,9 +76,7 @@ const CreateAppointment = ({form}) => {
   );
 };
 
-CreateAppointment.propTypes = {
-  form: Types.Form.isRequired,
-};
+CreateAppointment.propTypes = {};
 
 const Wrapper = ({sessionExpired = false, children, ...props}) => {
   if (sessionExpired) return <>{children}</>;

--- a/src/components/appointments/CreateAppointment/CreateAppointment.stories.js
+++ b/src/components/appointments/CreateAppointment/CreateAppointment.stories.js
@@ -3,6 +3,7 @@ import {userEvent, waitFor, within} from '@storybook/testing-library';
 import {addDays, format} from 'date-fns';
 import {RouterProvider, createMemoryRouter} from 'react-router-dom';
 
+import {FormContext} from 'Context';
 import {buildForm} from 'api-mocks';
 import {mockSubmissionPost} from 'api-mocks/submissions';
 import {mockPrivacyPolicyConfigGet} from 'components/Summary/mocks';
@@ -47,7 +48,7 @@ const Wrapper = ({form}) => {
   const routes = [
     {
       path: '/appointments/*',
-      element: <CreateAppointment form={form} />,
+      element: <CreateAppointment />,
       children: childRoutes,
     },
   ];
@@ -55,7 +56,11 @@ const Wrapper = ({form}) => {
     initialEntries: ['/appointments/'],
     initialIndex: 0,
   });
-  return <RouterProvider router={router} />;
+  return (
+    <FormContext.Provider value={form}>
+      <RouterProvider router={router} />
+    </FormContext.Provider>
+  );
 };
 
 const render = ({showProgressIndicator, supportsMultipleProducts, name}) => {

--- a/src/developer-docs.mdx
+++ b/src/developer-docs.mdx
@@ -6,6 +6,38 @@ import {Meta} from '@storybook/blocks';
 
 This documentation is aimed at Open Formulieren-developers working on the SDK.
 
+## Router integration and flow of data
+
+The SDK started with react-router v5, which didn't have data routers. Since the upgrade to v6.4, we
+_can_ make use of data routers, but not everything has been converted yet.
+
+New code should maximize the use of data routers. Ideally you can do this by exporting the nested
+routes in your code like so:
+
+```jsx
+export const routes = [
+  {
+    path: 'some-nested-path',
+    element: <MyComponent />,
+    // any additional data router features
+  },
+];
+```
+
+This implies that the element cannot take dynamic props anymore, which is the biggest draw-back.
+However, there are mechanisms to load data from the route arguments via the `loader` (see the
+react-router documentation). Currently we still do this manually using the `useAsync` hook.
+
+Often you need access to the `form` object. This is now exposed via React context for the entire
+application:
+
+```jsx
+const MyComponent = () => {
+  const form = useFormContext();
+  return (...);
+};
+```
+
 ## Story guidelines
 
 Stories are written in [CSF](https://storybook.js.org/docs/react/writing-stories/introduction) and

--- a/src/hooks/useFormContext.js
+++ b/src/hooks/useFormContext.js
@@ -1,0 +1,7 @@
+import {useContext} from 'react';
+
+import {FormContext} from 'Context';
+
+const useFormContext = () => useContext(FormContext);
+
+export default useFormContext;

--- a/src/story-utils/decorators.js
+++ b/src/story-utils/decorators.js
@@ -4,7 +4,7 @@ import merge from 'lodash/merge';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 
 import {ConfigContext} from 'Context';
-import {BASE_URL} from 'api-mocks';
+import {BASE_URL, buildForm} from 'api-mocks';
 import Card from 'components/Card';
 import {Layout, LayoutRow} from 'components/Layout';
 import {LiteralsProvider} from 'components/Literal';


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#3067

This refactors the existing application to pass the `form` via context so we can make the router routes statically defined and avoid some prop-drilling, moving more towards the intended usage of react-router's data routers.