### PR TITLE
Fix appointment change and cancel links

### DIFF
--- a/src/Context.js
+++ b/src/Context.js
@@ -22,6 +22,7 @@ FormContext.displayName = 'FormContext';
 
 const ConfigContext = React.createContext({
   baseUrl: '',
+  clientBaseUrl: window.location.href,
   basePath: '',
   baseTitle: '',
   requiredFieldsWithAsterisk: true,

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -19,7 +19,7 @@ import AppDisplay from './AppDisplay';
 
 export const routes = [
   {
-    path: 'afspraak-annuleren',
+    path: 'afspraak-annuleren/*',
     element: <ManageAppointment />,
   },
   {
@@ -56,6 +56,7 @@ const App = ({noDebug = false}) => {
   const form = useFormContext();
   const config = useContext(ConfigContext);
   const appointmentMatch = useMatch('afspraak-maken/*');
+  const appointmentCancelMatch = useMatch('afspraak-annuleren/*');
 
   const AppDisplayComponent = config?.displayComponents?.app ?? AppDisplay;
 
@@ -64,7 +65,7 @@ const App = ({noDebug = false}) => {
   const appDebug = DEBUG && !noDebug ? <AppDebug /> : null;
 
   const isAppointment = form.appointmentOptions?.isAppointment ?? false;
-  if (isAppointment && !appointmentMatch) {
+  if (isAppointment && !appointmentMatch && !appointmentCancelMatch) {
     return <Navigate replace to="../afspraak-maken" />;
   }
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -165,7 +165,7 @@ const Form = () => {
       return;
     }
 
-    const submission = await createSubmission(config.baseUrl, form);
+    const submission = await createSubmission(config.baseUrl, form, config.clientBaseUrl);
     dispatch({
       type: 'SUBMISSION_LOADED',
       payload: submission,

--- a/src/components/appointments/CancelAppointment.integration.spec.js
+++ b/src/components/appointments/CancelAppointment.integration.spec.js
@@ -1,0 +1,52 @@
+import {act, render, screen} from '@testing-library/react';
+import messagesEN from 'i18n/compiled/en.json';
+import {IntlProvider} from 'react-intl';
+import {RouterProvider, createMemoryRouter} from 'react-router-dom';
+
+import {ConfigContext, FormContext} from 'Context';
+import {BASE_URL, buildForm, mockFormGet} from 'api-mocks';
+import mswServer from 'api-mocks/msw-server';
+import App, {routes} from 'components/App';
+
+const Wrapper = () => {
+  const form = buildForm({
+    appointmentOptions: {
+      isAppointment: true,
+      supportsMultipleProducts: true,
+    },
+  });
+  const router = createMemoryRouter(routes, {
+    initialEntries: [
+      '/afspraak-annuleren?time=2023-08-31T07:35:00Z&submission_uuid=bc38ca5e-4efd-4d9d-a3df-8cf5be7f0726',
+    ],
+    initialIndex: 0,
+  });
+  return (
+    <ConfigContext.Provider
+      value={{
+        baseUrl: BASE_URL,
+        basePath: '',
+        baseTitle: '',
+        requiredFieldsWithAsterisk: true,
+        displayComponents: {},
+      }}
+    >
+      <IntlProvider locale="en" messages={messagesEN}>
+        <FormContext.Provider value={form}>
+          <RouterProvider router={router} />
+        </FormContext.Provider>
+      </IntlProvider>
+    </ConfigContext.Provider>
+  );
+};
+
+describe('Cancelling an appointment', () => {
+  it('renders the correct page for a cancel route', async () => {
+    render(<Wrapper />);
+
+    const textbox = screen.getByRole('textbox', {name: 'Your email address'});
+    expect(textbox).toBeVisible();
+    expect(textbox.name).toBe('email');
+    expect(screen.getByRole('button')).toBeVisible();
+  });
+});

--- a/src/components/forms/EmailField/EmailField.js
+++ b/src/components/forms/EmailField/EmailField.js
@@ -6,7 +6,7 @@ const EmailField = props => <TextField {...props} type="email" />;
 
 EmailField.propTypes = {
   name: PropTypes.string.isRequired,
-  label: PropTypes.string,
+  label: PropTypes.node,
   isRequired: PropTypes.bool,
   description: PropTypes.node,
   id: PropTypes.string,

--- a/src/components/forms/TextField/TextField.js
+++ b/src/components/forms/TextField/TextField.js
@@ -46,7 +46,7 @@ export const TextField = ({
 
 TextField.propTypes = {
   name: PropTypes.string.isRequired,
-  label: PropTypes.string,
+  label: PropTypes.node,
   isRequired: PropTypes.bool,
   description: PropTypes.node,
   id: PropTypes.string,

--- a/src/data/submissions.js
+++ b/src/data/submissions.js
@@ -6,12 +6,13 @@ import {post} from 'api';
  * Create a submission instance from a given form instance
  * @param  {String} baseUrl The Open Forms backend baseUrl of the API (e.g. https://example.com/api/v2/)
  * @param  {Object} form   The relevant Open Forms form instance.
+ * @param  {String} formUrl The client-side URL hosting the form entrypoint.
  * @return {Object}        The Submission instance.
  */
-export const createSubmission = async (baseUrl, form, signal) => {
+export const createSubmission = async (baseUrl, form, formUrl, signal) => {
   const createData = {
     form: form.url,
-    formUrl: window.location.toString(),
+    formUrl,
   };
   const submissionResponse = await post(`${baseUrl}submissions`, createData, signal);
   return submissionResponse.data;

--- a/src/hooks/useGetOrCreateSubmission.js
+++ b/src/hooks/useGetOrCreateSubmission.js
@@ -7,7 +7,7 @@ import {createSubmission, flagActiveSubmission, flagNoActiveSubmission} from 'da
 export const SESSION_STORAGE_KEY = 'appointment|submission';
 
 const useGetOrCreateSubmission = (form, skipCreation) => {
-  const {baseUrl} = useContext(ConfigContext);
+  const {baseUrl, clientBaseUrl} = useContext(ConfigContext);
   const [submission, setSubmission] = useSessionStorage(SESSION_STORAGE_KEY, null);
 
   const clear = () => {
@@ -23,7 +23,7 @@ const useGetOrCreateSubmission = (form, skipCreation) => {
     async signal => {
       if (shouldCreate) {
         try {
-          setSubmission(await createSubmission(baseUrl, form, signal));
+          setSubmission(await createSubmission(baseUrl, form, clientBaseUrl, signal));
         } catch (e) {
           if (error.name !== 'AbortError') {
             throw e;

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -5,7 +5,7 @@ import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {Formio, Templates} from 'react-formio';
 import ReactModal from 'react-modal';
-import {RouterProvider, createBrowserRouter, createHashRouter} from 'react-router-dom';
+import {RouterProvider, createBrowserRouter, createHashRouter, resolvePath} from 'react-router-dom';
 import {NonceProvider} from 'react-select';
 
 import {ConfigContext, FormContext} from 'Context';
@@ -98,6 +98,18 @@ class OpenForm {
       pathname = pathname.slice(0, pathname.length - 1);
     }
     this.basePath = pathname;
+    this.calculateClientBaseUrl();
+  }
+
+  calculateClientBaseUrl() {
+    // calculate the client-side base URL, as this is recorded in backend calls for
+    // submissions.
+    const clientBase = resolvePath(this.basePath).pathname; // has leading slash
+    const prefix = this.useHashRouting ? window.location.pathname : ''; // may have trailing slash
+    this.clientBaseUrl = new URL(
+      this.useHashRouting ? `${prefix}#${clientBase}` : clientBase,
+      window.location.origin
+    ).href;
   }
 
   async init() {
@@ -127,6 +139,7 @@ class OpenForm {
           <ConfigContext.Provider
             value={{
               baseUrl: this.baseUrl,
+              clientBaseUrl: this.clientBaseUrl,
               basePath: this.basePath,
               baseTitle: this.baseTitle,
               displayComponents: this.displayComponents,

--- a/src/sdk.spec.js
+++ b/src/sdk.spec.js
@@ -112,4 +112,30 @@ describe('OpenForm', () => {
 
     expect(within(formRoot).getAllByText('English version').length).toBeGreaterThan(0);
   });
+
+  it('should correctly set the formUrl', () => {
+    mswServer.use(...apiMocks);
+    const formRoot = document.createElement('div');
+    const form = new OpenForm(formRoot, {
+      baseUrl: BASE_URL,
+      basePath: '/some-subpath/',
+      formId: '81a22589-abce-4147-a2a3-62e9a56685aa',
+    });
+
+    expect(form.clientBaseUrl).toEqual('http://localhost/some-subpath');
+  });
+
+  it('should correctly set the formUrl (hash fragment routing)', () => {
+    mswServer.use(...apiMocks);
+    window.history.pushState({}, 'Dummy title', '/some-server-side/path');
+    const formRoot = document.createElement('div');
+    const form = new OpenForm(formRoot, {
+      baseUrl: BASE_URL,
+      basePath: '/some-subpath/',
+      formId: '81a22589-abce-4147-a2a3-62e9a56685aa',
+      useHashRouting: true,
+    });
+
+    expect(form.clientBaseUrl).toEqual('http://localhost/some-server-side/path#/some-subpath');
+  });
 });


### PR DESCRIPTION
Partially closes open-formulieren/open-forms#3322

Two issues at hand here:

* the `form.isAppointment` handling caused the cancel URL to always redirect to the flow to create a new appointment
* the backend was not able to correctly reconstruct the cancel URL due to a deeply nested `formUrl` being passed to submission creation. This is now normalized base on the SDK `basePath` option (which specifies where a particular form is publicly hosted).

The handling of fragment routing in the backend is something that will still require particular attention, I've no idea yet how to do this :cry: 