### PR TITLE
Fix submission state

### DIFF
--- a/src/api-mocks/submissions.js
+++ b/src/api-mocks/submissions.js
@@ -60,3 +60,20 @@ export const mockSubmissionProcessingStatusGet = rest.get(
       })
     )
 );
+
+export const mockSubmissionProcessingStatusPendingGet = rest.get(
+  `${BASE_URL}submissions/:uuid/:token/status`,
+  (req, res, ctx) =>
+    res(
+      ctx.json({
+        status: 'in_progress',
+        result: '',
+        errorMessage: '',
+        publicReference: '',
+        confirmationPageContent: '',
+        reportDownloadUrl: '',
+        paymentUrl: '',
+        mainWebsiteUrl: '',
+      })
+    )
+);

--- a/src/api-mocks/submissions.js
+++ b/src/api-mocks/submissions.js
@@ -20,6 +20,11 @@ const SUBMISSION_DETAILS = {
   ],
   submissionAllowed: 'yes',
   isAuthenticated: false,
+  payment: {
+    isRequired: false,
+    amount: undefined,
+    hasPaid: false,
+  },
 };
 
 /**

--- a/src/components/SubmissionConfirmation.js
+++ b/src/components/SubmissionConfirmation.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
+import React from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useAsync} from 'react-use';
 
@@ -75,29 +75,28 @@ const SubmissionConfirmation = ({statusUrl, onFailure, onConfirmed, donwloadPDFT
   });
   useTitle(pageTitle);
 
-  const [statusResponse, setStatusResponse] = useState(null);
   const genericErrorMessage = intl.formatMessage({
     description: 'Generic submission error',
     defaultMessage: 'Something went wrong while submitting the form.',
   });
 
-  const {loading, error} = usePoll(statusUrl, 1000, response => {
-    setStatusResponse(response);
-    switch (response.status) {
-      case 'done': {
-        if (response.result === RESULT_FAILED) {
-          const errorMessage = response.errorMessage || genericErrorMessage;
-          onFailure && onFailure(errorMessage);
-        } else if (response.result === RESULT_SUCCESS) {
-          onConfirmed && onConfirmed();
-        }
-        return true;
-      }
-      default: {
-        // nothing, it's pending/started or retrying
+  const {
+    loading,
+    error,
+    response: statusResponse,
+  } = usePoll(
+    statusUrl,
+    1000,
+    response => response.status === 'done',
+    response => {
+      if (response.result === RESULT_FAILED) {
+        const errorMessage = response.errorMessage || genericErrorMessage;
+        onFailure && onFailure(errorMessage);
+      } else if (response.result === RESULT_SUCCESS) {
+        onConfirmed && onConfirmed();
       }
     }
-  });
+  );
 
   // FIXME: https://github.com/open-formulieren/open-forms/issues/3255
   // errors (bad gateway 502, for example) appear to result in infinite loading

--- a/src/components/SubmissionConfirmation.stories.js
+++ b/src/components/SubmissionConfirmation.stories.js
@@ -2,8 +2,10 @@ import {expect} from '@storybook/jest';
 import {waitFor, within} from '@storybook/testing-library';
 
 import {BASE_URL} from 'api-mocks';
-import {buildForm} from 'api-mocks';
-import {mockSubmissionProcessingStatusGet} from 'api-mocks/submissions';
+import {
+  mockSubmissionProcessingStatusGet,
+  mockSubmissionProcessingStatusPendingGet,
+} from 'api-mocks/submissions';
 import {LayoutDecorator, withCard} from 'story-utils/decorators';
 
 import SubmissionConfirmation from './SubmissionConfirmation';
@@ -41,5 +43,13 @@ export const Success = {
     );
     expect(canvas.getByText(/OF-L337/)).toBeVisible();
     expect(args.onConfirmed).toBeCalledTimes(1);
+  },
+};
+
+export const Pending = {
+  parameters: {
+    msw: {
+      handlers: [mockSubmissionProcessingStatusPendingGet],
+    },
   },
 };


### PR DESCRIPTION
Related to open-formulieren/open-forms#3067

When implementing the confirmation state, the loading flag from the useGetOrCreateSubmission hook caused UI flicker due to unintended component remounting. This fixes the problem at the root so that developers don't really have to worry about the React internals.

Additionally, a story is added for the loading state - this should work in Chromatic because they disable CSS animations.