### PR TITLE
Collapse vertical spacing for hidden components

### DIFF
--- a/src/formio/components/composite.stories.js
+++ b/src/formio/components/composite.stories.js
@@ -110,3 +110,28 @@ export const WithValidationErrors = {
     await userEvent.click(canvas.getByRole('button'));
   },
 };
+
+export const WithHiddenComponent = {
+  render: MultipleFormioComponents,
+
+  args: {
+    components: [
+      {
+        type: 'textfield',
+        key: 'textfield1',
+        label: 'Field 1: visible',
+      },
+      {
+        type: 'textfield',
+        key: 'textfield2',
+        label: 'Field 2: hidden',
+        hidden: true,
+      },
+      {
+        type: 'textfield',
+        key: 'textfield3',
+        label: 'Field 3: visible',
+      },
+    ],
+  },
+};

--- a/src/formio/templates/component.ejs
+++ b/src/formio/templates/component.ejs
@@ -1,5 +1,5 @@
-<div id="{{ctx.id}}" class="" {% if (ctx.styles) { %} styles="{{ctx.styles}}"{% } %} ref="component">
-    {% if (ctx.visible) { %}
-      {{ctx.children}}
-    {% } %}
+<div id="{{ctx.id}}" class="{% if (! ctx.visible) { %}formio-component formio-component--hidden{% } %}" {% if (ctx.styles) { %} styles="{{ctx.styles}}"{% } %} ref="component">
+  {% if (ctx.visible) { %}
+    {{ctx.children}}
+  {% } %}
 </div>

--- a/src/scss/components/_formio-component.scss
+++ b/src/scss/components/_formio-component.scss
@@ -1,3 +1,5 @@
+@use 'microscope-sass/lib/bem';
+
 @use '@utrecht/components/form-field/css/mixin' as form-field;
 @use '@utrecht/components/form-fieldset/css/mixin' as form-fieldset;
 
@@ -28,4 +30,13 @@
 // disable default formio styles
 .field-required:after {
   all: revert;
+}
+
+// we only set these class names when the component is (dynamically) hidden, as
+// otherwise the empty div causes flexbox gap to be applied before and after it,
+// messing up the spacing. See https://github.com/open-formulieren/open-forms/issues/3485
+.formio-component {
+  @include bem.modifier('hidden') {
+    display: none;
+  }
 }


### PR DESCRIPTION
Closes open-formulieren/open-forms#3485

Mark a hidden component with a CSS class and apply display: none in CSS.

Other options considered but not viable:

* targetting :empty -> doesn't work because the template renders whitespace in the div and afaik there's no {% spaceless %} tag in EJS
* not rendering the ref=component node if it's not visible -> doesn't work because then dynamically toggling from hidden to visible fails to render the now-visible field, as formio doesn't find the component ref to mount the DOM node under