### PR TITLE
Make required asterisk theme-independant

### DIFF
--- a/src/components/forms/Label.js
+++ b/src/components/forms/Label.js
@@ -13,6 +13,7 @@ export const LabelContent = ({id, disabled = false, isRequired = false, type, ch
       htmlFor={id}
       disabled={disabled}
       className={classNames({
+        'utrecht-form-label--openforms': true,
         'utrecht-form-label--openforms-required': isRequired && requiredFieldsWithAsterisk,
         [`utrecht-form-label--${type}`]: type,
       })}

--- a/src/formio/templates/checkbox.ejs
+++ b/src/formio/templates/checkbox.ejs
@@ -2,7 +2,7 @@
 <p class="utrecht-form-field__label utrecht-form-field__label--checkbox">
   <label
     for="{{ctx.instance.id}}-{{ctx.component.key}}"
-    class="utrecht-form-label utrecht-form-label--checkbox {% if (ctx.disabled) { %}utrecht-form-label--disabled{% } %} {{ctx.input.labelClass}} {% if (ctx.component.validate.required && ctx.requiredFieldsWithAsterisk) { %}utrecht-form-label--openforms-required{% } %}"
+    class="utrecht-form-label utrecht-form-label--checkbox utrecht-form-label--openforms {% if (ctx.disabled) { %}utrecht-form-label--disabled{% } %} {{ctx.input.labelClass}} {% if (ctx.component.validate.required && ctx.requiredFieldsWithAsterisk) { %}utrecht-form-label--openforms-required{% } %}"
   >
     {{ctx.input.label}}{% if (!ctx.component.validate.required && !ctx.requiredFieldsWithAsterisk) { %}&nbsp;{{ ctx.t('(not required)') }} {% } %}
     {% if (ctx.component.tooltip) { %}

--- a/src/formio/templates/field.ejs
+++ b/src/formio/templates/field.ejs
@@ -8,7 +8,7 @@
     >
 
       <legend class="utrecht-form-fieldset__legend utrecht-form-fieldset__legend--html-legend utrecht-form-field__label">
-        <span class="utrecht-form-label{% if (ctx.component.validate.required && ctx.requiredFieldsWithAsterisk){%} utrecht-form-label--openforms-required{%}%}">
+        <span class="utrecht-form-label utrecht-form-label--openforms{% if (ctx.component.validate.required && ctx.requiredFieldsWithAsterisk){%} utrecht-form-label--openforms-required{%}%}">
           {{ ctx.t(ctx.component.label, { _userInput: true }) }}
           {% if (!ctx.component.validate.required && !ctx.requiredFieldsWithAsterisk) { %}
             {{ ctx.t('(optional)') }}
@@ -52,7 +52,7 @@
     {% } %}
 
     {% if (ctx.label.hidden && ctx.label.className && ctx.component.validate.required && ctx.requiredFieldsWithAsterisk) { %}
-      <label class="utrecht-form-label utrecht-form-label--openforms-required {{ctx.label.className}}"></label>
+      <label class="utrecht-form-label utrecht-form-label--openforms utrecht-form-label--openforms-required {{ctx.label.className}}"></label>
     {% } %}
 
     {{ctx.element}}

--- a/src/formio/templates/label.ejs
+++ b/src/formio/templates/label.ejs
@@ -1,6 +1,6 @@
 <p class="utrecht-paragraph utrecht-form-field__label">
   <label
-    class="utrecht-form-label {{ctx.label.className}} {% if (ctx.component.validate.required && ctx.requiredFieldsWithAsterisk) { %}utrecht-form-label--openforms-required{% } %}"
+    class="utrecht-form-label utrecht-form-label--openforms {{ctx.label.className}} {% if (ctx.component.validate.required && ctx.requiredFieldsWithAsterisk) { %}utrecht-form-label--openforms-required{% } %}"
     for="{{ctx.instance.id}}-{{ctx.component.key}}"
     {% if (ctx.component.suffix) { %}
       id="label-{{ctx.instance.id}}-{{ctx.component.key}}"

--- a/src/scss/components/_label.scss
+++ b/src/scss/components/_label.scss
@@ -13,21 +13,19 @@
   color: var(--of-color-fg-muted);
 }
 
-.openforms-theme {
-  .utrecht-form-label {
-    display: block;
-    line-height: 1.333;
-    overflow-wrap: break-word; // see open-formulieren/open-forms#576
-    @include anchor.extend-utrecht-link;
-    // TODO: remove font-weight rule on 2.0, it's only here for backwards compatibility
-    font-weight: var(--utrecht-form-label-font-weight, var(--of-label-font-weight));
+.utrecht-form-label {
+  display: block;
+  line-height: 1.333;
+  overflow-wrap: break-word; // see open-formulieren/open-forms#576
+  @include anchor.extend-utrecht-link;
+  // TODO: remove font-weight rule on 2.0, it's only here for backwards compatibility
+  font-weight: var(--utrecht-form-label-font-weight, var(--of-label-font-weight));
 
-    @include bem.modifier('openforms-required') {
-      &:after {
-        content: ' *';
-        color: var(--of-color-danger);
-        z-index: 0; // otherwise this is above the progress indicator in some browsers
-      }
+  @include bem.modifier('openforms-required') {
+    &:after {
+      content: ' *';
+      color: var(--of-color-danger);
+      z-index: 0; // otherwise this is above the progress indicator in some browsers
     }
   }
 }

--- a/src/scss/components/_label.scss
+++ b/src/scss/components/_label.scss
@@ -14,12 +14,14 @@
 }
 
 .utrecht-form-label {
-  display: block;
-  line-height: 1.333;
-  overflow-wrap: break-word; // see open-formulieren/open-forms#576
-  @include anchor.extend-utrecht-link;
-  // TODO: remove font-weight rule on 2.0, it's only here for backwards compatibility
-  font-weight: var(--utrecht-form-label-font-weight, var(--of-label-font-weight));
+  @include bem.modifier('openforms') {
+    display: block;
+    line-height: 1.333;
+    overflow-wrap: break-word; // see open-formulieren/open-forms#576
+    @include anchor.extend-utrecht-link;
+    // TODO: remove font-weight rule on 2.0, it's only here for backwards compatibility
+    font-weight: var(--utrecht-form-label-font-weight, var(--of-label-font-weight));
+  }
 
   @include bem.modifier('openforms-required') {
     &:after {


### PR DESCRIPTION
In _formio_component.scss the field-required asterisk is removed because it is handled with the "utrecht-form-label--openforms-required" class. But this class was scoped on the "openforms-theme", meaning it did not work with other themes.

As the showing/hiding of the asterisk is a core functionality I think this css should be scoped on all themes. Styling can be further tweaked in the specific design system.