### PR TITLE
[open-formulieren/open-forms#4082] Fix duplicate creation of submissions

### DIFF
--- a/src/components/FormStart/index.js
+++ b/src/components/FormStart/index.js
@@ -64,8 +64,8 @@ const FormStart = ({form, submission, onFormStart, onDestroySession}) => {
     }
 
     if (doStart && !hasAuthErrors) {
-      await onFormStart();
       onFormStartCalledRef.current = true;
+      await onFormStart();
     }
   }, [doStart, hasAuthErrors, onFormStart]);
 


### PR DESCRIPTION
Fixes open-formulieren/open-forms#4082

A race condition is happening and the `useAsync` hook is being called three times, and `onFormStart` would be called every time as `onFormStartCalledRef` wasn't set to `true` by the first called in time.

This only happens when using a login button, as the `useAync` hook is watching on the `_start` query parameter, and a change to this query parameter seems to trigger the hook three times for some reason.

(This doesn't happen with the "Begin form" button as in this case, the `onFormStart` function is called directly).