### PR TITLE
Ensure react-select emotion uses available CSP Nonce

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,9 @@ window.onload = () => {
     baseUrl: REACT_APP_BASE_API_URL,
     formId: formId || REACT_APP_FORM_ID,
     basePath: '/',
+    // added for testing purposes - adding a real CSP breaks *a lot* of things of Create
+    // React App :(
+    CSPNonce: 'RqgbALvp8D5b3+8NuhfuKg==',
     // displayComponents,
     useHashRouting: REACT_APP_USE_HASH_ROUTING === 'true' || false,
   });

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -6,6 +6,7 @@ import {createRoot} from 'react-dom/client';
 import {Formio, Templates} from 'react-formio';
 import ReactModal from 'react-modal';
 import {RouterProvider, createBrowserRouter, createHashRouter} from 'react-router-dom';
+import {NonceProvider} from 'react-select';
 
 import {ConfigContext, FormContext} from 'Context';
 import {get} from 'api';
@@ -133,14 +134,16 @@ class OpenForm {
               requiredFieldsWithAsterisk: this.formObject.requiredFieldsWithAsterisk,
             }}
           >
-            <I18NErrorBoundary>
-              <I18NManager
-                languageSelectorTarget={this.languageSelectorTarget}
-                onLanguageChangeDone={this.onLanguageChangeDone.bind(this)}
-              >
-                <RouterProvider router={router} />
-              </I18NManager>
-            </I18NErrorBoundary>
+            <NonceProvider nonce={CSPNonce.getValue()} cacheKey="sdk-react-select">
+              <I18NErrorBoundary>
+                <I18NManager
+                  languageSelectorTarget={this.languageSelectorTarget}
+                  onLanguageChangeDone={this.onLanguageChangeDone.bind(this)}
+                >
+                  <RouterProvider router={router} />
+                </I18NManager>
+              </I18NErrorBoundary>
+            </NonceProvider>
           </ConfigContext.Provider>
         </FormContext.Provider>
       </React.StrictMode>


### PR DESCRIPTION
Closes open-formulieren/open-forms#3312

This one is hard to test due to CRA dev server/hot module replacement borking hard when adding a CSP to index.html, but the easiest is:

* Ensure you have CSP enabled in your backend
* Create a production build of this branch using `yarn build`
* Load a form (that is *not* CSP ignored) in the backend
* Check that the select dropdown now works