### PR TITLE
✨ [open-formulieren/open-forms#2952] Support form steps to be N/A by default

### DIFF
--- a/src/components/ProgressIndicator/index.js
+++ b/src/components/ProgressIndicator/index.js
@@ -86,7 +86,7 @@ const ProgressIndicator = ({
       to: step.href || `/stap/${step.slug}`,
       formDefinition: step.formDefinition,
       isCompleted: submission ? submission.steps[index].completed : false,
-      isApplicable: submission ? submission.steps[index].isApplicable : true,
+      isApplicable: submission ? submission.steps[index].isApplicable : step.isApplicable ?? true,
       isCurrent: step.slug === stepSlug,
       canNavigateTo: canNavigateToStep(index),
     }));
@@ -131,6 +131,7 @@ ProgressIndicator.propTypes = {
       slug: PropTypes.string.isRequired,
       href: PropTypes.string,
       formDefinition: PropTypes.string.isRequired,
+      isApplicable: PropTypes.bool,
     })
   ).isRequired,
   submissionAllowed: PropTypes.oneOf(Object.values(SUBMISSION_ALLOWED)).isRequired,


### PR DESCRIPTION
Fixes open-formulieren/open-forms#2952
Part of https://github.com/open-formulieren/open-forms/pull/3551

Tests were refactored to use testing-library where possible (i.e. when using aria roles was possible)