### PR TITLE
:bug: Fix Leaflet styles

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,5 +1,4 @@
 // Note: the styles here are only relevant in dev mode with `yarn start`
-@import '~leaflet/dist/leaflet';
 @import '~microscope-sass/lib/color';
 @import '~microscope-sass/lib/responsive';
 @import 'scss/settings';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -7,6 +7,7 @@
 @import '@fortawesome/fontawesome-free/scss/solid';
 @import 'flatpickr/dist/flatpickr.min.css';
 @import 'formiojs/dist/formio.form.css';
+@import 'leaflet/dist/leaflet';
 
 // output the design tokens under the .openforms-theme classname
 @import '@open-formulieren/design-tokens/dist/index';


### PR DESCRIPTION
The layout/container refactor (in the backend) broke the map styles in an 'interesting' way. We were loading the admin CSS for the form builder in the public frontend too, and that refactor PR realised this should not be needed and removed it. This admin CSS included the Leaflet CSS to be able to render the map in the form builder. It also provided the necessary CSS for the SDK maps, because it turns out the SDK never properly bundled the Leaflet CSS.

Cleaning up in the backend exposed this issue in the SDK, so now the import is moved to the SDK styles bundle to make it work reliably. This also means that the map component probably never worked properly with embedded forms on third party domains rather than served directly by our own backend.

The layout refactor is after Open Forms 2.4.0, so I don't expect any stable versions to be affected by this.