### PR TITLE
Support statement checkboxes per form

### DIFF
--- a/src/Context.js
+++ b/src/Context.js
@@ -10,6 +10,7 @@ const FormContext = React.createContext({
   maintenanceMode: false,
   showProgressIndicator: true,
   submissionAllowed: 'yes',
+  submissionStatementsConfiguration: [],
   literals: {
     beginText: {value: '', resolved: 'Begin'},
     changeText: {value: '', resolved: 'Change'},

--- a/src/api-mocks/forms.js
+++ b/src/api-mocks/forms.js
@@ -1,6 +1,8 @@
 import produce from 'immer';
 import {rest} from 'msw';
 
+import {PRIVACY_POLICY_ACCEPTED} from 'components/SummaryConfirmation/mocks';
+
 import {BASE_URL, getDefaultFactory} from './base';
 
 const FORM_DEFAULTS = {
@@ -17,6 +19,7 @@ const FORM_DEFAULTS = {
   active: true,
   submissionAllowed: 'yes',
   suspensionAllowed: true,
+  submissionStatementsConfiguration: [PRIVACY_POLICY_ACCEPTED],
   appointmentOptions: {
     isAppointment: false,
     supportsMultipleProducts: null,

--- a/src/components/LoginOptions/tests.spec.js
+++ b/src/components/LoginOptions/tests.spec.js
@@ -21,10 +21,12 @@ beforeEach(() => {
 
 afterEach(() => {
   // cleanup on exiting
-  root.unmount();
-  container.remove();
-  root = null;
-  container = null;
+  act(() => {
+    root.unmount();
+    container.remove();
+    root = null;
+    container = null;
+  });
 });
 
 it('Login not required, options wrapped in form tag', () => {

--- a/src/components/StatementCheckboxes/StatementCheckbox.js
+++ b/src/components/StatementCheckboxes/StatementCheckbox.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormattedMessage} from 'react-intl';
+import {defineMessages, useIntl} from 'react-intl';
 
 import Body from 'components/Body';
 import ErrorMessage from 'components/ErrorMessage';
@@ -8,7 +8,21 @@ import {FormioComponent} from 'components/formio';
 
 import './StatementCheckbox.scss';
 
+// FIXME: when the checkboxes are made generic, the warnings should be provided by the
+// backend.
+const WARNINGS = defineMessages({
+  privacyPolicyAccepted: {
+    description: 'Warning privacy policy not checked when submitting',
+    defaultMessage: 'Please accept the privacy policy before submitting',
+  },
+  truthStatementAccepted: {
+    description: 'Warning statement of truth not checked when submitting',
+    defaultMessage: 'You must declare the form to be filled out truthfully before submitting',
+  },
+});
+
 const StatementCheckbox = ({configuration, showWarning = false}) => {
+  const intl = useIntl();
   if (!configuration.validate.required) return null;
 
   const labelBody = (
@@ -28,10 +42,7 @@ const StatementCheckbox = ({configuration, showWarning = false}) => {
       <FormioComponent component={formioDefinition} />
       {showWarning && (
         <ErrorMessage modifiers={['warning']}>
-          <FormattedMessage
-            description="Warning declaration not checked when submitting"
-            defaultMessage="Please check the above declaration before submitting"
-          />
+          {intl.formatMessage(WARNINGS[configuration.key])}
         </ErrorMessage>
       )}
     </div>

--- a/src/components/Summary/Summary.stories.js
+++ b/src/components/Summary/Summary.stories.js
@@ -1,9 +1,14 @@
 import {expect} from '@storybook/jest';
 import {userEvent, waitFor, within} from '@storybook/testing-library';
-import {getWorker} from 'msw-storybook-addon';
+import cloneDeep from 'lodash/cloneDeep';
 import {withRouter} from 'storybook-addon-react-router-v6';
 
-import {mockStatementsConfigGet} from 'components/SummaryConfirmation/mocks';
+import {FormContext} from 'Context';
+import {buildForm} from 'api-mocks';
+import {
+  PRIVACY_POLICY_ACCEPTED,
+  STATEMENT_OF_TRUTH_ACCEPTED,
+} from 'components/SummaryConfirmation/mocks';
 import {SUBMISSION_ALLOWED} from 'components/constants';
 import {ConfigDecorator, FormikDecorator, LiteralDecorator} from 'story-utils/decorators';
 
@@ -97,6 +102,9 @@ export default {
     errors: [],
     submissionAllowed: SUBMISSION_ALLOWED.yes,
     editStepText: 'Change',
+    // formContext args
+    askPrivacyConsent: true,
+    askStatementOfTruth: false,
     // LiteralDecorator args
     confirmText: 'Confirm',
     previousText: 'Previous',
@@ -124,29 +132,39 @@ export default {
   },
 };
 
-const worker = getWorker();
-
-export const Default = {
-  render: ({
-    // component props
-    title,
-    submissionAllowed,
-    summaryData,
-    showPaymentInformation,
-    amountToPay,
-    editStepText,
-    isLoading,
-    isAuthenticated,
-    errors,
-    onSubmit,
-    onLogout,
-    onPrevPage,
-    // story args
-    showPreviousPageLink,
-  }) => {
-    worker.use(mockStatementsConfigGet());
-
-    return (
+const render = ({
+  // component props
+  title,
+  submissionAllowed,
+  summaryData,
+  showPaymentInformation,
+  amountToPay,
+  editStepText,
+  isLoading,
+  isAuthenticated,
+  errors,
+  onSubmit,
+  onLogout,
+  onPrevPage,
+  // story args
+  showPreviousPageLink,
+  askPrivacyConsent,
+  askStatementOfTruth,
+}) => {
+  const configuration = [];
+  if (askPrivacyConsent !== null) {
+    const privacyPolicyStatement = cloneDeep(PRIVACY_POLICY_ACCEPTED);
+    privacyPolicyStatement.validate.required = askPrivacyConsent;
+    configuration.push(privacyPolicyStatement);
+  }
+  if (askStatementOfTruth !== null) {
+    const truthStatement = cloneDeep(STATEMENT_OF_TRUTH_ACCEPTED);
+    truthStatement.validate.required = askStatementOfTruth;
+    configuration.push(truthStatement);
+  }
+  const form = buildForm({submissionStatementsConfiguration: configuration});
+  return (
+    <FormContext.Provider value={form}>
       <GenericSummary
         title={title}
         submissionAllowed={submissionAllowed}
@@ -164,199 +182,87 @@ export const Default = {
         onLogout={onLogout}
         onPrevPage={showPreviousPageLink ? onPrevPage : null}
       />
-    );
-  },
+    </FormContext.Provider>
+  );
+};
+
+export const Default = {
+  render,
 };
 
 export const MultipleRequiredStatements = {
-  render: ({
-    // component props
-    title,
-    submissionAllowed,
-    summaryData,
-    showPaymentInformation,
-    amountToPay,
-    editStepText,
-    isLoading,
-    isAuthenticated,
-    errors,
-    onSubmit,
-    onLogout,
-    onPrevPage,
-    // story args
-    showPreviousPageLink,
-  }) => {
-    const multipleRequiredStatements = [
-      {
-        key: 'privacyPolicyAccepted',
-        type: 'checkbox',
-        validate: {required: true},
-        label: 'I accept the privacy policy and consent to the processing of my personal data.',
-      },
-      {
-        key: 'truthStatementAccepted',
-        type: 'checkbox',
-        validate: {required: true},
-        label: 'I responded very honestly.',
-      },
-    ];
-    worker.use(mockStatementsConfigGet(multipleRequiredStatements));
-
-    return (
-      <GenericSummary
-        title={title}
-        submissionAllowed={submissionAllowed}
-        summaryData={summaryData}
-        showPaymentInformation={showPaymentInformation}
-        amountToPay={amountToPay}
-        editStepText={editStepText}
-        isLoading={isLoading}
-        isAuthenticated={isAuthenticated}
-        errors={errors}
-        onSubmit={event => {
-          event.preventDefault();
-          onSubmit(event);
-        }}
-        onLogout={onLogout}
-        onPrevPage={showPreviousPageLink ? onPrevPage : null}
-      />
-    );
+  render,
+  args: {
+    askPrivacyConsent: true,
+    askStatementOfTruth: true,
   },
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
 
-    await step('Wait for the statements to load', async () => {
-      await waitFor(
-        async () =>
-          await expect(
-            await canvas.getByLabelText(
-              /I accept the privacy policy and consent to the processing of my personal data/
-            )
-          )
-      );
-    });
+    await canvas.findByLabelText(
+      /I accept the privacy policy and consent to the processing of my personal data/
+    );
 
     await step(
       'Verify that warnings appear if trying to submit without accepting statements',
       async () => {
         const submitButton = canvas.getByRole('button', {name: 'Confirm'});
-        await waitFor(async () => {
-          expect(submitButton).toHaveAttribute('aria-disabled', 'true');
-        });
+        expect(submitButton).toHaveAttribute('aria-disabled', 'true');
 
         // Clicking 'submit' without checking the statements results in all the warnings being
         // displayed
         await userEvent.click(submitButton);
-        await waitFor(async () => {
-          const warnings = canvas.queryAllByText(
-            'Please check the above declaration before submitting'
-          );
-          expect(warnings).toHaveLength(2);
-        });
+        expect(
+          await canvas.findByText('U moet akkoord gaan met het privacybeleid om door te gaan')
+        ).toBeVisible();
+        expect(
+          await canvas.findByText(
+            'You must declare the form to be filled out truthfully before submitting'
+          )
+        ).toBeVisible();
 
         // Accepting the privacy policy makes one warning disappear
         const checkboxPrivacy = canvas.getByLabelText(
           /I accept the privacy policy and consent to the processing of my personal data/
         );
         await userEvent.click(checkboxPrivacy);
-        await waitFor(async () => {
-          const warnings = canvas.queryAllByText(
-            'Please check the above declaration before submitting'
-          );
-          expect(warnings).toHaveLength(1);
-        });
+        await canvas.findByText(
+          'You must declare the form to be filled out truthfully before submitting'
+        );
+        expect(
+          canvas.queryByText('U moet akkoord gaan met het privacybeleid om door te gaan')
+        ).toBeNull();
 
         // Accepting the truth declaration makes the second warning disappear and the 'submit'
         // button is no longer disabled
         const checkboxTruth = canvas.getByLabelText('I responded very honestly.');
         await userEvent.click(checkboxTruth);
-        await waitFor(async () => {
-          const warnings = canvas.queryAllByText(
-            'Please check the above declaration before submitting'
-          );
-          expect(warnings).toHaveLength(0);
-        });
-        await waitFor(async () => {
-          expect(submitButton).not.toHaveAttribute('aria-disabled', 'true');
-        });
+        expect(
+          canvas.queryByText('U moet akkoord gaan met het privacybeleid om door te gaan')
+        ).toBeNull();
+        expect(
+          canvas.queryByText('U moet akkoord gaan met het privacybeleid om door te gaan')
+        ).toBeNull();
+        expect(submitButton).not.toHaveAttribute('aria-disabled', 'true');
       }
     );
   },
 };
 
 export const OnlyOneRequiredStatement = {
-  render: ({
-    // component props
-    title,
-    submissionAllowed,
-    summaryData,
-    showPaymentInformation,
-    amountToPay,
-    editStepText,
-    isLoading,
-    isAuthenticated,
-    errors,
-    onSubmit,
-    onLogout,
-    onPrevPage,
-    // story args
-    showPreviousPageLink,
-  }) => {
-    const multipleRequiredStatements = [
-      {
-        key: 'privacyPolicyAccepted',
-        type: 'checkbox',
-        validate: {required: true},
-        label: 'I accept the privacy policy and consent to the processing of my personal data.',
-      },
-      {
-        key: 'truthStatementAccepted',
-        type: 'checkbox',
-        validate: {required: false},
-        label: 'I responded very honestly.',
-      },
-    ];
-    worker.use(mockStatementsConfigGet(multipleRequiredStatements));
-
-    return (
-      <GenericSummary
-        title={title}
-        submissionAllowed={submissionAllowed}
-        summaryData={summaryData}
-        showPaymentInformation={showPaymentInformation}
-        amountToPay={amountToPay}
-        editStepText={editStepText}
-        isLoading={isLoading}
-        isAuthenticated={isAuthenticated}
-        errors={errors}
-        onSubmit={event => {
-          event.preventDefault();
-          onSubmit(event);
-        }}
-        onLogout={onLogout}
-        onPrevPage={showPreviousPageLink ? onPrevPage : null}
-      />
-    );
+  render,
+  args: {
+    askPrivacyConsent: true,
+    askStatementOfTruth: false,
   },
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
 
-    await step('Wait for the statements to load', async () => {
-      await waitFor(
-        async () =>
-          await expect(
-            await canvas.getByLabelText(
-              /I accept the privacy policy and consent to the processing of my personal data/
-            )
-          )
-      );
-    });
+    await canvas.findByLabelText(
+      /I accept the privacy policy and consent to the processing of my personal data/
+    );
 
-    await step('Verify that only one checkbox is visible', async () => {
-      await waitFor(async () => {
-        const checkboxTruth = canvas.queryByLabelText('I responded very honestly.');
-        expect(checkboxTruth).toBeNull();
-      });
-    });
+    const checkboxTruth = canvas.queryByLabelText('I responded very honestly.');
+    expect(checkboxTruth).toBeNull();
   },
 };

--- a/src/components/SummaryConfirmation/mocks.js
+++ b/src/components/SummaryConfirmation/mocks.js
@@ -1,17 +1,13 @@
-import {rest} from 'msw';
+export const PRIVACY_POLICY_ACCEPTED = {
+  key: 'privacyPolicyAccepted',
+  type: 'checkbox',
+  validate: {required: true},
+  label: 'I accept the privacy policy and consent to the processing of my personal data.',
+};
 
-import {BASE_URL} from 'api-mocks';
-
-import {STATEMENTS_INFO_ENDPOINT} from '.';
-
-const DEFAULT_STATEMENTS = [
-  {
-    key: 'privacyPolicyAccepted',
-    type: 'checkbox',
-    validate: {required: true},
-    label: 'I accept the privacy policy and consent to the processing of my personal data.',
-  },
-];
-
-export const mockStatementsConfigGet = (statements = DEFAULT_STATEMENTS) =>
-  rest.get(`${BASE_URL}${STATEMENTS_INFO_ENDPOINT}`, (req, res, ctx) => res(ctx.json(statements)));
+export const STATEMENT_OF_TRUTH_ACCEPTED = {
+  key: 'truthStatementAccepted',
+  type: 'checkbox',
+  validate: {required: true},
+  label: 'I responded very honestly.',
+};

--- a/src/components/appointments/CreateAppointment/CreateAppointment.stories.js
+++ b/src/components/appointments/CreateAppointment/CreateAppointment.stories.js
@@ -7,7 +7,6 @@ import {FormContext} from 'Context';
 import {buildForm} from 'api-mocks';
 import {mockSubmissionPost} from 'api-mocks/submissions';
 import {mockSubmissionProcessingStatusGet} from 'api-mocks/submissions';
-import {mockStatementsConfigGet} from 'components/SummaryConfirmation/mocks';
 import {loadCalendarLocale} from 'components/forms/DateField/DatePickerCalendar';
 import {ConfigDecorator, LayoutDecorator} from 'story-utils/decorators';
 
@@ -34,7 +33,6 @@ export default {
         mockAppointmentDatesGet,
         mockAppointmentTimesGet,
         mockAppointmentCustomerFieldsGet,
-        mockStatementsConfigGet(),
         mockAppointmentPost,
         mockSubmissionProcessingStatusGet,
       ],

--- a/src/components/appointments/CreateAppointment/Summary.spec.js
+++ b/src/components/appointments/CreateAppointment/Summary.spec.js
@@ -5,11 +5,10 @@ import messagesEN from 'i18n/compiled/en.json';
 import {IntlProvider} from 'react-intl';
 import {Outlet, RouterProvider, createMemoryRouter} from 'react-router-dom';
 
-import {ConfigContext} from 'Context';
+import {ConfigContext, FormContext} from 'Context';
 import {BASE_URL, buildForm, buildSubmission} from 'api-mocks';
 import mswServer from 'api-mocks/msw-server';
 import {LiteralsProvider} from 'components/Literal';
-import {mockStatementsConfigGet} from 'components/SummaryConfirmation/mocks';
 
 import {CreateAppointmentContext} from '../Context';
 import {
@@ -88,12 +87,15 @@ const renderSummary = errorHandler => {
     initialEntries: ['/appointments/overzicht'],
     initialIndex: 0,
   });
-  realRender(<RouterProvider router={router} />);
+  realRender(
+    <FormContext.Provider value={form}>
+      <RouterProvider router={router} />
+    </FormContext.Provider>
+  );
 };
 
 beforeEach(() => {
   mswServer.use(
-    mockStatementsConfigGet(),
     mockAppointmentProductsGet,
     mockAppointmentLocationsGet,
     mockAppointmentCustomerFieldsGet

--- a/src/components/appointments/CreateAppointment/Summary.stories.js
+++ b/src/components/appointments/CreateAppointment/Summary.stories.js
@@ -1,8 +1,13 @@
 import {withRouter} from 'storybook-addon-react-router-v6';
 
 import {buildSubmission} from 'api-mocks/submissions';
-import {mockStatementsConfigGet} from 'components/SummaryConfirmation/mocks';
-import {ConfigDecorator, LayoutDecorator, LiteralDecorator, withCard} from 'story-utils/decorators';
+import {
+  ConfigDecorator,
+  LayoutDecorator,
+  LiteralDecorator,
+  withCard,
+  withForm,
+} from 'story-utils/decorators';
 
 import {
   mockAppointmentCustomerFieldsGet,
@@ -21,6 +26,7 @@ export default {
     LayoutDecorator,
     withAppointmentState,
     LiteralDecorator,
+    withForm,
     withRouter,
     ConfigDecorator,
   ],
@@ -50,7 +56,6 @@ export default {
     },
     msw: {
       handlers: [
-        mockStatementsConfigGet(),
         mockAppointmentProductsGet,
         mockAppointmentLocationsGet,
         mockAppointmentCustomerFieldsGet,

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -145,12 +145,6 @@
       "value": "Time"
     }
   ],
-  "8MZ9TV": [
-    {
-      "type": 0,
-      "value": "Please accept the privacy policy before submitting"
-    }
-  ],
   "8wgdHE": [
     {
       "type": 0,
@@ -923,6 +917,12 @@
     {
       "type": 0,
       "value": "Suspending the form failed, please try again later"
+    }
+  ],
+  "rUdi0E": [
+    {
+      "type": 0,
+      "value": "Please check the above declaration before submitting"
     }
   ],
   "sSmY1N": [

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -115,6 +115,12 @@
       "value": "Pay now"
     }
   ],
+  "6ysm6G": [
+    {
+      "type": 0,
+      "value": "You must declare the form to be filled out truthfully before submitting"
+    }
+  ],
   "7Fk8NY": [
     {
       "type": 1,
@@ -143,6 +149,12 @@
     {
       "type": 0,
       "value": "Time"
+    }
+  ],
+  "8MZ9TV": [
+    {
+      "type": 0,
+      "value": "Please accept the privacy policy before submitting"
     }
   ],
   "8wgdHE": [
@@ -917,12 +929,6 @@
     {
       "type": 0,
       "value": "Suspending the form failed, please try again later"
-    }
-  ],
-  "rUdi0E": [
-    {
-      "type": 0,
-      "value": "Please check the above declaration before submitting"
     }
   ],
   "sSmY1N": [

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -145,12 +145,6 @@
       "value": "Tijdstip"
     }
   ],
-  "8MZ9TV": [
-    {
-      "type": 0,
-      "value": "U moet akkoord gaan met het privacybeleid om door te gaan"
-    }
-  ],
   "8wgdHE": [
     {
       "type": 0,
@@ -923,6 +917,12 @@
     {
       "type": 0,
       "value": "Het pauzeren van het formulier is mislukt. Probeer het later opnieuw."
+    }
+  ],
+  "rUdi0E": [
+    {
+      "type": 0,
+      "value": "Please check the above declaration before submitting"
     }
   ],
   "sSmY1N": [

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -115,6 +115,12 @@
       "value": "Nu betalen"
     }
   ],
+  "6ysm6G": [
+    {
+      "type": 0,
+      "value": "You must declare the form to be filled out truthfully before submitting"
+    }
+  ],
   "7Fk8NY": [
     {
       "type": 1,
@@ -143,6 +149,12 @@
     {
       "type": 0,
       "value": "Tijdstip"
+    }
+  ],
+  "8MZ9TV": [
+    {
+      "type": 0,
+      "value": "U moet akkoord gaan met het privacybeleid om door te gaan"
     }
   ],
   "8wgdHE": [
@@ -917,12 +929,6 @@
     {
       "type": 0,
       "value": "Het pauzeren van het formulier is mislukt. Probeer het later opnieuw."
-    }
-  ],
-  "rUdi0E": [
-    {
-      "type": 0,
-      "value": "Please check the above declaration before submitting"
     }
   ],
   "sSmY1N": [

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -84,11 +84,6 @@
     "description": "Appoinments: time select label",
     "originalDefault": "Time"
   },
-  "8MZ9TV": {
-    "defaultMessage": "Please accept the privacy policy before submitting",
-    "description": "Warning privacy policy not checked when submitting",
-    "originalDefault": "Please accept the privacy policy before submitting"
-  },
   "8wgdHE": {
     "defaultMessage": "Log in on behalf of someone else",
     "description": "Log in on behalf of someone else title",
@@ -608,6 +603,11 @@
     "defaultMessage": "Suspending the form failed, please try again later",
     "description": "Modal suspending form failed message",
     "originalDefault": "Suspending the form failed, please try again later"
+  },
+  "rUdi0E": {
+    "defaultMessage": "Please check the above declaration before submitting",
+    "description": "Warning declaration not checked when submitting",
+    "originalDefault": "Please check the above declaration before submitting"
   },
   "sSmY1N": {
     "defaultMessage": "Enter address, please",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -69,6 +69,11 @@
     "description": "Start payment button",
     "originalDefault": "Pay now"
   },
+  "6ysm6G": {
+    "defaultMessage": "You must declare the form to be filled out truthfully before submitting",
+    "description": "Warning statement of truth not checked when submitting",
+    "originalDefault": "You must declare the form to be filled out truthfully before submitting"
+  },
   "7Fk8NY": {
     "defaultMessage": "{name}: {amount}x",
     "description": "Product summary on appointments location and time step",
@@ -83,6 +88,11 @@
     "defaultMessage": "Time",
     "description": "Appoinments: time select label",
     "originalDefault": "Time"
+  },
+  "8MZ9TV": {
+    "defaultMessage": "Please accept the privacy policy before submitting",
+    "description": "Warning privacy policy not checked when submitting",
+    "originalDefault": "Please accept the privacy policy before submitting"
   },
   "8wgdHE": {
     "defaultMessage": "Log in on behalf of someone else",
@@ -603,11 +613,6 @@
     "defaultMessage": "Suspending the form failed, please try again later",
     "description": "Modal suspending form failed message",
     "originalDefault": "Suspending the form failed, please try again later"
-  },
-  "rUdi0E": {
-    "defaultMessage": "Please check the above declaration before submitting",
-    "description": "Warning declaration not checked when submitting",
-    "originalDefault": "Please check the above declaration before submitting"
   },
   "sSmY1N": {
     "defaultMessage": "Enter address, please",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -69,6 +69,11 @@
     "description": "Start payment button",
     "originalDefault": "Pay now"
   },
+  "6ysm6G": {
+    "defaultMessage": "You must declare the form to be filled out truthfully before submitting",
+    "description": "Warning statement of truth not checked when submitting",
+    "originalDefault": "You must declare the form to be filled out truthfully before submitting"
+  },
   "7Fk8NY": {
     "defaultMessage": "{name}: {amount}x",
     "description": "Product summary on appointments location and time step",
@@ -84,6 +89,11 @@
     "defaultMessage": "Tijdstip",
     "description": "Appoinments: time select label",
     "originalDefault": "Time"
+  },
+  "8MZ9TV": {
+    "defaultMessage": "U moet akkoord gaan met het privacybeleid om door te gaan",
+    "description": "Warning privacy policy not checked when submitting",
+    "originalDefault": "Please accept the privacy policy before submitting"
   },
   "8wgdHE": {
     "defaultMessage": "Inloggen voor iemand anders",
@@ -613,11 +623,6 @@
     "defaultMessage": "Het pauzeren van het formulier is mislukt. Probeer het later opnieuw.",
     "description": "Modal suspending form failed message",
     "originalDefault": "Suspending the form failed, please try again later"
-  },
-  "rUdi0E": {
-    "defaultMessage": "Please check the above declaration before submitting",
-    "description": "Warning declaration not checked when submitting",
-    "originalDefault": "Please check the above declaration before submitting"
   },
   "sSmY1N": {
     "defaultMessage": "Enter address, please",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -85,11 +85,6 @@
     "description": "Appoinments: time select label",
     "originalDefault": "Time"
   },
-  "8MZ9TV": {
-    "defaultMessage": "U moet akkoord gaan met het privacybeleid om door te gaan",
-    "description": "Warning privacy policy not checked when submitting",
-    "originalDefault": "Please accept the privacy policy before submitting"
-  },
   "8wgdHE": {
     "defaultMessage": "Inloggen voor iemand anders",
     "description": "Log in on behalf of someone else title",
@@ -618,6 +613,11 @@
     "defaultMessage": "Het pauzeren van het formulier is mislukt. Probeer het later opnieuw.",
     "description": "Modal suspending form failed message",
     "originalDefault": "Suspending the form failed, please try again later"
+  },
+  "rUdi0E": {
+    "defaultMessage": "Please check the above declaration before submitting",
+    "description": "Warning declaration not checked when submitting",
+    "originalDefault": "Please check the above declaration before submitting"
   },
   "sSmY1N": {
     "defaultMessage": "Enter address, please",


### PR DESCRIPTION
Closes open-formulieren/open-forms#3372

Reworked statement checkboxes to not hit the global configuration endpoint, but instead read the configuration from the form data retrieved from the form detail endpoint.

This also sets up the accessible message texts which were a bit too generic.