### PR TITLE
Appointment details: clear dependent field values

### DIFF
--- a/src/components/appointments/DateSelect.js
+++ b/src/components/appointments/DateSelect.js
@@ -1,6 +1,7 @@
 import {Paragraph} from '@utrecht/component-library-react';
 import {eachDayOfInterval, formatISO, parseISO} from 'date-fns';
 import {useFormikContext} from 'formik';
+import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 import {FormattedMessage, defineMessage, useIntl} from 'react-intl';
 import {useAsync} from 'react-use';
@@ -29,7 +30,7 @@ const getDates = async (baseUrl, productIds, locationId) => {
   return results.sort();
 };
 
-const DateSelect = ({products}) => {
+const DateSelect = ({products, onChange}) => {
   const intl = useIntl();
   const {baseUrl} = useContext(ConfigContext);
   const {
@@ -86,12 +87,14 @@ const DateSelect = ({products}) => {
       disabledDates={disabledDays}
       minDate={minDate}
       maxDate={maxDate}
+      onChange={onChange}
     />
   );
 };
 
 DateSelect.propTypes = {
   products: ProductsType.isRequired,
+  onChange: PropTypes.func,
 };
 
 export default DateSelect;

--- a/src/components/appointments/LocationAndTimeStep.js
+++ b/src/components/appointments/LocationAndTimeStep.js
@@ -1,5 +1,5 @@
 import {Heading3, UnorderedList, UnorderedListItem} from '@utrecht/component-library-react';
-import {Form, Formik} from 'formik';
+import {Form, Formik, useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 import {flushSync} from 'react-dom';
@@ -38,15 +38,38 @@ const INITIAL_VALUES = {
 
 const LocationAndTimeStepFields = () => {
   const intl = useIntl();
+  const {values, setFieldValue} = useFormikContext();
   const {
     appointmentData: {products = []},
   } = useCreateAppointmentContext();
+
+  const onFieldChange = event => {
+    const {name, value: newValue} = event.target;
+    const currentValue = values[name];
+
+    if (newValue === currentValue) return;
+
+    switch (name) {
+      case 'location': {
+        setFieldValue('date', '');
+        setFieldValue('datetime', '');
+        break;
+      }
+      case 'date': {
+        setFieldValue('datetime', '');
+        break;
+      }
+      default:
+        throw new Error(`Unknown field: '${name}'`);
+    }
+  };
+
   return (
     // TODO: don't do inline style
     <Form style={{width: '100%'}}>
       <div>
-        <LocationSelect products={products} />
-        <DateSelect products={products} />
+        <LocationSelect products={products} onChange={onFieldChange} />
+        <DateSelect products={products} onChange={onFieldChange} />
         <TimeSelect products={products} />
       </div>
 

--- a/src/components/appointments/LocationAndTimeStep.stories.js
+++ b/src/components/appointments/LocationAndTimeStep.stories.js
@@ -1,5 +1,6 @@
 import {expect} from '@storybook/jest';
-import {within} from '@storybook/testing-library';
+import {userEvent, within} from '@storybook/testing-library';
+import {formatISO} from 'date-fns';
 import {withRouter} from 'storybook-addon-react-router-v6';
 
 import {ConfigDecorator, LayoutDecorator, withCard} from 'story-utils/decorators';
@@ -74,5 +75,41 @@ export const WithBackendErrors = {
     await expect(await canvas.findByText('This date is not available')).toBeVisible();
     const submitButton = canvas.getByRole('button', {name: 'Naar contactgegevens'});
     expect(submitButton).not.toHaveAttribute('aria-disabled', 'true');
+  },
+};
+
+const TODAY = formatISO(new Date(), {representation: 'date'});
+
+export const DependentFieldsReset = {
+  name: 'Dependent fields reset',
+  parameters: {
+    appointmentState: {
+      currentStep: 'kalender',
+      appointmentData: {
+        producten: {
+          products: [{productId: 'e8e045ab', amount: 1}],
+        },
+        kalender: {
+          location: '34000e85',
+          date: TODAY,
+          datetime: '',
+        },
+      },
+    },
+  },
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.getByLabelText('Tijdstip')).not.toBeDisabled();
+
+    await step('Change location', async () => {
+      const dropdown = canvas.getByLabelText('Locatie');
+      await userEvent.click(dropdown);
+      await userEvent.keyboard('[ArrowDown]');
+      await userEvent.click(await canvas.findByText('Open Gem'));
+    });
+
+    expect(canvas.getByLabelText('Datum')).toHaveDisplayValue('');
+    expect(canvas.getByLabelText('Tijdstip')).toBeDisabled();
   },
 };

--- a/src/components/appointments/LocationSelect.js
+++ b/src/components/appointments/LocationSelect.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, {useCallback, useContext} from 'react';
 import {defineMessage, useIntl} from 'react-intl';
 
@@ -30,7 +31,7 @@ export const getLocations = async (baseUrl, productIds) => {
   return locationList;
 };
 
-const LocationSelect = ({products}) => {
+const LocationSelect = ({products, onChange}) => {
   const intl = useIntl();
   const {baseUrl} = useContext(ConfigContext);
   const productIds = products.map(prod => prod.productId).sort(); // sort to get a stable identity
@@ -49,12 +50,14 @@ const LocationSelect = ({products}) => {
       valueProperty="identifier"
       getOptionLabel={location => location.name}
       autoSelectOnlyOption
+      onChange={onChange}
     />
   );
 };
 
 LocationSelect.propTypes = {
   products: ProductsType.isRequired,
+  onChange: PropTypes.func,
 };
 
 export default LocationSelect;

--- a/src/components/forms/DateField/DateField.js
+++ b/src/components/forms/DateField/DateField.js
@@ -30,6 +30,7 @@ const DateField = ({
   maxDate,
   disabledDates = [],
   showFormattedDate = false,
+  onChange,
   ...props
 }) => {
   const {getFieldMeta} = useFormikContext();
@@ -75,6 +76,7 @@ const DateField = ({
           id={id}
           disabled={disabled}
           invalid={invalid}
+          extraOnChange={onChange}
           {...fieldProps}
           {...props}
         />
@@ -99,6 +101,7 @@ DateField.propTypes = {
   disabledDates: PropTypes.arrayOf(PropTypes.string),
   widget: PropTypes.oneOf(WIDGETS),
   showFormattedDate: PropTypes.bool,
+  onChange: PropTypes.func,
 };
 
 export default DateField;

--- a/src/components/forms/DateField/DateInputGroup.js
+++ b/src/components/forms/DateField/DateInputGroup.js
@@ -109,6 +109,7 @@ const DateInputGroup = ({
   label,
   isRequired,
   onChange,
+  extraOnChange,
   disabled = false,
   showFormattedDate = false,
   autoComplete,
@@ -141,7 +142,9 @@ const DateInputGroup = ({
     const newDate = dateFromParts(year, month, day);
 
     // clear value if it's not a valid date or update it if it is valid
-    onChange({target: {name, value: newDate ?? ''}});
+    const _event = {target: {name, value: newDate ?? ''}};
+    onChange(_event);
+    extraOnChange?.(_event);
   };
 
   return (
@@ -171,6 +174,7 @@ DateInputGroup.propTypes = {
   label: PropTypes.node,
   isRequired: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
+  extraOnChange: PropTypes.func,
   disabled: PropTypes.bool,
   showFormattedDate: PropTypes.bool,
   autoComplete: PropTypes.string,

--- a/src/components/forms/DateField/DatePicker.js
+++ b/src/components/forms/DateField/DatePicker.js
@@ -15,7 +15,17 @@ import {useDateLocaleMeta} from './hooks';
 import {PART_PLACEHOLDERS} from './messages';
 import {orderByPart, parseDate} from './utils';
 
-const DatePicker = ({name, label, isRequired, onChange, id, disabled, calendarProps, ...extra}) => {
+const DatePicker = ({
+  name,
+  label,
+  isRequired,
+  onChange,
+  extraOnChange,
+  id,
+  disabled,
+  calendarProps,
+  ...extra
+}) => {
   const intl = useIntl();
   const dateLocaleMeta = useDateLocaleMeta();
   const {getFieldProps, getFieldHelpers} = useFormikContext();
@@ -80,13 +90,17 @@ const DatePicker = ({name, label, isRequired, onChange, id, disabled, calendarPr
             // if we couldn't parse a valid date -> clear the value in the formik state
             // (hitting backspace, deleting the input value completely...)
             if (!newDate) {
-              onChange({target: {name, value: ''}});
+              const _event = {target: {name, value: ''}};
+              onChange(_event);
+              extraOnChange?.(_event);
               return;
             }
 
             // set the ISO-8601 date in the actual form state
             const enteredDate = formatISO(newDate, {representation: 'date'});
-            onChange({target: {name, value: enteredDate}});
+            const _event = {target: {name, value: enteredDate}};
+            onChange(_event);
+            extraOnChange?.(_event);
           }}
           onFocus={event => {
             onFocus(event);
@@ -120,7 +134,9 @@ const DatePicker = ({name, label, isRequired, onChange, id, disabled, calendarPr
           onCalendarClick={selectedDate => {
             flushSync(() => {
               const truncated = selectedDate.substring(0, 10);
-              onChange({target: {name, value: truncated}});
+              const event = {target: {name, value: truncated}};
+              onChange(event);
+              extraOnChange?.(event);
               setIsOpen(false, {keepDismissed: true});
             });
             setTouched(true);
@@ -138,6 +154,7 @@ DatePicker.propTypes = {
   label: PropTypes.node,
   isRequired: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
+  extraOnChange: PropTypes.func,
   id: PropTypes.string,
   disabled: PropTypes.bool,
   calendarProps: PropTypes.shape({

--- a/src/components/forms/SelectField/SelectField.js
+++ b/src/components/forms/SelectField/SelectField.js
@@ -20,6 +20,7 @@ const SelectField = ({
   valueProperty = 'value',
   autoSelectOnlyOption = false,
   validateOnChange = false,
+  onChange,
   ...props
 }) => {
   const {getFieldProps, getFieldHelpers, getFieldMeta} = useFormikContext();
@@ -111,6 +112,7 @@ const SelectField = ({
             const rawValues = normalized.map(val => val?.[valueProperty] ?? null);
             const rawValue = isSingle ? rawValues[0] : rawValues;
             setValue(rawValue, validateOnChange);
+            onChange?.({target: {name, value: rawValue}});
           }}
           value={value}
           onBlur={() => setTouched(true)}
@@ -132,6 +134,10 @@ export const SelectFieldPropTypes = {
   valueProperty: PropTypes.string,
   autoSelectOnlyOption: PropTypes.bool,
   validateOnChange: PropTypes.bool,
+  /**
+   * Optional additional onChange callback.
+   */
+  onChange: PropTypes.func,
 };
 
 SelectField.propTypes = {


### PR DESCRIPTION
Closes #492

I'm not 100% convinced of this pattern yet - the thing is that formik's `Field` component automatically provides the `onChange` handler (and I'd like to keep that), so to do additional work we basically need to make sure to call the original handler.

This handler comes all the way from `formikContext.handleChange` and "wrapping" that thing is not trivial. An alternative would be to rely on `useEffect`, but that complicates things a lot more since you need to track previous values & do the comparisons, plus you require an additional render to actual reset things, while now the entire form values state update is batched in a single `onChange` event handler.

I'd like to let this simmer a bit and use the experience for the upcoming formio-renderer. Perhaps relying on the `Field` component is not suited for our complex cases, and we should build everything directly using formik's `useFormikContext` and/or `useField` hooks to pass the props explicitly, which gives us less "magic" to understand where things are coming from.