### PR TITLE
[#3647] Prevent invalid time from crashing form

### DIFF
--- a/src/formio/components/TimeField.js
+++ b/src/formio/components/TimeField.js
@@ -29,6 +29,20 @@ class TimeField extends Time {
     ].join(' ');
     return info;
   }
+
+  getStringAsValue(value) {
+    const result = super.getStringAsValue(value);
+    if (result === 'Invalid date') return value;
+
+    return result;
+  }
+
+  getValueAsString(value) {
+    const result = super.getValueAsString(value);
+    if (result === 'Invalid date') return value;
+
+    return result;
+  }
 }
 
 export default TimeField;

--- a/src/formio/components/TimeField.spec.js
+++ b/src/formio/components/TimeField.spec.js
@@ -1,0 +1,48 @@
+import {screen, waitFor} from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
+import _ from 'lodash';
+import {Formio} from 'react-formio';
+
+import OpenFormsModule from 'formio/module';
+
+// Use our custom components
+Formio.use(OpenFormsModule);
+
+const phoneForm = {
+  type: 'form',
+  components: [
+    {
+      key: 'time',
+      type: 'time',
+      input: true,
+      label: 'Time',
+      inputType: 'text',
+    },
+  ],
+};
+
+const renderForm = async () => {
+  let formJSON = _.cloneDeep(phoneForm);
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const form = await Formio.createForm(container, formJSON);
+  return {form, container};
+};
+
+describe('The time component', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('Time component with invalid time', async () => {
+    const user = userEvent.setup({delay: 50});
+    const {form} = await renderForm();
+
+    const input = screen.getByLabelText('Time');
+    expect(input).toBeVisible();
+    await user.type(input, '25:00');
+    expect(input).toHaveDisplayValue('25:00');
+
+    expect(form.isValid()).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes open-formulieren/open-forms#3647

The behaviour is still not right: the validation only triggers on the 'on blur' event (so the check logic call happens with invalid data). But the backend doesn't crash anymore (with this fix https://github.com/open-formulieren/open-forms/pull/3670) so the form doesn't crash.