### PR TITLE
🐛 Fix potential race condition on WebKit

### DIFF
--- a/src/components/FormStep/index.js
+++ b/src/components/FormStep/index.js
@@ -414,7 +414,7 @@ const FormStep = ({
    *
    *   - `LOGIC_CHECK_INTERRUPTED` When there's no point/change in state to be expected by the logic
    *       check
-   *   - `BLOCK_SUBMISSION` When the the logic is checking and the form should be disabled for
+   *   - `BLOCK_SUBMISSION` When the logic is checking and the form should be disabled for
    *       submission.
    *   - `LOGIC_CHECK_DONE` When the logic check is done and the form should be enabled for
    *       submission.
@@ -751,7 +751,7 @@ const FormStep = ({
    *
    * During evaluation, the following actions are/may be dispatched:
    *
-   *   - `BLOCK_SUBMISSION` When the the form midfier by a humer (`modifiedByHuman`)  and the form
+   *   - `BLOCK_SUBMISSION` When the form was modified by a human (`modifiedByHuman`)  and the form
    *       should be disabled for submission.
    *   - `ERROR` When an error occurred while evaluating the form logic.
    *   - `FORMIO_CHANGE_HANDLED` When the change is successfully handled .
@@ -767,6 +767,7 @@ const FormStep = ({
   const onFormIOChange = async (changed, flags, modifiedByHuman) => {
     // formio form not mounted -> nothing to do
     if (!formRef.current) return;
+    if (logicChecking) return;
 
     // backend logic leads to changes in FormIO configuration, which triggers onFormIOInitialized.
     // This in turn triggers the onFormIOChange event because the submission data is set

--- a/src/components/FormStep/index.js
+++ b/src/components/FormStep/index.js
@@ -767,7 +767,12 @@ const FormStep = ({
   const onFormIOChange = async (changed, flags, modifiedByHuman) => {
     // formio form not mounted -> nothing to do
     if (!formRef.current) return;
-    if (logicChecking) return;
+    // Under some conditions and engines (e.g. WebKit), `onFormIOChange` can be triggered while
+    // logicChecking is currently running (that is the scheduled logic check with `setTimeout` is ongoing).
+    // While it is running, `canSubmit` is set to `false` because of the fired `BLOCK_SUBMISSION` action.
+    // We don't want to get in conflict with the current check if the change doesn't come from the user.
+    // See https://github.com/open-formulieren/open-forms/issues/3572 for an example.
+    if (!modifiedByHuman && logicChecking) return;
 
     // backend logic leads to changes in FormIO configuration, which triggers onFormIOInitialized.
     // This in turn triggers the onFormIOChange event because the submission data is set


### PR DESCRIPTION
Fixes https://github.com/open-formulieren/open-forms/issues/3572.

The race condition happens after `onFormIOChange` is called a first time:
- Firefox
![image](https://github.com/open-formulieren/open-forms-sdk/assets/65306057/384f0774-17a8-4e31-86a7-3e4b31570c31)
- WebKit
![image](https://github.com/open-formulieren/open-forms-sdk/assets/65306057/8030ee9c-36c7-4eda-9e35-18d4e3730fb4)

`onFormIOChange` will schedule a call to `evaluateFormLogic` that will in turn dispatch `BLOCK_SUBMISSION` (thus setting `canSubmit=false`). Logic check is performed, and `LOGIC_CHECK_DONE` is about to be dispatched (which will set `canSubmit` to `true` if the logic check allows it).

For some reason, having a colored HTML element triggers `onFormIOChange` at this specific time. On Firefox, `LOGIC_CHECK_DONE` was fired in time so it had time to set `canSubmit` to `true` again (as you can see `logicChecking` is `false` when this `onFormIOChange` call happens). However, WebKit seems to be to slow and `onFormIOChange` is called _before_ `LOGIC_CHECK_DONE` is fired.

For now my fix is to return if we are still _formChecking_, but ideally a more robust solution should be found (e.g. a queue handling all the form change events?)