### PR TITLE
Improve summary accessibility

### DIFF
--- a/src/components/FormStepSummary/index.js
+++ b/src/components/FormStepSummary/index.js
@@ -10,7 +10,6 @@ import React from 'react';
 
 import FAIcon from 'components/FAIcon';
 import Link from 'components/Link';
-import {DEBUG} from 'utils';
 
 import ComponentValueDisplay from './ComponentValueDisplay';
 
@@ -41,12 +40,7 @@ LabelValueRow.propTypes = {
   component: PropTypes.object.isRequired,
 };
 
-const FormStepSummary = ({editUrl, slug, name, data, editStepText = ''}) => {
-  if (!editUrl) {
-    if (DEBUG && !slug) console.error('Provide either a step slug or editUrl prop');
-    editUrl = `/stap/${slug}`;
-  }
-
+const FormStepSummary = ({editUrl, name, data, editStepText = ''}) => {
   return (
     <div className="openforms-summary">
       <div className="openforms-summary__header">
@@ -76,8 +70,7 @@ const FormStepSummary = ({editUrl, slug, name, data, editStepText = ''}) => {
 
 FormStepSummary.propTypes = {
   name: PropTypes.node.isRequired,
-  editUrl: PropTypes.string,
-  slug: PropTypes.string,
+  editUrl: PropTypes.string.isRequired,
   editStepText: PropTypes.node,
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
 };

--- a/src/components/FormStepSummary/index.js
+++ b/src/components/FormStepSummary/index.js
@@ -6,7 +6,8 @@ import {
   Heading2,
 } from '@utrecht/component-library-react';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useId} from 'react';
+import {FormattedMessage} from 'react-intl';
 
 import FAIcon from 'components/FAIcon';
 import Link from 'components/Link';
@@ -41,16 +42,27 @@ LabelValueRow.propTypes = {
 };
 
 const FormStepSummary = ({editUrl, name, data, editStepText = ''}) => {
+  const linkDescriptionId = useId();
   return (
     <div className="openforms-summary">
       <div className="openforms-summary__header">
         <Heading2 className="utrecht-heading-2--openforms-summary-step-name">{name}</Heading2>
 
         {editStepText && (
-          <Link to={editUrl}>
-            <FAIcon icon="pen-to-square" />
-            {editStepText}
-          </Link>
+          <>
+            <span className="openforms-summary__link-description" id={linkDescriptionId}>
+              <FormattedMessage
+                description="Form step change link accessible description"
+                defaultMessage="Change fields in form step ''{name}''"
+                values={{name}}
+              />
+            </span>
+
+            <Link to={editUrl} aria-describedby={linkDescriptionId}>
+              <FAIcon icon="pen-to-square" />
+              {editStepText}
+            </Link>
+          </>
         )}
       </div>
 

--- a/src/components/Summary/GenericSummary.js
+++ b/src/components/Summary/GenericSummary.js
@@ -48,7 +48,7 @@ const GenericSummary = ({
           {summaryData.map((step, index) => (
             <FormStepSummary
               key={`${index}-${step.slug}`}
-              slug={step.slug}
+              editUrl={`/stap/${step.slug}`}
               name={step.name}
               data={step.data}
               editStepText={editStepText}

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -823,6 +823,20 @@
       "value": "Contact details"
     }
   ],
+  "MHkO0o": [
+    {
+      "type": 0,
+      "value": "Change fields in form step '"
+    },
+    {
+      "type": 1,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": "'"
+    }
+  ],
   "MJXZYI": [
     {
       "type": 0,

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -823,6 +823,20 @@
       "value": "Contactgegevens"
     }
   ],
+  "MHkO0o": [
+    {
+      "type": 0,
+      "value": "Wijzig velden in formulierstap '"
+    },
+    {
+      "type": 1,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": "'"
+    }
+  ],
   "MJXZYI": [
     {
       "type": 0,

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -389,6 +389,11 @@
     "description": "Appointment overview: contact details step title",
     "originalDefault": "Contact details"
   },
+  "MHkO0o": {
+    "defaultMessage": "Change fields in form step ''{name}''",
+    "description": "Form step change link accessible description",
+    "originalDefault": "Change fields in form step ''{name}''"
+  },
   "MJXZYI": {
     "defaultMessage": "m",
     "description": "Placeholder for month part of a date",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -393,6 +393,11 @@
     "description": "Appointment overview: contact details step title",
     "originalDefault": "Contact details"
   },
+  "MHkO0o": {
+    "defaultMessage": "Wijzig velden in formulierstap ''{name}''",
+    "description": "Form step change link accessible description",
+    "originalDefault": "Change fields in form step ''{name}''"
+  },
   "MJXZYI": {
     "defaultMessage": "m",
     "description": "Placeholder for month part of a date",

--- a/src/scss/components/_summary.scss
+++ b/src/scss/components/_summary.scss
@@ -35,6 +35,11 @@
     border-block-end-color: var(--of-summary-header-border-block-end-color, var(--of-color-border));
   }
 
+  // accessible description
+  @include bem.element('link-description') {
+    display: none;
+  }
+
   // TODO: check if there's a modifier for utrecht-link with icon instead.
   .utrecht-link.utrecht-link--openforms .fa-icon {
     padding-inline-end: var(--of-summary-header-link-icon-padding-inline-end, 5px);


### PR DESCRIPTION
This was mentioned by @Robbert during our latest NL DS chat.

Rather than using `aria-describedby` I opted for `aria-label` to get good translatable messages - depending on the language, we can't anticipate how the form-designer provided `editStepText` properly fits into a sentence strung together from various DOM elements in a particular order.