### PR TITLE
Prepare release 2.3.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 2.3.0-alpha.0
+current_version = 2.3.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<pre>[a-z]+)\.(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{pre}.{build}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,53 @@
 SDK Changelog
 =============
 
+2.3.0 (2024-07-09)
+==================
+
+Feature release - this changelog also includes the changes from the alpha release.
+
+.. warning:: SDK 2.3.0 requires the backend API version 2.7.0 or newer.
+
+New features
+------------
+
+* [#4115, #4208] Support different kinds of GovMetric feedback (aborting the form vs.
+  completing the form).
+* [#3993] The ``addressNL`` component can now derive street name/city from postcode and
+  house number.
+* [#4423] The ``addressNL`` component now supports single column layout mode too, in
+  addition to the existing double column layout.
+
+Bugfixes
+--------
+
+* [#4382] Fixed the "pause modal" not being submittable after validation errors and
+  added better validation.
+* [#4328] Fixed the Govmetric smiley images not rendering.
+* [#4199] Fixed starting submissions anonymously while already logged in. Before, the
+  existing authentication metadata was added as if you started the form with login.
+* [#4158] Fixed custom error messages not being picked up for datetime, date and time
+  components.
+* [#4009] Fixed fieldset components accidentally displaying a value in the summary.
+* [#4082] Fixed multiple submissions being created when starting a form.
+* [#4172] Fixed a crash when validating a date against a minimum/maximum date.
+* [#4130] Forms requiring payment no longer offer the user to go back to the main page.
+* [#4201] Fixed a crash when a map component is hidden.
+* [#4222] Fixed being able to circumvent the maximum number of files limit.
+* [#4220] Fixed "optional" translation for radio and selectboxes components.
+* [#4207] Fixed styling overflow for select dropdown.
+
+Project maintenance
+-------------------
+
+* Dropped support for SDk 2.0 and older.
+
+Deprecations
+------------
+
+* Location autofill in textfield components is deprecated and will be removed in SDK
+  3.0. Instead, use the ``addressNL`` component.
+
 2.2.3 (2024-06-14)
 ==================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,12 +2,15 @@
 SDK Changelog
 =============
 
-2.3.0 (2024-07-09)
+2.3.1 (2024-07-09)
 ==================
 
 Feature release - this changelog also includes the changes from the alpha release.
 
 .. warning:: SDK 2.3.0 requires the backend API version 2.7.0 or newer.
+
+.. note:: Version 2.3.0 does not exist - a beta build was accidentally released to npm
+   as 2.3.0.
 
 New features
 ------------

--- a/README.NL.rst
+++ b/README.NL.rst
@@ -2,7 +2,7 @@
 Open Formulieren SDK
 ====================
 
-:Version: 2.3.0-alpha.0
+:Version: 2.3.0
 :Source: https://github.com/open-formulieren/open-forms-sdk
 :Keywords: e-Formulieren, Common Ground, FormIO, API
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Open Forms SDK
 ==============
 
-:Version: 2.3.0-alpha.0
+:Version: 2.3.0
 :Source: https://github.com/open-formulieren/open-forms-sdk
 :Keywords: e-Formulieren, Common Ground, FormIO, API
 

--- a/docker/ci/config.json
+++ b/docker/ci/config.json
@@ -5,6 +5,10 @@
       "tag": "latest"
     },
     {
+      "gitRef": "stable/2.3.x",
+      "tag": null
+    },
+    {
       "gitRef": "stable/2.2.x",
       "tag": null
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-formulieren/sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-formulieren/sdk",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "EUPL-1.2",
       "workspaces": [
         "design-tokens"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-formulieren/sdk",
-  "version": "2.3.0-alpha.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-formulieren/sdk",
-      "version": "2.3.0-alpha.0",
+      "version": "2.3.0",
       "license": "EUPL-1.2",
       "workspaces": [
         "design-tokens"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-formulieren/sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": true,
   "main": "dist/open-forms-sdk.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-formulieren/sdk",
-  "version": "2.3.0-alpha.0",
+  "version": "2.3.0",
   "private": true,
   "main": "dist/open-forms-sdk.js",
   "exports": {

--- a/publiccode.yaml
+++ b/publiccode.yaml
@@ -7,7 +7,7 @@ publiccodeYmlVersion: '0.2'
 name: Open Forms SDK
 url: 'http://github.com/open-formulieren/open-forms-sdk.git'
 softwareType: standalone/frontend
-softwareVersion: 2.3.0-alpha.0
+softwareVersion: 2.3.0
 releaseDate: 't.b.d.'
 logo: 'https://github.com/open-formulieren/open-forms/blob/master/docs/logo.svg'
 platforms:


### PR DESCRIPTION
Release date is planned for next Tuesday, so tagging this branch as beta for testing purposes.

* Updated translations
* Bumped version
* Updated changelog