### PR TITLE
Use NL DS components (where possible) for edit grid component

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@floating-ui/react": "^0.24.2",
     "@formio/protected-eval": "^1.2.1",
     "@fortawesome/fontawesome-free": "^6.1.1",
-    "@open-formulieren/design-tokens": "^0.44.1",
+    "@open-formulieren/design-tokens": "^0.45.0",
     "@sentry/react": "^6.13.2",
     "@sentry/tracing": "^6.13.2",
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",

--- a/src/components/EditGrid/EditGrid.js
+++ b/src/components/EditGrid/EditGrid.js
@@ -1,0 +1,39 @@
+import {ButtonGroup} from '@utrecht/component-library-react';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import {OFButton} from 'components/Button';
+import FAIcon from 'components/FAIcon';
+
+const DefaultAddButtonLabel = () => (
+  <>
+    <FAIcon icon="plus" />{' '}
+    <FormattedMessage
+      description="Edit grid add button, default label text"
+      defaultMessage="Add another"
+    />
+  </>
+);
+
+const EditGrid = ({children, onAddItem, addButtonLabel}) => (
+  <div className="openforms-editgrid">
+    <div>{children}</div>
+
+    {onAddItem && (
+      <ButtonGroup>
+        <OFButton type="button" appearance="primary-action-button" onClick={onAddItem}>
+          {addButtonLabel || <DefaultAddButtonLabel />}
+        </OFButton>
+      </ButtonGroup>
+    )}
+  </div>
+);
+
+EditGrid.propTypes = {
+  children: PropTypes.node.isRequired,
+  addButtonLabel: PropTypes.node,
+  onAddItem: PropTypes.func,
+};
+
+export default EditGrid;

--- a/src/components/EditGrid/EditGrid.stories.js
+++ b/src/components/EditGrid/EditGrid.stories.js
@@ -1,0 +1,56 @@
+import Body from 'components/Body';
+import {OFButton} from 'components/Button';
+
+import {EditGrid, EditGridButtonGroup, EditGridItem} from '.';
+
+export default {
+  title: 'Pure React components / EditGrid / EditGrid',
+  component: EditGrid,
+  argTypes: {
+    children: {control: false},
+    onAddItem: {control: false},
+  },
+  args: {
+    children: (
+      <>
+        <EditGridItem
+          heading="Item 1"
+          buttons={
+            <EditGridButtonGroup>
+              <OFButton appearance="primary-action-button">A button</OFButton>
+            </EditGridButtonGroup>
+          }
+        >
+          <Body>First item</Body>
+        </EditGridItem>
+        <EditGridItem
+          heading="Item 2"
+          buttons={
+            <EditGridButtonGroup>
+              <OFButton appearance="primary-action-button">A button</OFButton>
+            </EditGridButtonGroup>
+          }
+        >
+          <Body>Second item</Body>
+        </EditGridItem>
+      </>
+    ),
+  },
+  parameters: {
+    controls: {sort: 'requiredFirst'},
+  },
+};
+
+export const WithAddButton = {};
+
+export const WithCustomAddButtonLabel = {
+  args: {
+    addButtonLabel: 'Custom add button label',
+  },
+};
+
+export const WithoutAddbutton = {
+  args: {
+    onAddItem: undefined,
+  },
+};

--- a/src/components/EditGrid/EditGridButtonGroup.js
+++ b/src/components/EditGrid/EditGridButtonGroup.js
@@ -1,0 +1,13 @@
+import {ButtonGroup} from '@utrecht/component-library-react';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const EditGridButtonGroup = ({children}) => (
+  <ButtonGroup className="utrecht-button-group--openforms-editgrid">{children}</ButtonGroup>
+);
+
+EditGridButtonGroup.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+};
+
+export default EditGridButtonGroup;

--- a/src/components/EditGrid/EditGridItem.js
+++ b/src/components/EditGrid/EditGridItem.js
@@ -1,0 +1,21 @@
+import {Fieldset, FieldsetLegend} from '@utrecht/component-library-react';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const EditGridItem = ({heading, children: body, buttons}) => {
+  return (
+    <Fieldset className="openforms-editgrid__item">
+      <FieldsetLegend className="openforms-editgrid__item-heading">{heading}</FieldsetLegend>
+      {body}
+      {buttons}
+    </Fieldset>
+  );
+};
+
+EditGridItem.propTypes = {
+  heading: PropTypes.node.isRequired,
+  children: PropTypes.node,
+  buttons: PropTypes.node,
+};
+
+export default EditGridItem;

--- a/src/components/EditGrid/EditGridItem.stories.js
+++ b/src/components/EditGrid/EditGridItem.stories.js
@@ -1,0 +1,30 @@
+import Body from 'components/Body';
+import {OFButton} from 'components/Button';
+
+import {EditGridButtonGroup, EditGridItem as EditGridItemComponent} from '.';
+
+export default {
+  title: 'Pure React components / EditGrid / Item',
+  component: EditGridItemComponent,
+  argTypes: {
+    children: {control: false},
+    buttons: {control: false},
+  },
+  args: {
+    heading: 'Item heading',
+    children: <Body>Item body, typically form fields</Body>,
+    buttons: (
+      <EditGridButtonGroup>
+        <OFButton appearance="primary-action-button">Save</OFButton>
+        <OFButton appearance="primary-action-button" hint="danger">
+          Remove
+        </OFButton>
+      </EditGridButtonGroup>
+    ),
+  },
+  parameters: {
+    controls: {sort: 'requiredFirst'},
+  },
+};
+
+export const Item = {};

--- a/src/components/EditGrid/design-tokens.mdx
+++ b/src/components/EditGrid/design-tokens.mdx
@@ -1,0 +1,73 @@
+import ofTokens from '@open-formulieren/design-tokens/dist/tokens';
+import {Meta} from '@storybook/addon-docs';
+import utrechtTokens from '@utrecht/design-tokens/dist/tokens';
+import TokensTable from 'design-token-editor/lib/esm/TokensTable';
+
+<Meta title="Pure React components / EditGrid" name="Design tokens" />
+
+## Available design tokens
+
+**Open Forms specific tokens**
+
+<TokensTable container={ofTokens} limitTo="of.editgrid" autoExpand />
+
+**Utrecht tokens**
+
+Under the hood, the following components & tokens are used & can be leveraged to change the
+appearance of the editgrid component.
+
+- `utrecht.button-group`
+- `utrecht.form-fieldset`
+
+## Updating your theme
+
+Before SDK 1.6, the CSS for edit grid was hardcoded. With 1.6, this is now parametrized, but there
+are no backwards compatible defaults set. To recover the original styles, use the following tokens:
+
+```json
+{
+  "of": {
+    "editgrid": {
+      "line-height": {"value": 1.5},
+      "gap": {"value": "12px"},
+
+      "item": {
+        "gap": {"value": "12px"},
+        "border": {"value": "solid 1px {of.color.border}"},
+        "padding-block-end": {"value": "24px"},
+        "padding-block-start": {"value": "24px"},
+        "padding-inline-end": {"value": "24px"},
+        "padding-inline-start": {"value": "24px"}
+      },
+
+      "item-heading": {
+        "font-family": {"value": "{of.typography.sans-serif.font-family}"},
+        "font-size": {"value": "0.875rem"},
+        "line-height": {"value": "1.2"},
+        "margin-block-end": {"value": "24px"}
+      }
+    }
+  }
+}
+```
+
+or in CSS:
+
+```css
+.your-theme {
+  --of-editgrid-item-border: solid 1px var(--of-color-border);
+  --of-editgrid-item-gap: 12px;
+  --of-editgrid-item-padding-block-end: 24px;
+  --of-editgrid-item-padding-block-start: 24px;
+  --of-editgrid-item-padding-inline-start: 24px;
+  --of-editgrid-item-padding-inline-end: 24px;
+
+  --of-editgrid-item-heading-font-family: var(--of-typography-sans-serif-font-family);
+  --of-editgrid-item-heading-font-size: 0.875rem;
+  --of-editgrid-item-heading-line-height: 1.2;
+  --of-editgrid-item-heading-margin-block-end: 24px;
+
+  --of-editgrid-line-height: 1.5;
+  --of-editgrid-gap: 12p;
+}
+```

--- a/src/components/EditGrid/index.js
+++ b/src/components/EditGrid/index.js
@@ -1,0 +1,3 @@
+export {default as EditGridButtonGroup} from './EditGridButtonGroup';
+export {default as EditGridItem} from './EditGridItem';
+export {default as EditGrid} from './EditGrid';

--- a/src/components/appointments/steps/ChooseProductStep.js
+++ b/src/components/appointments/steps/ChooseProductStep.js
@@ -10,11 +10,10 @@ import {toFormikValidationSchema} from 'zod-formik-adapter';
 
 import {OFButton} from 'components/Button';
 import {CardTitle} from 'components/Card';
+import {EditGrid, EditGridButtonGroup, EditGridItem} from 'components/EditGrid';
 import FAIcon from 'components/FAIcon';
-import {Toolbar, ToolbarList} from 'components/Toolbar';
 import useQuery from 'hooks/useQuery';
 import useTitle from 'hooks/useTitle';
-import {getBEMClassName} from 'utils';
 
 import {AppointmentConfigContext} from '../Context';
 import {useCreateAppointmentContext} from '../CreateAppointment/CreateAppointmentState';
@@ -61,37 +60,34 @@ const ChooseProductStepFields = ({values: {products = []}, validateForm}) => {
     <Form style={{width: '100%'}}>
       <FieldArray name="products">
         {arrayHelpers => (
-          <div className={getBEMClassName('editgrid')}>
-            <div className={getBEMClassName('editgrid__groups')}>
-              {products.map(({productId}, index) => (
-                // blank blocks don't have a product selected yet -> so the index is added
-                // to make the key guaranteed unique
-                <ProductWrapper
-                  key={`${productId}-${index}`}
-                  index={index}
-                  numProducts={numProducts}
-                  onRemove={withValidate(() => arrayHelpers.remove(index))}
-                >
-                  <Product namePrefix="products" index={index} selectedProducts={products} />
-                </ProductWrapper>
-              ))}
-            </div>
-
-            {supportsMultipleProducts && (
-              <div className={getBEMClassName('editgrid__add-button')}>
-                <OFButton
-                  appearance="primary-action-button"
-                  onClick={withValidate(() => arrayHelpers.push({productId: '', amount: 1}))}
-                >
-                  <FAIcon icon="plus" />
-                  <FormattedMessage
-                    description="Appointments: add additional product/service button text"
-                    defaultMessage="Add another product"
-                  />
-                </OFButton>
-              </div>
-            )}
-          </div>
+          <EditGrid
+            addButtonLabel={
+              <>
+                <FAIcon icon="plus" />{' '}
+                <FormattedMessage
+                  description="Appointments: add additional product/service button text"
+                  defaultMessage="Add another product"
+                />
+              </>
+            }
+            onAddItem={
+              supportsMultipleProducts &&
+              withValidate(() => arrayHelpers.push({productId: '', amount: 1}))
+            }
+          >
+            {products.map(({productId}, index) => (
+              // blank blocks don't have a product selected yet -> so the index is added
+              // to make the key guaranteed unique
+              <ProductWrapper
+                key={`${productId}-${index}`}
+                index={index}
+                numProducts={numProducts}
+                onRemove={withValidate(() => arrayHelpers.remove(index))}
+              >
+                <Product namePrefix="products" index={index} selectedProducts={products} />
+              </ProductWrapper>
+            ))}
+          </EditGrid>
         )}
       </FieldArray>
 
@@ -118,31 +114,31 @@ const ProductWrapper = ({index, numProducts, onRemove, children}) => {
   if (!supportsMultipleProducts) {
     return <>{children}</>;
   }
+
+  const buttonRow = numProducts > 1 && (
+    <EditGridButtonGroup>
+      <OFButton appearance="primary-action-button" hint="danger" onClick={onRemove}>
+        <FormattedMessage
+          description="Appointments: remove product/service button text"
+          defaultMessage="Remove"
+        />
+      </OFButton>
+    </EditGridButtonGroup>
+  );
+
   return (
-    <div className={getBEMClassName('editgrid__group')}>
-      <div className={getBEMClassName('editgrid__group-label')}>
+    <EditGridItem
+      heading={
         <FormattedMessage
           description="Appointments: single product label/header"
           defaultMessage="Product {number}/{total}"
           values={{number: index + 1, total: numProducts}}
         />
-      </div>
-
+      }
+      buttons={buttonRow}
+    >
       {children}
-
-      {numProducts > 1 && (
-        <Toolbar modifiers={['reverse']}>
-          <ToolbarList>
-            <OFButton appearance="primary-action-button" hint="danger" onClick={onRemove}>
-              <FormattedMessage
-                description="Appointments: remove product/service button text"
-                defaultMessage="Remove"
-              />
-            </OFButton>
-          </ToolbarList>
-        </Toolbar>
-      )}
-    </div>
+    </EditGridItem>
   );
 };
 

--- a/src/formio/templates/editGrid.ejs
+++ b/src/formio/templates/editGrid.ejs
@@ -1,42 +1,53 @@
-<div class="{{ctx.ofPrefix}}editgrid">
-  <div class="{{ctx.ofPrefix}}editgrid__groups">
-    <ul>
-      {% ctx.rows.forEach(function(row, rowIndex) { %}
-      <div class="{{ctx.ofPrefix}}editgrid__group">
-				{% if (!!ctx.component.groupLabel) { %}<div class="{{ctx.ofPrefix}}editgrid__group-label">{{ ctx.t(ctx.component.groupLabel, { _userInput: true }) }} {{ rowIndex + 1 }}</div>{% } %}
-        <li class="{{ctx.ofPrefix}}editgrid__list" ref="{{ctx.ref.row}}">
-          {{row}}
+<div class="openforms-editgrid">
+  {% if(ctx.rows.length) { %}
+  <div>
+    {% ctx.rows.forEach(function(row, rowIndex) { %}
+      <div class="utrecht-form-fieldset openforms-editgrid__item">
+        <fieldset class="utrecht-form-fieldset__fieldset utrecht-form-fieldset--html-fieldset">
+          {% if (!!ctx.component.groupLabel) { %}
+            <legend class="utrecht-form-fieldset__legend utrecht-form-fieldset__legend--html-legend openforms-editgrid__item-heading">
+              {{ ctx.t(ctx.component.groupLabel, { _userInput: true }) }} {{ rowIndex + 1 }}
+            </legend>
+          {% } %}
+
+          <div ref="{{ctx.ref.row}}">{{row}}</div>
 
           {% if (ctx.openRows[rowIndex] && !ctx.readOnly) { %}
-          <div class="{{ctx.ofPrefix}}editgrid__group-actions {{ctx.ofPrefix}}toolbar {{ctx.ofPrefix}}toolbar--reverse">
-              <ul class="{{ctx.ofPrefix}}toolbar__list">
-              <li class="{{ctx.ofPrefix}}toolbar__list-item">
-                <button class="utrecht-button utrecht-button--primary-action" ref="{{ctx.ref.saveRow}}">{{ctx.t(ctx.component.saveRow || 'Save', { _userInput: true })}}</button>
-              </li>
+            <p
+              class="utrecht-button-group utrecht-button-group--openforms-editgrid"
+              {% if (ctx.component.removeRow) { %}role="group"{% } %}
+            >
+
+              <button class="utrecht-button utrecht-button--primary-action" ref="{{ctx.ref.saveRow}}">
+                {{ctx.t(ctx.component.saveRow || 'Save', { _userInput: true })}}
+              </button>
+
               {% if (ctx.component.removeRow) { %}
-                  <li class="{{ctx.ofPrefix}}toolbar__list-item">
-              <button class="utrecht-button utrecht-button--primary-action utrecht-button--danger" ref="{{ctx.ref.cancelRow}}">{{ctx.t(ctx.component.removeRow || 'Cancel', { _userInput: true })}}</button>
-                  </li>
+                <button class="utrecht-button utrecht-button--primary-action utrecht-button--danger" ref="{{ctx.ref.cancelRow}}">
+                  {{ctx.t(ctx.component.removeRow || 'Cancel', { _userInput: true })}}
+                </button>
               {% } %}
-              </ul>
-          </div>
+            </p>
           {% } %}
 
           <!-- Formio needs a div with class="has-error" with inside a div with class="editgrid-row-error" -->
-          <div class="{{ctx.ofPrefix}}errors has-error">
+          <div class="openforms-errors has-error">
             <div class="editgrid-row-error">{{ctx.errors[rowIndex]}}</div>
           </div>
-        </li>
+
+        </fieldset>
       </div>
-      {% }) %}
-    </ul>
+
+    {% }) %}
   </div>
+  {% } %}
 
   {% if (!ctx.readOnly && ctx.hasAddButton) { %}
-  <div class="{{ctx.ofPrefix}}editgrid__add-button">
-    <button class="utrecht-button utrecht-button--primary-action" ref="{{ctx.ref.addRow}}">
-      <i class="{{ctx.iconClass('plus')}}"></i> {{ctx.t(ctx.component.addAnother || 'Add Another', { _userInput: true })}}
-    </button>
-  </div>
+    <p class="utrecht-button-group">
+      <button class="utrecht-button utrecht-button--primary-action" ref="{{ctx.ref.addRow}}">
+        <i class="{{ctx.iconClass('plus')}}"></i>
+        {{ctx.t(ctx.component.addAnother || 'Add Another', { _userInput: true })}}
+      </button>
+    </p>
   {% } %}
 </div>

--- a/src/formio/templates/editGridRow.ejs
+++ b/src/formio/templates/editGridRow.ejs
@@ -1,20 +1,16 @@
-<div class="{{ctx.ofPrefix}}editgrid__row">
-    {% for (const key in ctx.flattenedComponents) { %}
-        {% if (ctx.isVisibleInRow(ctx.flattenedComponents[key])) { %}
-            <div>{{ctx.flattenedComponents[key].label}}: {{ ctx.getView(ctx.flattenedComponents[key], ctx.row[key]) }}</div>
-        {% } %}
-    {% } %}
-
-  {% if (!ctx.self.options.readOnly) { %}
-    <div class="{{ctx.ofPrefix}}toolbar {{ctx.ofPrefix}}toolbar--reverse">
-        <ul class="{{ctx.ofPrefix}}toolbar__list">
-            <li class="{{ctx.ofPrefix}}toolbar__list-item">
-                <button class="utrecht-button utrecht-button--secondary-action editRow"><i class="{{ ctx.iconClass('edit') }}"></i></button>
-            </li>
-            <li class="{{ctx.ofPrefix}}toolbar__list-item">
-                <button class="utrecht-button utrecht-button--primary-action utrecht-button--danger removeRow"><i class="{{ ctx.iconClass('trash-can') }}"></i></button>
-            </li>
-        </ul>
-    </div>
+  {% for (const key in ctx.flattenedComponents) { %}
+      {% if (ctx.isVisibleInRow(ctx.flattenedComponents[key])) { %}
+          <div>{{ctx.flattenedComponents[key].label}}: {{ ctx.getView(ctx.flattenedComponents[key], ctx.row[key]) }}</div>
+      {% } %}
   {% } %}
-</div>
+
+{% if (!ctx.self.options.readOnly) { %}
+  <p class="utrecht-button-group utrecht-button-group--openforms-editgrid" role="group">
+    <button class="utrecht-button utrecht-button--secondary-action editRow">
+      <i class="{{ ctx.iconClass('edit') }}"></i>
+    </button>
+    <button class="utrecht-button utrecht-button--primary-action utrecht-button--danger removeRow">
+      <i class="{{ ctx.iconClass('trash-can') }}"></i>
+    </button>
+  </p>
+{% } %}

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -1175,6 +1175,12 @@
       "value": "Your payment is received and processed."
     }
   ],
+  "cKFCTI": [
+    {
+      "type": 0,
+      "value": "Add another"
+    }
+  ],
   "cxDC/G": [
     {
       "type": 0,

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -1179,6 +1179,12 @@
       "value": "Uw betaling is ontvangen en verwerkt."
     }
   ],
+  "cKFCTI": [
+    {
+      "type": 0,
+      "value": "Nog één toevoegen"
+    }
+  ],
   "cxDC/G": [
     {
       "type": 0,

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -544,6 +544,11 @@
     "description": "payment registered status",
     "originalDefault": "Your payment is received and processed."
   },
+  "cKFCTI": {
+    "defaultMessage": "Add another",
+    "description": "Edit grid add button, default label text",
+    "originalDefault": "Add another"
+  },
   "cxDC/G": {
     "defaultMessage": "The required field is not filled out.",
     "description": "ZOD 'required' error message",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -550,6 +550,11 @@
     "description": "payment registered status",
     "originalDefault": "Your payment is received and processed."
   },
+  "cKFCTI": {
+    "defaultMessage": "Nog één toevoegen",
+    "description": "Edit grid add button, default label text",
+    "originalDefault": "Add another"
+  },
   "cxDC/G": {
     "defaultMessage": "Het verplichte veld is niet ingevuld.",
     "description": "ZOD 'required' error message",

--- a/src/scss/components/_button-group.scss
+++ b/src/scss/components/_button-group.scss
@@ -1,0 +1,23 @@
+/**
+ * Extensions on the Utrecht button-group community component.
+ */
+@use 'microscope-sass/lib/bem';
+
+@import '@utrecht/components/button-group/css/index';
+
+.utrecht-button-group {
+  // A button group used in an edit grid item
+  @include bem.modifier('openforms-editgrid') {
+    // there currently does not exist a design token in the upstream component, and
+    // the alignment is also contextual, so we opt for an open-forms extension that
+    // can be tweaked with proprietary design tokens.
+    justify-content: var(--of-button-group-editgrid-justify-content, flex-end);
+  }
+}
+
+// Reference: https://nl-design-system.github.io/utrecht/storybook/?path=/docs/css_css-button-group--docs
+@include mobile-only {
+  .utrecht-button-group {
+    @include utrecht-button-group--vertical;
+  }
+}

--- a/src/scss/components/_editgrid.scss
+++ b/src/scss/components/_editgrid.scss
@@ -1,42 +1,54 @@
-@import '~microscope-sass/lib/color';
-@import '~microscope-sass/lib/typography';
+/**
+ * The Utrecht community components do not seem to have a ready-to-use component
+ * for the edit grid layout, so we can't shake of some custom CSS yet.
+ */
+@use 'microscope-sass/lib/bem';
 
-@import '../mixins/prefix';
+.openforms-editgrid {
+  line-height: var(--of-editgrid-line-height, var(--utrecht-document-line-height));
 
-.#{prefix(editgrid)} {
-  @include body;
+  display: flex;
+  flex-direction: column;
+  gap: var(--of-editgrid-gap);
 
-  ul {
-    padding: 0;
-  }
+  @include bem.element('item') {
+    // NL DS markup uses a field with nested fieldset element inside
+    .utrecht-form-fieldset__fieldset {
+      display: flex;
+      flex-direction: column;
+      gap: var(--of-editgrid-item-gap);
+    }
 
-  &__group {
-    padding: $grid-margin-4;
-    border-style: solid;
-    border-width: thin;
-    border-color: $color-border;
+    border: var(--of-editgrid-item-border);
+    max-inline-size: var(--of-editgrid-item-max-inline-size);
+    padding-block-end: var(--of-editgrid-item-padding-block-end);
+    padding-block-start: var(--of-editgrid-item-padding-block-start);
+    padding-inline-end: var(--of-editgrid-item-padding-inline-end);
+    padding-inline-start: var(--of-editgrid-item-padding-inline-start);
 
-    &:not(:first-child) {
-      border-top-style: none;
+    // ensure borders are 'collapsed'
+    & + .openforms-editgrid__item {
+      border-block-start: none;
     }
   }
 
-  &__group-label {
-    @include h4;
-    padding-bottom: $grid-margin-4;
-  }
-
-  &__list {
-    list-style: none;
-  }
-
-  &__group-actions {
-    padding-top: $grid-margin-2;
-  }
-
-  &__add-button {
-    display: flex;
-    width: 100%;
-    padding: $grid-margin-2 0;
+  @include bem.element('item-heading') {
+    font-family: var(
+      --of-editgrid-item-heading-font-family,
+      var(--utrecht-form-fieldset-legend-font-family, var(--utrecht-document-font-family))
+    );
+    font-size: var(
+      --of-editgrid-item-heading-font-size,
+      var(--utrecht-form-fieldset-legend-font-size)
+    );
+    line-height: var(
+      --of-editgrid-item-heading-line-height,
+      var(--utrecht-form-fieldset-legend-line-height)
+    );
+    // display: contents was considered, but that doesn't allow specifying different
+    // margins/paddings at the bottom to create extra space :(
+    // legend element doesn't care about the fieldset itself having display: flex, so we
+    // must treat this specially
+    margin-block-end: var(--of-editgrid-item-heading-margin-block-end, var(--of-editgrid-item-gap));
   }
 }

--- a/src/scss/components/_language-selection.scss
+++ b/src/scss/components/_language-selection.scss
@@ -1,7 +1,6 @@
 @import '~microscope-sass/lib/typography';
 
 @import '@utrecht/components/dist/alternate-lang-nav/css/index.css';
-@import '@utrecht/components/dist/button-group/css/index.css';
 
 /**
  * Allow using different spacing rules for this specific component

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -24,6 +24,7 @@
 @import './scss/components/alert';
 @import './scss/components/anchor';
 @import './scss/components/button';
+@import './scss/components/button-group';
 @import './scss/components/card';
 @import './scss/components/content';
 @import './scss/components/errors';


### PR DESCRIPTION
Partially closes #454
Depends on open-formulieren/design-tokens#36

The markup is now more accessible and the theming of the edit grid can be done through design tokens. I tried to go shopping in the utrecht component library but couldn't find any appropriate existing components.

Tasks:

- [x] Use `ButtonGroup` component for button row
- [x] Refactor appointments product step to use broken out edit grid components
- [x] Refactor markup + classnames of formio edit grid template