### PR TITLE
:lipstick: Fix width of progress indicator

### DIFF
--- a/src/scss/components/_progress-indicator.scss
+++ b/src/scss/components/_progress-indicator.scss
@@ -52,6 +52,8 @@
   @include mobile-only {
     @include margin($grid-container-margin, $properties: (padding-top, padding-bottom));
     box-shadow: var(--of-progress-indicator-mobile-box-shadow);
+    // otherwise the bar is too short, and setting a width creates a horizontal scrollbar
+    width: unset;
 
     // style layout
     @at-root .#{prefix('layout__row')} & {


### PR DESCRIPTION
The bar was not taking up full width due to the negative margin-left and margin-right values, combined with the width: 100% of the parent. Setting the width to calc(100% + 2 * margin) results in a horizontal scrollbar, but unsetting the width fixes the styling on mobile while not destroying it on desktop.