### PR TITLE
[#524] Improve input element accessibility

### DIFF
--- a/src/formio/templates/label.ejs
+++ b/src/formio/templates/label.ejs
@@ -2,6 +2,7 @@
   <label
     class="utrecht-form-label {{ctx.label.className}} {% if (ctx.component.validate.required && ctx.requiredFieldsWithAsterisk) { %}utrecht-form-label--openforms-required{% } %}"
     for="{{ctx.instance.id}}-{{ctx.component.key}}"
+    id="label-{{ctx.instance.id}}-{{ctx.component.key}}"
   >
     {{ ctx.t(ctx.component.label, { _userInput: true }) }}
     {% if (!ctx.component.validate.required && !ctx.requiredFieldsWithAsterisk) { %}

--- a/src/formio/templates/label.ejs
+++ b/src/formio/templates/label.ejs
@@ -2,7 +2,9 @@
   <label
     class="utrecht-form-label {{ctx.label.className}} {% if (ctx.component.validate.required && ctx.requiredFieldsWithAsterisk) { %}utrecht-form-label--openforms-required{% } %}"
     for="{{ctx.instance.id}}-{{ctx.component.key}}"
-    id="label-{{ctx.instance.id}}-{{ctx.component.key}}"
+    {% if (ctx.component.suffix) { %}
+      id="label-{{ctx.instance.id}}-{{ctx.component.key}}"
+    {% } %}
   >
     {{ ctx.t(ctx.component.label, { _userInput: true }) }}
     {% if (!ctx.component.validate.required && !ctx.requiredFieldsWithAsterisk) { %}

--- a/src/formio/templates/text.ejs
+++ b/src/formio/templates/text.ejs
@@ -16,6 +16,7 @@
   {{attr}}="{{ctx.input.attr[attr]}}"
   {% } %}
   id="{{ctx.instance.id}}-{{ctx.component.key}}"
+  aria-labelledby="label-{{ctx.instance.id}}-{{ctx.component.key}} {{ctx.instance.id}}-{{ctx.component.key}} suffix-{{ctx.instance.id}}-{{ctx.component.key}}"
 >{{ctx.input.content}}</{{ctx.input.type}}>
 {% if (ctx.component.showCharCount) { %}
 <span class="charcount" ref="charcount"></span>
@@ -24,7 +25,7 @@
 <span class="wordcount" ref="wordcount"></span>
 {% } %}
 {% if (ctx.suffix) { %}
-<span class="{{ctx.ofPrefix}}input-container__affix {{ctx.ofPrefix}}input-container__affix--suffix" ref="suffix">
+<span class="{{ctx.ofPrefix}}input-container__affix {{ctx.ofPrefix}}input-container__affix--suffix" ref="suffix" id="suffix-{{ctx.instance.id}}-{{ctx.component.key}}">
     {% if(ctx.suffix instanceof HTMLElement){ %}
       {{ ctx.t(ctx.suffix.outerHTML) }}
     {% } else{ %}

--- a/src/formio/templates/text.ejs
+++ b/src/formio/templates/text.ejs
@@ -16,7 +16,9 @@
   {{attr}}="{{ctx.input.attr[attr]}}"
   {% } %}
   id="{{ctx.instance.id}}-{{ctx.component.key}}"
-  aria-labelledby="label-{{ctx.instance.id}}-{{ctx.component.key}} {{ctx.instance.id}}-{{ctx.component.key}} suffix-{{ctx.instance.id}}-{{ctx.component.key}}"
+  {% if (ctx.suffix) { %}
+    aria-labelledby="label-{{ctx.instance.id}}-{{ctx.component.key}} {{ctx.instance.id}}-{{ctx.component.key}} suffix-{{ctx.instance.id}}-{{ctx.component.key}}"
+  {% } %}
 >{{ctx.input.content}}</{{ctx.input.type}}>
 {% if (ctx.component.showCharCount) { %}
 <span class="charcount" ref="charcount"></span>


### PR DESCRIPTION
Fixes #524

A new attribute has been added (`aria-labelledby`) in order to combine multiple elements (`label`, `span`) and have a proper accessible name. This attribute identifies the element (or elements) that labels the element it is applied to. This was tested with Orca screen reader in Ubuntu (`super+alt+s` to enable it).

**References**:
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby
https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA16 (example 3)
https://help.gnome.org/users/orca/stable/index.html.en

**Some remarks:**

- `aria-labelledby` can be used to reference another element to define its accessible name, when an element's accessible name needs to use content from elsewhere in the DOM

- The `aria-labelledby` property value can include content from elements that aren't even visible (CSS display: none, and CSS visibility: hidden)

