### PR TITLE
:bug: [#3419] tooltips match design-token colour

### DIFF
--- a/src/formio/templates/checkbox.ejs
+++ b/src/formio/templates/checkbox.ejs
@@ -16,7 +16,7 @@
   >
     {{ctx.input.label}}{% if (!ctx.component.validate.required && !ctx.requiredFieldsWithAsterisk) { %}&nbsp;{{ ctx.t('(optional)') }} {% } %}
     {% if (ctx.component.tooltip) { %}
-      <i ref="tooltip" class="{{ctx.iconClass('question-sign')}}" data-tooltip="{{ ctx.tooltip }}"></i>
+      <i ref="tooltip" class="openforms-tooltip-icon {{ctx.iconClass('question-sign')}}" data-tooltip="{{ ctx.tooltip }}"></i>
     {% } %}
   </label>
 </p>

--- a/src/formio/templates/field.ejs
+++ b/src/formio/templates/field.ejs
@@ -13,7 +13,7 @@
             {{ ctx.t('(optional)') }}
           {% } %}
           {% if (ctx.component.tooltip) { %}
-            <i ref="tooltip" class="{{ctx.iconClass('question-sign')}}"data-tooltip="{{ ctx.tooltip }}"></i>
+            <i ref="tooltip" class="openforms-tooltip-icon {{ctx.iconClass('question-sign')}}"data-tooltip="{{ ctx.tooltip }}"></i>
           {% } %}
         </span>
       </legend>


### PR DESCRIPTION
fixes https://github.com/open-formulieren/open-forms/issues/3419

updates class names of tooltip html components