### PR TITLE
:speech_balloon: [open-formulieren/open-forms#4505] Add error messages for AddressNL validation

### DIFF
--- a/src/formio/components/AddressNL.js
+++ b/src/formio/components/AddressNL.js
@@ -201,8 +201,20 @@ const FIELD_LABELS = defineMessages({
 });
 
 const addressNLSchema = (required, intl) => {
-  let postcodeSchema = z.string().regex(/^[1-9][0-9]{3} ?(?!sa|sd|ss|SA|SD|SS)[a-zA-Z]{2}$/);
-  let houseNumberSchema = z.string().regex(/^\d{1,5}$/);
+  let postcodeSchema = z.string().regex(/^[1-9][0-9]{3} ?(?!sa|sd|ss|SA|SD|SS)[a-zA-Z]{2}$/, {
+    message: intl.formatMessage({
+      description:
+        'ZOD error message when AddressNL postcode does not match the postcode regular expression',
+      defaultMessage: 'Postcode must be four digits followed by two letters (e.g. 1234 AB).',
+    }),
+  });
+  let houseNumberSchema = z.string().regex(/^\d{1,5}$/, {
+    message: intl.formatMessage({
+      description:
+        'ZOD error message when AddressNL house number does not match the house number regular expression',
+      defaultMessage: 'House number must be a number with up to five digits (e.g. 456).',
+    }),
+  });
   if (!required) {
     postcodeSchema = postcodeSchema.optional();
     houseNumberSchema = houseNumberSchema.optional();
@@ -214,11 +226,23 @@ const addressNLSchema = (required, intl) => {
       houseNumber: houseNumberSchema,
       houseLetter: z
         .string()
-        .regex(/^[a-zA-Z]$/)
+        .regex(/^[a-zA-Z]$/, {
+          message: intl.formatMessage({
+            description:
+              'ZOD error message when AddressNL house letter does not match the house letter regular expression',
+            defaultMessage: 'House letter must be a single letter.',
+          }),
+        })
         .optional(),
       houseNumberAddition: z
         .string()
-        .regex(/^([a-zA-Z0-9]){1,4}$/)
+        .regex(/^([a-zA-Z0-9]){1,4}$/, {
+          message: intl.formatMessage({
+            description:
+              'ZOD error message when AddressNL house number addition does not match the house number addition regular expression',
+            defaultMessage: 'House number addition must be up to four letters and digits.',
+          }),
+        })
         .optional(),
     })
     .superRefine((val, ctx) => {

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -357,6 +357,12 @@
       "value": "Check and confirm"
     }
   ],
+  "AM6xqd": [
+    {
+      "type": 0,
+      "value": "House number must be a number with up to five digits (e.g. 456)."
+    }
+  ],
   "ATXTTM": [
     {
       "type": 0,
@@ -531,6 +537,12 @@
     {
       "type": 0,
       "value": "Rate this form as 'Good'"
+    }
+  ],
+  "EPQl+D": [
+    {
+      "type": 0,
+      "value": "House number addition must be up to four letters and digits."
     }
   ],
   "GbPef0": [
@@ -1387,6 +1399,12 @@
       "value": "Something went wrong while submitting the form."
     }
   ],
+  "hWv0yN": [
+    {
+      "type": 0,
+      "value": "House letter must be a single letter."
+    }
+  ],
   "hkZ8N1": [
     {
       "type": 0,
@@ -1851,6 +1869,12 @@
     {
       "type": 0,
       "value": "Suspending the form failed, please try again later"
+    }
+  ],
+  "rUsmvU": [
+    {
+      "type": 0,
+      "value": "Postcode must be four digits followed by two letters (e.g. 1234 AB)."
     }
   ],
   "sSmY1N": [

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -357,6 +357,12 @@
       "value": "Controleer en bevestig"
     }
   ],
+  "AM6xqd": [
+    {
+      "type": 0,
+      "value": "Huisnummer moet een nummer zijn met maximaal 5 cijfers (bijv. 456)."
+    }
+  ],
   "ATXTTM": [
     {
       "type": 0,
@@ -531,6 +537,12 @@
     {
       "type": 0,
       "value": "Beoordeel dit formulier als 'goed'"
+    }
+  ],
+  "EPQl+D": [
+    {
+      "type": 0,
+      "value": "Huisnummertoevoeging moet bestaan uit maximaal vier letters en cijfers."
     }
   ],
   "GbPef0": [
@@ -1391,6 +1403,12 @@
       "value": "Er is iets fout gegaan bij het verzenden."
     }
   ],
+  "hWv0yN": [
+    {
+      "type": 0,
+      "value": "Huisletter moet een enkele letter zijn."
+    }
+  ],
   "hkZ8N1": [
     {
       "type": 0,
@@ -1855,6 +1873,12 @@
     {
       "type": 0,
       "value": "Het pauzeren van het formulier is mislukt. Probeer het later opnieuw."
+    }
+  ],
+  "rUsmvU": [
+    {
+      "type": 0,
+      "value": "Postcode moet bestaan uit vier cijfers gevolgd door twee letters (bijv. 1234 AB)."
     }
   ],
   "sSmY1N": [

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -164,6 +164,11 @@
     "description": "Check overview and confirm",
     "originalDefault": "Check and confirm"
   },
+  "AM6xqd": {
+    "defaultMessage": "House number must be a number with up to five digits (e.g. 456).",
+    "description": "ZOD error message when AddressNL house number does not match the house number regular expression",
+    "originalDefault": "House number must be a number with up to five digits (e.g. 456)."
+  },
   "ATXTTM": {
     "defaultMessage": "A payment is required for this product.",
     "description": "Payment request text",
@@ -283,6 +288,11 @@
     "defaultMessage": "Rate this form as 'Good'",
     "description": "Feedback face title - Good",
     "originalDefault": "Rate this form as 'Good'"
+  },
+  "EPQl+D": {
+    "defaultMessage": "House number addition must be up to four letters and digits.",
+    "description": "ZOD error message when AddressNL house number addition does not match the house number addition regular expression",
+    "originalDefault": "House number addition must be up to four letters and digits."
   },
   "GbPef0": {
     "defaultMessage": "You must provide a house number.",
@@ -679,6 +689,11 @@
     "description": "Generic submission error",
     "originalDefault": "Something went wrong while submitting the form."
   },
+  "hWv0yN": {
+    "defaultMessage": "House letter must be a single letter.",
+    "description": "ZOD error message when AddressNL house letter does not match the house letter regular expression",
+    "originalDefault": "House letter must be a single letter."
+  },
   "hkZ8N1": {
     "defaultMessage": "Invalid input.",
     "description": "ZOD 'custom' error message",
@@ -863,6 +878,11 @@
     "defaultMessage": "Suspending the form failed, please try again later",
     "description": "Modal suspending form failed message",
     "originalDefault": "Suspending the form failed, please try again later"
+  },
+  "rUsmvU": {
+    "defaultMessage": "Postcode must be four digits followed by two letters (e.g. 1234 AB).",
+    "description": "ZOD error message when AddressNL postcode does not match the postcode regular expression",
+    "originalDefault": "Postcode must be four digits followed by two letters (e.g. 1234 AB)."
   },
   "sSmY1N": {
     "defaultMessage": "Find address",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -166,6 +166,11 @@
     "description": "Check overview and confirm",
     "originalDefault": "Check and confirm"
   },
+  "AM6xqd": {
+    "defaultMessage": "Huisnummer moet een nummer zijn met maximaal 5 cijfers (bijv. 456).",
+    "description": "ZOD error message when AddressNL house number does not match the house number regular expression",
+    "originalDefault": "House number must be a number with up to five digits (e.g. 456)."
+  },
   "ATXTTM": {
     "defaultMessage": "Voor dit product is betaling vereist.",
     "description": "Payment request text",
@@ -287,6 +292,11 @@
     "defaultMessage": "Beoordeel dit formulier als 'goed'",
     "description": "Feedback face title - Good",
     "originalDefault": "Rate this form as 'Good'"
+  },
+  "EPQl+D": {
+    "defaultMessage": "Huisnummertoevoeging moet bestaan uit maximaal vier letters en cijfers.",
+    "description": "ZOD error message when AddressNL house number addition does not match the house number addition regular expression",
+    "originalDefault": "House number addition must be up to four letters and digits."
   },
   "GbPef0": {
     "defaultMessage": "Huisnummer is verplicht.",
@@ -688,6 +698,11 @@
     "description": "Generic submission error",
     "originalDefault": "Something went wrong while submitting the form."
   },
+  "hWv0yN": {
+    "defaultMessage": "Huisletter moet een enkele letter zijn.",
+    "description": "ZOD error message when AddressNL house letter does not match the house letter regular expression",
+    "originalDefault": "House letter must be a single letter."
+  },
   "hkZ8N1": {
     "defaultMessage": "Ongeldige invoer.",
     "description": "ZOD 'custom' error message",
@@ -875,6 +890,11 @@
     "defaultMessage": "Het pauzeren van het formulier is mislukt. Probeer het later opnieuw.",
     "description": "Modal suspending form failed message",
     "originalDefault": "Suspending the form failed, please try again later"
+  },
+  "rUsmvU": {
+    "defaultMessage": "Postcode moet bestaan uit vier cijfers gevolgd door twee letters (bijv. 1234 AB).",
+    "description": "ZOD error message when AddressNL postcode does not match the postcode regular expression",
+    "originalDefault": "Postcode must be four digits followed by two letters (e.g. 1234 AB)."
   },
   "sSmY1N": {
     "defaultMessage": "Zoek adres",


### PR DESCRIPTION
as well as their translations

partially fixes open-formulieren/open-forms#4505