### PR TITLE
[OF#180] Add a completion callback to the SDK

### DIFF
--- a/src/api-mocks/submissions.js
+++ b/src/api-mocks/submissions.js
@@ -143,3 +143,13 @@ export const mockSubmissionPaymentStartGet = rest.post(
     return res(ctx.json({data: {method: 'get', action: 'https://example.com'}}));
   }
 );
+
+export const mockSubmissionComplete = rest.post(
+  `${BASE_URL}submissions/:uuid/_complete`,
+  (req, res, ctx) =>
+    res(
+      ctx.json({
+        statusUrl: 'http://example.com',
+      })
+    )
+);

--- a/src/components/Summary/SubmissionSummary.js
+++ b/src/components/Summary/SubmissionSummary.js
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useContext} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useNavigate} from 'react-router-dom';
 import {useAsync} from 'react-use';
 import {useImmerReducer} from 'use-immer';
 
+import {ConfigContext} from 'Context';
 import {post} from 'api';
 import {LiteralsProvider} from 'components/Literal';
 import {SUBMISSION_ALLOWED} from 'components/constants';
@@ -43,6 +44,7 @@ const SubmissionSummary = ({
   const [state, dispatch] = useImmerReducer(reducer, initialState);
   const navigate = useNavigate();
   const intl = useIntl();
+  const config = useContext(ConfigContext);
 
   const refreshedSubmission = useRefreshSubmission(submission);
 
@@ -92,6 +94,17 @@ const SubmissionSummary = ({
       // TODO Specific error for each type of invalid data?
       throw new Error('InvalidSubmissionData');
     } else {
+      if (config.onComplete) {
+        try {
+          config.onComplete();
+        } catch (exception) {
+          // At this point the submission is completed and removed from the session.
+          // If the callback errors, then the user will no longer be able to see the confirmation
+          // page with the submission reference.
+          console.error(exception);
+        }
+      }
+
       return response.data;
     }
   };

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -70,6 +70,7 @@ class OpenForm {
       languageSelectorTarget,
       displayComponents = {}, // TODO: document as unstable API
       useHashRouting = false,
+      onComplete = () => {},
     } = opts;
 
     this.targetNode = targetNode;
@@ -79,6 +80,7 @@ class OpenForm {
     this.lang = lang;
     this.displayComponents = {...defaultDisplayComponents, ...displayComponents};
     this.useHashRouting = useHashRouting;
+    this.onComplete = onComplete;
 
     switch (typeof languageSelectorTarget) {
       case 'string': {
@@ -192,6 +194,7 @@ class OpenForm {
               // XXX: deprecate and refactor usage to use useFormContext?
               requiredFieldsWithAsterisk: this.formObject.requiredFieldsWithAsterisk,
               debug: DEBUG,
+              onComplete: this.onComplete,
             }}
           >
             <NonceProvider nonce={CSPNonce.getValue()} cacheKey="sdk-react-select">


### PR DESCRIPTION
Fixes open-formulieren/open-forms#180 (partly) 

This can be then used by the page embedding the SDK to show the govmetric feedback button on the summary page