### PR TITLE
fix: fix selected value for combobox, when not expanded, would overflow the form control.

### DIFF
--- a/src/scss/components/_deprecated-select.scss
+++ b/src/scss/components/_deprecated-select.scss
@@ -71,6 +71,7 @@ $select-background-color: var(--of-select-background-color, $color-white);
     display: flex;
     align-items: center;
     flex-wrap: wrap; // Allow flex to wrap.
+    max-inline-size: calc(100% - 44px); // leave 44px space for the "Clear" button and the expanded icon
   }
 
   // Selected choices.


### PR DESCRIPTION
[issue-link](https://github.com/frameless/strapi/issues/847);

**Screenshot**:

![Screenshot 2024-08-09 at 10 38 40](https://github.com/user-attachments/assets/6924994c-1599-48f7-9a3d-f830ec9b7d3f)
