### PR TITLE
A couple more button tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@floating-ui/react": "^0.24.2",
     "@formio/protected-eval": "^1.2.1",
     "@fortawesome/fontawesome-free": "^6.1.1",
-    "@open-formulieren/design-tokens": "^0.45.0",
+    "@open-formulieren/design-tokens": "^0.45.1",
     "@sentry/react": "^6.13.2",
     "@sentry/tracing": "^6.13.2",
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
     "css-loader": "^6.5.1",
     "css-minimizer-webpack-plugin": "^3.2.0",
-    "design-token-editor": "^0.3.0",
+    "design-token-editor": "^0.5.0",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
     "ejs-loader": "^0.5.0",

--- a/src/components/Button/design-tokens.mdx
+++ b/src/components/Button/design-tokens.mdx
@@ -3,13 +3,9 @@ import {Meta} from '@storybook/addon-docs';
 import utrechtTokens from '@utrecht/design-tokens/dist/tokens';
 import TokensTable from 'design-token-editor/lib/esm/TokensTable';
 
-<Meta title="Pure React components/Button" name="Design tokens" />
+<Meta title="Pure React components/OF Button" name="Design tokens" />
 
 ## Available design tokens
-
-**Open Forms specific tokens**
-
-<TokensTable container={ofTokens} limitTo="of.button." autoExpand />
 
 **Utrecht button tokens**
 

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -18,8 +18,7 @@
 
     // approximate browser default behaviour for focus outline
     &:focus-visible {
-      border-radius: 3px;
-      border-color: transparent;
+      --utrecht-button-border-radius: 2px;
     }
   }
 }

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -15,5 +15,11 @@
         border-inline-start-color: transparent;
       }
     }
+
+    // approximate browser default behaviour for focus outline
+    &:focus-visible {
+      border-radius: 3px;
+      border-color: transparent;
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7395,10 +7395,10 @@ dequal@^2.0.2, dequal@^2.0.3:
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
 
-design-token-editor@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/design-token-editor/-/design-token-editor-0.3.0.tgz#9d0fe24726c23ec547939de9563d9980abb6f033"
-  integrity sha512-RpN8ZdbSPm8TqDVoMhzjriNjK80pIqlQPnFUYxcLVoHkcUexepFilqUs0Oi4WcTTvqK9o7yclbNWvOWggmxBIg==
+design-token-editor@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/design-token-editor/-/design-token-editor-0.5.0.tgz#6f942e9a5be100f702d470d593e9669c43c709f4"
+  integrity sha512-DDg4dGfxI9mDtqgYMlIXn74CANrG7y7ojpAIfSO5i0dMaSp46epusheyB7mP4TsDMrnzPvrxxtQgGs9VFEMieA==
   dependencies:
     clsx "^1.2.1"
     color "^4.2.3"


### PR DESCRIPTION
I wasn't entirely satisfied yet with the changed focus ring on the button, and as there is no border-width design token for focus states, I think a CSS override in our own theme is the only viable option, but please convince me that I'm wrong!

I've also updated the design token documentation in storybook.