### PR TITLE
Always allow formik submission and validate on submit

### DIFF
--- a/src/components/appointments/ChooseProductStep.js
+++ b/src/components/appointments/ChooseProductStep.js
@@ -94,7 +94,7 @@ const ChooseProductStepFields = ({values: {products = []}, validateForm, isValid
       </FieldArray>
 
       <SubmitRow
-        canSubmit={dirty && isValid}
+        canSubmit
         nextText={intl.formatMessage({
           description: 'Appointments products step: next step text',
           defaultMessage: 'Confirm products',
@@ -192,7 +192,7 @@ const ChooseProductStep = ({navigateTo = null}) => {
         initialErrors={initialErrors}
         initialTouched={initialTouched}
         validateOnChange={false}
-        validateOnBlur
+        validateOnBlur={false}
         validationSchema={toFormikValidationSchema(validationSchema)}
         onSubmit={(values, {setSubmitting}) => {
           flushSync(() => {

--- a/src/components/appointments/ChooseProductStep.stories.js
+++ b/src/components/appointments/ChooseProductStep.stories.js
@@ -157,6 +157,6 @@ export const WithBackendErrors = {
 
     await expect(await canvas.findByText('Product is sold out.')).toBeVisible();
     const submitButton = canvas.getByRole('button', {name: 'Bevestig producten'});
-    expect(submitButton).toHaveAttribute('aria-disabled', 'true');
+    expect(submitButton).not.toHaveAttribute('aria-disabled', 'true');
   },
 };

--- a/src/components/appointments/ContactDetailsStep.js
+++ b/src/components/appointments/ContactDetailsStep.js
@@ -98,7 +98,7 @@ const ContactDetailsStep = ({navigateTo = null}) => {
           initialTouched={initialTouched?.contactDetails}
           enableReinitialize
           validateOnChange={false}
-          validateOnBlur
+          validateOnBlur={false}
           validationSchema={
             validationSchema ? toFormikValidationSchema(validationSchema) : undefined
           }
@@ -119,7 +119,7 @@ const ContactDetailsStep = ({navigateTo = null}) => {
               ))}
 
               <SubmitRow
-                canSubmit={dirty && !loading && validationSchema && isValid}
+                canSubmit={!loading && validationSchema}
                 nextText={intl.formatMessage({
                   description: 'Appointments contact details step: next step text',
                   defaultMessage: 'To overview',

--- a/src/components/appointments/ContactDetailsStep.stories.js
+++ b/src/components/appointments/ContactDetailsStep.stories.js
@@ -101,6 +101,6 @@ export const WithBackendErrors = {
       await canvas.findByText('Unfortunately, you are banned from making appointments.')
     ).toBeVisible();
     const submitButton = canvas.getByRole('button', {name: 'Naar overzicht'});
-    expect(submitButton).toHaveAttribute('aria-disabled', 'true');
+    expect(submitButton).not.toHaveAttribute('aria-disabled', 'true');
   },
 };

--- a/src/components/appointments/CreateAppointment/CreateAppointment.stories.js
+++ b/src/components/appointments/CreateAppointment/CreateAppointment.stories.js
@@ -108,7 +108,7 @@ export const HappyFlow = {
         async () =>
           await expect(
             await canvas.queryByRole('button', {name: 'Bevestig producten'})
-          ).toHaveAttribute('aria-disabled', 'true')
+          ).not.toHaveAttribute('aria-disabled', 'true')
       );
     });
 
@@ -136,7 +136,7 @@ export const HappyFlow = {
         await expect(canvas.getByRole('button', {name: 'Terug naar producten'})).toBeVisible();
         await expect(
           await canvas.queryByRole('button', {name: 'Naar contactgegevens'})
-        ).toHaveAttribute('aria-disabled', 'true');
+        ).not.toHaveAttribute('aria-disabled', 'true');
         // location auto-filled
         await canvas.findByText('Open Gem');
       });
@@ -178,10 +178,9 @@ export const HappyFlow = {
         ).toBeVisible();
       });
       await waitFor(async () => {
-        await expect(await canvas.queryByRole('button', {name: 'Naar overzicht'})).toHaveAttribute(
-          'aria-disabled',
-          'true'
-        );
+        await expect(
+          await canvas.queryByRole('button', {name: 'Naar overzicht'})
+        ).not.toHaveAttribute('aria-disabled', 'true');
       });
       await userEvent.type(await canvas.findByLabelText('Last name'), 'Elvis');
       await userEvent.type(canvas.getByLabelText('Dag'), '8');

--- a/src/components/appointments/LocationAndTimeStep.js
+++ b/src/components/appointments/LocationAndTimeStep.js
@@ -1,7 +1,7 @@
 import {Heading3, UnorderedList, UnorderedListItem} from '@utrecht/component-library-react';
 import {Form, Formik} from 'formik';
 import PropTypes from 'prop-types';
-import React, {useContext, useEffect} from 'react';
+import React, {useContext} from 'react';
 import {flushSync} from 'react-dom';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useNavigate} from 'react-router-dom';
@@ -36,24 +36,11 @@ const INITIAL_VALUES = {
   datetime: '',
 };
 
-const LocationAndTimeStepFields = ({isValid, dirty, validateForm, setErrors}) => {
+const LocationAndTimeStepFields = () => {
   const intl = useIntl();
   const {
     appointmentData: {products = []},
-    stepErrors: {initialErrors},
   } = useCreateAppointmentContext();
-  // workaround to validate the form on mount without discarding the initialErrors.
-  // Due to the auto location select, the form is marked dirty but validation hasn't run
-  // as validateOnMount is not set. Setting validateOnMount causes initialErrors to be
-  // discarded otherwise.
-  useEffect(() => {
-    validateForm().then(() => {
-      if (!Object.keys(initialErrors).length) return;
-      setErrors(initialErrors);
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   return (
     // TODO: don't do inline style
     <Form style={{width: '100%'}}>
@@ -64,7 +51,7 @@ const LocationAndTimeStepFields = ({isValid, dirty, validateForm, setErrors}) =>
       </div>
 
       <SubmitRow
-        canSubmit={dirty && isValid}
+        canSubmit
         nextText={intl.formatMessage({
           description: 'Appointments location and time step: next step text',
           defaultMessage: 'To contact details',
@@ -84,7 +71,7 @@ const LocationAndTimeStep = ({navigateTo = null}) => {
   const {
     appointmentData: {products = []},
     stepData,
-    stepErrors: {initialTouched},
+    stepErrors: {initialErrors, initialTouched},
     clearStepErrors,
     submitStep,
   } = useCreateAppointmentContext();
@@ -114,9 +101,10 @@ const LocationAndTimeStep = ({navigateTo = null}) => {
 
       <Formik
         initialValues={{...INITIAL_VALUES, ...stepData}}
+        initialErrors={initialErrors}
         initialTouched={initialTouched}
         validateOnChange={false}
-        validateOnBlur
+        validateOnBlur={false}
         validationSchema={toFormikValidationSchema(schema)}
         onSubmit={(values, {setSubmitting}) => {
           flushSync(() => {

--- a/src/components/appointments/LocationAndTimeStep.stories.js
+++ b/src/components/appointments/LocationAndTimeStep.stories.js
@@ -73,6 +73,6 @@ export const WithBackendErrors = {
 
     await expect(await canvas.findByText('This date is not available')).toBeVisible();
     const submitButton = canvas.getByRole('button', {name: 'Naar contactgegevens'});
-    expect(submitButton).toHaveAttribute('aria-disabled', 'true');
+    expect(submitButton).not.toHaveAttribute('aria-disabled', 'true');
   },
 };

--- a/src/components/appointments/LocationSelect.js
+++ b/src/components/appointments/LocationSelect.js
@@ -49,7 +49,6 @@ const LocationSelect = ({products}) => {
       valueProperty="identifier"
       getOptionLabel={location => location.name}
       autoSelectOnlyOption
-      validateOnChange
     />
   );
 };

--- a/src/components/appointments/ProductSelect.js
+++ b/src/components/appointments/ProductSelect.js
@@ -36,7 +36,6 @@ const ProductSelect = ({name}) => {
       getOptions={getOptions}
       valueProperty="identifier"
       getOptionLabel={product => product.name}
-      validateOnChange
     />
   );
 };

--- a/src/components/appointments/TimeSelect.js
+++ b/src/components/appointments/TimeSelect.js
@@ -76,7 +76,6 @@ const TimeSelect = ({products}) => {
       }
       getOptions={getOptions}
       autoSelectOnlyOption
-      validateOnChange
     />
   );
 };


### PR DESCRIPTION
Closes #514

Due to situations (hard refresh) where valid data is filled out, but no changes are made, the form is not considered to be dirty, which blocked the submit button. Relying on the valid state is not an alternative option either, as this requires validation to run on mount, which in turn discards the initialErrors set via the backend.

Additionally, running validation on blur/on change has some drawbacks in the UI:
- browser autocomplete does not fire onBlur, which requires another click or [Tab] by the user to blur the active input for validadtion to trigger
- blur on the datepicker input triggers validation to early when the user is still selecting a date in the calendar (possibly navigating to the next/previous month)
- blur on the date input group may trigger validation too soon when a date part like day/month is being entered and no full date is yet available to validate
- running validation on change yields intrusive validation errors for email address input while the user is typing

Deferring the client-side validation to the actual submit action is the easiest solution in this case.

Possible future improvement: scroll the first validation error into view.