### PR TITLE
 [OF#4027] Turn url storage in valid constructor

### DIFF
--- a/src/formio/components/FileField.js
+++ b/src/formio/components/FileField.js
@@ -13,7 +13,7 @@ const addCSRFToken = xhr => {
   }
 };
 
-const CSRFEnabledUrl = formio => {
+const CSRFEnabledUrl = function (formio) {
   const defaultUrlStorage = formioUrlStorage(formio);
 
   // Taken and modified from Formio's formiojs/providers/storage/url.js


### PR DESCRIPTION
Fixes open-formulieren/open-forms#4027