### PR TITLE
feat: add custom class to classnames to textfield

### DIFF
--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -25,7 +25,8 @@ class TextField extends Formio.Components.components.textfield {
       'utrecht-textbox',
       'utrecht-textbox--html-input',
       'utrecht-textbox--openforms',
-    ].join(' ');
+      this.component.customClass
+    ].filter(Boolean).join(' ');
     return info;
   }
 


### PR DESCRIPTION
Naar aanleiding van gebruikersonderzoek wil de gemeente Utrecht de breedte van formuliervelden afwisselend maken, met kleinere velden voor korte input.

Deze custom class names willen we gebruiken zodat we een lijst van class names kunnen maken om de breedte van textfields te stylen. Dit willen we doen voor toegankelijkheid.

![image](https://github.com/open-formulieren/open-forms-sdk/assets/48519289/642dd354-e32a-4f44-858d-75cd33ab93b6)

Is er trouwens een manier om de custom class optie aan te zetten in open forms? Ik heb gezien dat het kan in de formio documentatie. Het zou handig zijn als de redactie niet in de JSON hoeft te werken...

![image](https://github.com/open-formulieren/open-forms-sdk/assets/48519289/ea4ab91c-6063-4e64-a21d-1a8c14bb09f7)


