### PR TITLE
Implement email verification flow on the UI side

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -18,6 +18,7 @@ import 'styles.scss';
 // ensure NL locale is included
 import OpenFormsModule from 'formio/module';
 import OFLibrary from 'formio/templates';
+import {withModalDecorator} from 'story-utils/decorators';
 
 import {
   utrechtDocumentDecorator,
@@ -51,6 +52,7 @@ export default {
     mswDecorator,
     withClearSessionStorage,
     withClearSubmissionLocalStorage,
+    withModalDecorator,
     utrechtDocumentDecorator,
   ],
   globals: {

--- a/src/components/Button/OFButton.js
+++ b/src/components/Button/OFButton.js
@@ -9,7 +9,10 @@ const OFButton = ({disabled, children, ...extraProps}) => {
   if (disabled) otherProps.className = 'utrecht-button--disabled';
 
   const onClick = event => {
-    if (disabled) event.preventDefault();
+    if (disabled) {
+      event.preventDefault();
+      return;
+    }
 
     if (onClickHandler) onClickHandler(event);
   };

--- a/src/components/EmailVerification/EmailVerificationForm.js
+++ b/src/components/EmailVerification/EmailVerificationForm.js
@@ -1,28 +1,19 @@
 import {Link as UtrechtLink} from '@utrecht/component-library-react';
 import {Formik} from 'formik';
 import PropTypes from 'prop-types';
-import React, {useContext, useState} from 'react';
+import React, {useContext} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {ConfigContext} from 'Context';
 import {post} from 'api';
 import Body from 'components/Body';
-import {OFButton} from 'components/Button';
-import Loader from 'components/Loader';
 import {Toolbar, ToolbarList} from 'components/Toolbar';
 import {TextField} from 'components/forms';
 import {ValidationError} from 'errors';
 
+import EnterCodeButton from './EnterCodeButton';
 import ModeField from './ModeField';
 import SendCodeButton from './SendCodeButton';
-
-const createVerification = async (baseUrl, {submissionUrl, componentKey, emailAddress}) => {
-  await post(`${baseUrl}submissions/email-verifications`, {
-    submission: submissionUrl,
-    componentKey,
-    email: emailAddress,
-  });
-};
 
 const submitVerificationCode = async (
   baseUrl,
@@ -36,134 +27,88 @@ const submitVerificationCode = async (
   });
 };
 
-const EmailVerificationForm = ({submissionUrl, componentKey, emailAddress}) => {
+const EmailVerificationForm = ({submissionUrl, componentKey, emailAddress, onVerified}) => {
   const {baseUrl} = useContext(ConfigContext);
-  const [codeSending, setCodeSending] = useState(false);
-  const [isVerified, setIsVerified] = useState(false);
+
+  /**
+   * On Formik submit, submit the verification code to the backend. If all is okay,
+   * the local state is updated so that the success message is displayed, otherwise
+   * display any validation errors.
+   */
+  const onSubmit = async (values, helpers) => {
+    try {
+      await submitVerificationCode(baseUrl, {
+        submissionUrl,
+        componentKey,
+        emailAddress,
+        code: values.code,
+      });
+      onVerified();
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        // TODO: set in formik state
+        console.error(e.invalidParams);
+      } else {
+        throw e;
+      }
+    } finally {
+      helpers.setSubmitting(false);
+    }
+  };
 
   return (
-    <Formik
-      initialValues={{
-        mode: 'sendCode',
-        code: '',
-      }}
-      onSubmit={async (values, helpers) => {
-        try {
-          await submitVerificationCode(baseUrl, {
-            submissionUrl,
-            componentKey,
-            emailAddress,
-            code: values.code,
-          });
-          setIsVerified(true);
-        } catch (e) {
-          if (e instanceof ValidationError) {
-            // TODO: set in formik state
-            console.error(e.invalidParams);
-          } else {
-            throw e;
-          }
-        } finally {
-          helpers.setSubmitting(false);
-        }
-      }}
-    >
-      {({handleSubmit, values: {mode}, setFieldValue, isSubmitting}) =>
-        isVerified ? (
-          <VerificationSuccess />
-        ) : (
-          <Body component="form" onSubmit={handleSubmit}>
-            <Body modifiers={['big']}>
-              <FormattedMessage
-                description="Email verification modal body text"
-                defaultMessage={`You are verifying the email address <link>{emailAddress}</link>.
+    <Formik initialValues={{mode: 'sendCode', code: ''}} onSubmit={onSubmit}>
+      {({handleSubmit, values: {mode}}) => (
+        <Body component="form" onSubmit={handleSubmit}>
+          <Body modifiers={['big']}>
+            <FormattedMessage
+              description="Email verification modal body text"
+              defaultMessage={`You are verifying the email address <link>{emailAddress}</link>.
               First, we need to send you a verification code on this email address. Then,
               you need to enter the code to confirm it.`}
-                values={{
-                  emailAddress,
-                  link: chunks => (
-                    <UtrechtLink href={`mailto:${emailAddress}`}>{chunks}</UtrechtLink>
-                  ),
-                }}
-              />
-            </Body>
+              values={{
+                emailAddress,
+                link: chunks => <UtrechtLink href={`mailto:${emailAddress}`}>{chunks}</UtrechtLink>,
+              }}
+            />
+          </Body>
 
-            <div className="openforms-form-field-container">
-              <ModeField />
-              {mode === 'enterCode' && (
-                <TextField
-                  name="code"
-                  label={
-                    <FormattedMessage
-                      description="Email verification: code input field label"
-                      defaultMessage="Enter the six-character code"
-                    />
-                  }
-                  pattern="[A-Z0-9]{6}"
-                  description={
-                    <FormattedMessage
-                      description="Email verification: code input field description"
-                      defaultMessage="The code is exactly six characters long and consists of only uppercase letters and numbers."
-                    />
-                  }
+          <div className="openforms-form-field-container">
+            <ModeField />
+            {mode === 'enterCode' && (
+              <TextField
+                name="code"
+                label={
+                  <FormattedMessage
+                    description="Email verification: code input field label"
+                    defaultMessage="Enter the six-character code"
+                  />
+                }
+                pattern="[A-Z0-9]{6}"
+                description={
+                  <FormattedMessage
+                    description="Email verification: code input field description"
+                    defaultMessage="The code is exactly six characters long and consists of only uppercase letters and numbers."
+                  />
+                }
+              />
+            )}
+          </div>
+
+          <Toolbar modifiers={['bottom', 'reverse']}>
+            <ToolbarList>
+              {mode === 'sendCode' && (
+                <SendCodeButton
+                  submissionUrl={submissionUrl}
+                  componentKey={componentKey}
+                  emailAddress={emailAddress}
                 />
               )}
-            </div>
-
-            <Toolbar modifiers={['bottom', 'reverse']}>
-              <ToolbarList>
-                {mode === 'sendCode' && (
-                  <SendCodeButton
-                    isSending={codeSending}
-                    onSendCode={async () => {
-                      if (!emailAddress) {
-                        // TODO: proper handling
-                        alert('no email set');
-                        return;
-                      }
-                      setCodeSending(true);
-                      try {
-                        await createVerification(baseUrl, {
-                          submissionUrl,
-                          componentKey,
-                          emailAddress,
-                        });
-                      } catch (e) {
-                        if (e instanceof ValidationError) {
-                          // TODO: set in formik state
-                          console.error(e.invalidParams);
-                        } else {
-                          throw e;
-                        }
-                      } finally {
-                        setCodeSending(false);
-                      }
-
-                      setFieldValue('mode', 'enterCode');
-                    }}
-                  />
-                )}
-                {mode === 'enterCode' && (
-                  <OFButton
-                    type="submit"
-                    appearance="primary-action-button"
-                    disabled={isSubmitting}
-                  >
-                    {isSubmitting ? (
-                      <Loader modifiers={['centered', 'only-child', 'small', 'gray']} />
-                    ) : (
-                      <FormattedMessage
-                        description="Email verification: verify code button text"
-                        defaultMessage="Verify"
-                      />
-                    )}
-                  </OFButton>
-                )}
-              </ToolbarList>
-            </Toolbar>
-          </Body>
-        )
-      }
+              {mode === 'enterCode' && <EnterCodeButton />}
+            </ToolbarList>
+          </Toolbar>
+        </Body>
+      )}
     </Formik>
   );
 };
@@ -172,16 +117,7 @@ EmailVerificationForm.propTypes = {
   submissionUrl: PropTypes.string.isRequired,
   componentKey: PropTypes.string.isRequired,
   emailAddress: PropTypes.string.isRequired,
+  onVerified: PropTypes.func.isRequired,
 };
-
-const VerificationSuccess = () => (
-  <Body modifiers={['big']}>
-    <FormattedMessage
-      description="Text displayed after successful email verification"
-      defaultMessage={`The email address has now been verified. You can close this
-      window and continue with the rest of the form.`}
-    />
-  </Body>
-);
 
 export default EmailVerificationForm;

--- a/src/components/EmailVerification/EmailVerificationForm.js
+++ b/src/components/EmailVerification/EmailVerificationForm.js
@@ -67,7 +67,7 @@ const EmailVerificationForm = ({submissionUrl, componentKey, emailAddress, onVer
 
   return (
     <Formik initialValues={{mode: 'sendCode', code: ''}} onSubmit={onSubmit}>
-      {({handleSubmit, values: {mode}}) =>
+      {({handleSubmit, values: {mode}, setFieldValue}) =>
         error ? (
           <Body component="div">
             <DisplayError error={error} />
@@ -107,6 +107,9 @@ const EmailVerificationForm = ({submissionUrl, componentKey, emailAddress, onVer
                       defaultMessage="The code is exactly six characters long and consists of only uppercase letters and numbers."
                     />
                   }
+                  onChange={event => {
+                    setFieldValue('code', event.target.value.toUpperCase());
+                  }}
                 />
               )}
             </div>

--- a/src/components/EmailVerification/EmailVerificationForm.js
+++ b/src/components/EmailVerification/EmailVerificationForm.js
@@ -46,8 +46,14 @@ const EmailVerificationForm = ({submissionUrl, componentKey, emailAddress, onVer
       onVerified();
     } catch (e) {
       if (e instanceof ValidationError) {
-        // TODO: set in formik state
-        console.error(e.invalidParams);
+        const errors = {};
+        e.invalidParams.forEach(({name, reason}) => {
+          // TODO: replace newlines with proper solution...
+          const hasErrorAlready = !!errors[name];
+          if (!hasErrorAlready) errors[name] = '';
+          errors[name] += `${hasErrorAlready ? '\n' : ''}${reason}`;
+        });
+        helpers.setErrors(errors);
       } else {
         throw e;
       }

--- a/src/components/EmailVerification/EmailVerificationForm.js
+++ b/src/components/EmailVerification/EmailVerificationForm.js
@@ -2,12 +2,13 @@ import {Link as UtrechtLink} from '@utrecht/component-library-react';
 import {Formik} from 'formik';
 import PropTypes from 'prop-types';
 import React, {useContext, useState} from 'react';
-import {FormattedMessage, useIntl} from 'react-intl';
+import {FormattedMessage} from 'react-intl';
 
 import {ConfigContext} from 'Context';
 import {post} from 'api';
 import Body from 'components/Body';
 import {OFButton} from 'components/Button';
+import Loader from 'components/Loader';
 import {Toolbar, ToolbarList} from 'components/Toolbar';
 import {TextField} from 'components/forms';
 import {ValidationError} from 'errors';
@@ -23,9 +24,22 @@ const createVerification = async (baseUrl, {submissionUrl, componentKey, emailAd
   });
 };
 
+const submitVerificationCode = async (
+  baseUrl,
+  {submissionUrl, componentKey, emailAddress, code}
+) => {
+  await post(`${baseUrl}submissions/email-verifications/verify`, {
+    submission: submissionUrl,
+    componentKey,
+    email: emailAddress,
+    code,
+  });
+};
+
 const EmailVerificationForm = ({submissionUrl, componentKey, emailAddress}) => {
   const {baseUrl} = useContext(ConfigContext);
   const [codeSending, setCodeSending] = useState(false);
+  const [isVerified, setIsVerified] = useState(false);
 
   return (
     <Formik
@@ -33,90 +47,123 @@ const EmailVerificationForm = ({submissionUrl, componentKey, emailAddress}) => {
         mode: 'sendCode',
         code: '',
       }}
-      onSubmit={console.log}
+      onSubmit={async (values, helpers) => {
+        try {
+          await submitVerificationCode(baseUrl, {
+            submissionUrl,
+            componentKey,
+            emailAddress,
+            code: values.code,
+          });
+          setIsVerified(true);
+        } catch (e) {
+          if (e instanceof ValidationError) {
+            // TODO: set in formik state
+            console.error(e.invalidParams);
+          } else {
+            throw e;
+          }
+        } finally {
+          helpers.setSubmitting(false);
+        }
+      }}
     >
-      {({handleSubmit, values: {mode}, setFieldValue}) => (
-        <Body component="form" onSubmit={handleSubmit}>
-          <Body modifiers={['big']}>
-            <FormattedMessage
-              description="Email verification modal body text"
-              defaultMessage={`You are verifying the email address <link>{emailAddress}</link>.
+      {({handleSubmit, values: {mode}, setFieldValue, isSubmitting}) =>
+        isVerified ? (
+          <VerificationSuccess />
+        ) : (
+          <Body component="form" onSubmit={handleSubmit}>
+            <Body modifiers={['big']}>
+              <FormattedMessage
+                description="Email verification modal body text"
+                defaultMessage={`You are verifying the email address <link>{emailAddress}</link>.
               First, we need to send you a verification code on this email address. Then,
               you need to enter the code to confirm it.`}
-              values={{
-                emailAddress,
-                link: chunks => <UtrechtLink href={`mailto:${emailAddress}`}>{chunks}</UtrechtLink>,
-              }}
-            />
-          </Body>
-
-          <div className="openforms-form-field-container">
-            <ModeField />
-            {mode === 'enterCode' && (
-              <TextField
-                name="code"
-                label={
-                  <FormattedMessage
-                    description="Email verification: code input field label"
-                    defaultMessage="Enter the six-character code"
-                  />
-                }
-                pattern="[A-Z0-9]{6}"
-                description={
-                  <FormattedMessage
-                    description="Email verification: code input field description"
-                    defaultMessage="The code is exactly six characters long and consists of only uppercase letters and numbers."
-                  />
-                }
+                values={{
+                  emailAddress,
+                  link: chunks => (
+                    <UtrechtLink href={`mailto:${emailAddress}`}>{chunks}</UtrechtLink>
+                  ),
+                }}
               />
-            )}
-          </div>
+            </Body>
 
-          <Toolbar modifiers={['bottom', 'reverse']}>
-            <ToolbarList>
-              {mode === 'sendCode' && (
-                <SendCodeButton
-                  isSending={codeSending}
-                  onSendCode={async () => {
-                    if (!emailAddress) {
-                      // TODO: proper handling
-                      alert('no email set');
-                      return;
-                    }
-                    setCodeSending(true);
-                    try {
-                      await createVerification(baseUrl, {
-                        submissionUrl,
-                        componentKey,
-                        emailAddress,
-                      });
-                    } catch (e) {
-                      if (e instanceof ValidationError) {
-                        // TODO: set in formik state
-                        console.error(e.invalidParams);
-                      } else {
-                        throw e;
-                      }
-                    } finally {
-                      setCodeSending(false);
-                    }
-
-                    setFieldValue('mode', 'enterCode');
-                  }}
+            <div className="openforms-form-field-container">
+              <ModeField />
+              {mode === 'enterCode' && (
+                <TextField
+                  name="code"
+                  label={
+                    <FormattedMessage
+                      description="Email verification: code input field label"
+                      defaultMessage="Enter the six-character code"
+                    />
+                  }
+                  pattern="[A-Z0-9]{6}"
+                  description={
+                    <FormattedMessage
+                      description="Email verification: code input field description"
+                      defaultMessage="The code is exactly six characters long and consists of only uppercase letters and numbers."
+                    />
+                  }
                 />
               )}
-              {mode === 'enterCode' && (
-                <OFButton type="submit" appearance="primary-action-button">
-                  <FormattedMessage
-                    description="Email verification: verify code button text"
-                    defaultMessage="Verify"
+            </div>
+
+            <Toolbar modifiers={['bottom', 'reverse']}>
+              <ToolbarList>
+                {mode === 'sendCode' && (
+                  <SendCodeButton
+                    isSending={codeSending}
+                    onSendCode={async () => {
+                      if (!emailAddress) {
+                        // TODO: proper handling
+                        alert('no email set');
+                        return;
+                      }
+                      setCodeSending(true);
+                      try {
+                        await createVerification(baseUrl, {
+                          submissionUrl,
+                          componentKey,
+                          emailAddress,
+                        });
+                      } catch (e) {
+                        if (e instanceof ValidationError) {
+                          // TODO: set in formik state
+                          console.error(e.invalidParams);
+                        } else {
+                          throw e;
+                        }
+                      } finally {
+                        setCodeSending(false);
+                      }
+
+                      setFieldValue('mode', 'enterCode');
+                    }}
                   />
-                </OFButton>
-              )}
-            </ToolbarList>
-          </Toolbar>
-        </Body>
-      )}
+                )}
+                {mode === 'enterCode' && (
+                  <OFButton
+                    type="submit"
+                    appearance="primary-action-button"
+                    disabled={isSubmitting}
+                  >
+                    {isSubmitting ? (
+                      <Loader modifiers={['centered', 'only-child', 'small', 'gray']} />
+                    ) : (
+                      <FormattedMessage
+                        description="Email verification: verify code button text"
+                        defaultMessage="Verify"
+                      />
+                    )}
+                  </OFButton>
+                )}
+              </ToolbarList>
+            </Toolbar>
+          </Body>
+        )
+      }
     </Formik>
   );
 };
@@ -126,5 +173,15 @@ EmailVerificationForm.propTypes = {
   componentKey: PropTypes.string.isRequired,
   emailAddress: PropTypes.string.isRequired,
 };
+
+const VerificationSuccess = () => (
+  <Body modifiers={['big']}>
+    <FormattedMessage
+      description="Text displayed after successful email verification"
+      defaultMessage={`The email address has now been verified. You can close this
+      window and continue with the rest of the form.`}
+    />
+  </Body>
+);
 
 export default EmailVerificationForm;

--- a/src/components/EmailVerification/EmailVerificationForm.js
+++ b/src/components/EmailVerification/EmailVerificationForm.js
@@ -1,0 +1,125 @@
+import {Link as UtrechtLink} from '@utrecht/component-library-react';
+import {Formik} from 'formik';
+import PropTypes from 'prop-types';
+import React, {useContext, useState} from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+
+import {ConfigContext} from 'Context';
+import {post} from 'api';
+import Body from 'components/Body';
+import {OFButton} from 'components/Button';
+import {Toolbar, ToolbarList} from 'components/Toolbar';
+import {TextField} from 'components/forms';
+import {ValidationError} from 'errors';
+
+import ModeField from './ModeField';
+import SendCodeButton from './SendCodeButton';
+
+const createVerification = async (baseUrl, {submissionUrl, componentKey, emailAddress}) => {
+  await post(`${baseUrl}submissions/email-verifications`, {
+    submission: submissionUrl,
+    componentKey,
+    email: emailAddress,
+  });
+};
+
+const EmailVerificationForm = ({submissionUrl, componentKey, emailAddress}) => {
+  const {baseUrl} = useContext(ConfigContext);
+  const [codeSending, setCodeSending] = useState(false);
+
+  return (
+    <Formik
+      initialValues={{
+        mode: 'sendCode',
+        code: '',
+      }}
+      onSubmit={console.log}
+    >
+      {({handleSubmit, values: {mode}, setFieldValue}) => (
+        <Body component="form" onSubmit={handleSubmit}>
+          <Body modifiers={['big']}>
+            <FormattedMessage
+              description="Email verification modal body text"
+              defaultMessage={`You are verifying the email address <link>{emailAddress}</link>.
+              First, we need to send you a verification code on this email address. Then,
+              you need to enter the code to confirm it.`}
+              values={{
+                emailAddress,
+                link: chunks => <UtrechtLink href={`mailto:${emailAddress}`}>{chunks}</UtrechtLink>,
+              }}
+            />
+          </Body>
+
+          <div className="openforms-form-field-container">
+            <ModeField />
+            {mode === 'enterCode' && (
+              <TextField
+                name="code"
+                label={
+                  <FormattedMessage
+                    description="Email verification: code input field label"
+                    defaultMessage="Enter the six-character code"
+                  />
+                }
+                pattern="[A-Z0-9]{6}"
+                description={
+                  <FormattedMessage
+                    description="Email verification: code input field description"
+                    defaultMessage="The code is exactly six characters long and consists of only uppercase letters and numbers."
+                  />
+                }
+              />
+            )}
+          </div>
+
+          <Toolbar modifiers={['bottom', 'reverse']}>
+            <ToolbarList>
+              {mode === 'sendCode' && (
+                <SendCodeButton
+                  isSending={codeSending}
+                  onSendCode={async () => {
+                    setCodeSending(true);
+                    try {
+                      await createVerification(baseUrl, {
+                        submissionUrl,
+                        componentKey,
+                        emailAddress,
+                      });
+                    } catch (e) {
+                      if (e instanceof ValidationError) {
+                        // TODO: set in formik state
+                        console.error(e.invalidParams);
+                      } else {
+                        throw e;
+                      }
+                    } finally {
+                      setCodeSending(false);
+                    }
+
+                    setFieldValue('mode', 'enterCode');
+                  }}
+                />
+              )}
+              {mode === 'enterCode' && (
+                <OFButton type="submit" appearance="primary-action-button">
+                  <FormattedMessage
+                    description="Email verification: verify code button text"
+                    defaultMessage="Verify"
+                  />
+                </OFButton>
+              )}
+            </ToolbarList>
+          </Toolbar>
+        </Body>
+      )}
+    </Formik>
+  );
+};
+
+EmailVerificationForm.propTypes = {
+  submissionUrl: PropTypes.string.isRequired,
+  componentKey: PropTypes.string.isRequired,
+  emailAddress: PropTypes.string.isRequired,
+};
+
+export default EmailVerificationForm;

--- a/src/components/EmailVerification/EmailVerificationForm.js
+++ b/src/components/EmailVerification/EmailVerificationForm.js
@@ -1,12 +1,13 @@
 import {Link as UtrechtLink} from '@utrecht/component-library-react';
 import {Formik} from 'formik';
 import PropTypes from 'prop-types';
-import React, {useContext} from 'react';
+import React, {useContext, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {ConfigContext} from 'Context';
 import {post} from 'api';
 import Body from 'components/Body';
+import {DisplayError} from 'components/Errors/ErrorBoundary';
 import {Toolbar, ToolbarList} from 'components/Toolbar';
 import {TextField} from 'components/forms';
 import {ValidationError} from 'errors';
@@ -29,6 +30,7 @@ const submitVerificationCode = async (
 
 const EmailVerificationForm = ({submissionUrl, componentKey, emailAddress, onVerified}) => {
   const {baseUrl} = useContext(ConfigContext);
+  const [error, setError] = useState(null);
 
   /**
    * On Formik submit, submit the verification code to the backend. If all is okay,
@@ -36,6 +38,7 @@ const EmailVerificationForm = ({submissionUrl, componentKey, emailAddress, onVer
    * display any validation errors.
    */
   const onSubmit = async (values, helpers) => {
+    setError(null);
     try {
       await submitVerificationCode(baseUrl, {
         submissionUrl,
@@ -55,7 +58,7 @@ const EmailVerificationForm = ({submissionUrl, componentKey, emailAddress, onVer
         });
         helpers.setErrors(errors);
       } else {
-        throw e;
+        setError(e);
       }
     } finally {
       helpers.setSubmitting(false);
@@ -64,57 +67,66 @@ const EmailVerificationForm = ({submissionUrl, componentKey, emailAddress, onVer
 
   return (
     <Formik initialValues={{mode: 'sendCode', code: ''}} onSubmit={onSubmit}>
-      {({handleSubmit, values: {mode}}) => (
-        <Body component="form" onSubmit={handleSubmit}>
-          <Body modifiers={['big']}>
-            <FormattedMessage
-              description="Email verification modal body text"
-              defaultMessage={`You are verifying the email address <link>{emailAddress}</link>.
+      {({handleSubmit, values: {mode}}) =>
+        error ? (
+          <Body component="div">
+            <DisplayError error={error} />
+          </Body>
+        ) : (
+          <Body component="form" onSubmit={handleSubmit}>
+            <Body modifiers={['big']}>
+              <FormattedMessage
+                description="Email verification modal body text"
+                defaultMessage={`You are verifying the email address <link>{emailAddress}</link>.
               First, we need to send you a verification code on this email address. Then,
               you need to enter the code to confirm it.`}
-              values={{
-                emailAddress,
-                link: chunks => <UtrechtLink href={`mailto:${emailAddress}`}>{chunks}</UtrechtLink>,
-              }}
-            />
-          </Body>
-
-          <div className="openforms-form-field-container">
-            <ModeField />
-            {mode === 'enterCode' && (
-              <TextField
-                name="code"
-                label={
-                  <FormattedMessage
-                    description="Email verification: code input field label"
-                    defaultMessage="Enter the six-character code"
-                  />
-                }
-                pattern="[A-Z0-9]{6}"
-                description={
-                  <FormattedMessage
-                    description="Email verification: code input field description"
-                    defaultMessage="The code is exactly six characters long and consists of only uppercase letters and numbers."
-                  />
-                }
+                values={{
+                  emailAddress,
+                  link: chunks => (
+                    <UtrechtLink href={`mailto:${emailAddress}`}>{chunks}</UtrechtLink>
+                  ),
+                }}
               />
-            )}
-          </div>
+            </Body>
 
-          <Toolbar modifiers={['bottom', 'reverse']}>
-            <ToolbarList>
-              {mode === 'sendCode' && (
-                <SendCodeButton
-                  submissionUrl={submissionUrl}
-                  componentKey={componentKey}
-                  emailAddress={emailAddress}
+            <div className="openforms-form-field-container">
+              <ModeField />
+              {mode === 'enterCode' && (
+                <TextField
+                  name="code"
+                  label={
+                    <FormattedMessage
+                      description="Email verification: code input field label"
+                      defaultMessage="Enter the six-character code"
+                    />
+                  }
+                  pattern="[A-Z0-9]{6}"
+                  description={
+                    <FormattedMessage
+                      description="Email verification: code input field description"
+                      defaultMessage="The code is exactly six characters long and consists of only uppercase letters and numbers."
+                    />
+                  }
                 />
               )}
-              {mode === 'enterCode' && <EnterCodeButton />}
-            </ToolbarList>
-          </Toolbar>
-        </Body>
-      )}
+            </div>
+
+            <Toolbar modifiers={['bottom', 'reverse']}>
+              <ToolbarList>
+                {mode === 'sendCode' && (
+                  <SendCodeButton
+                    submissionUrl={submissionUrl}
+                    componentKey={componentKey}
+                    emailAddress={emailAddress}
+                    onError={error => setError(error)}
+                  />
+                )}
+                {mode === 'enterCode' && <EnterCodeButton />}
+              </ToolbarList>
+            </Toolbar>
+          </Body>
+        )
+      }
     </Formik>
   );
 };

--- a/src/components/EmailVerification/EmailVerificationForm.js
+++ b/src/components/EmailVerification/EmailVerificationForm.js
@@ -78,6 +78,11 @@ const EmailVerificationForm = ({submissionUrl, componentKey, emailAddress}) => {
                 <SendCodeButton
                   isSending={codeSending}
                   onSendCode={async () => {
+                    if (!emailAddress) {
+                      // TODO: proper handling
+                      alert('no email set');
+                      return;
+                    }
                     setCodeSending(true);
                     try {
                       await createVerification(baseUrl, {

--- a/src/components/EmailVerification/EmailVerificationForm.stories.js
+++ b/src/components/EmailVerification/EmailVerificationForm.stories.js
@@ -1,19 +1,25 @@
-import {expect, userEvent, within} from '@storybook/test';
+import {expect, fn, userEvent, within} from '@storybook/test';
+import {withRouter} from 'storybook-addon-remix-react-router';
 
 import {BASE_URL} from 'api-mocks';
 import {ConfigDecorator} from 'story-utils/decorators';
 
 import {EmailVerificationForm} from '.';
-import {mockEmailVerificationPost, mockEmailVerificationVerifyCodePost} from './mocks';
+import {
+  mockEmailVerificationErrorPost,
+  mockEmailVerificationPost,
+  mockEmailVerificationVerifyCodePost,
+} from './mocks';
 
 export default {
   title: 'Private API / Email verification / Modal content',
   component: EmailVerificationForm,
-  decorators: [ConfigDecorator],
+  decorators: [ConfigDecorator, withRouter],
   args: {
     submissionUrl: `${BASE_URL}submissions/123`,
     emailAddress: 'openforms@example.com',
     componentKey: 'emailWithVerificationRequirement',
+    onVerified: fn(),
   },
   parameters: {
     msw: {
@@ -24,7 +30,7 @@ export default {
 
 export const Default = {};
 
-export const Flow = {
+export const HappyFlow = {
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
 
@@ -33,6 +39,21 @@ export const Flow = {
     expect(codeInput).toBeVisible();
     await userEvent.type(codeInput, 'ABCD12');
     await userEvent.click(canvas.getByRole('button', {name: 'Verify'}));
+  },
+};
+
+export const ArbitrarySendCodeErrorFlow = {
+  parameters: {
+    msw: {
+      handlers: [mockEmailVerificationErrorPost, mockEmailVerificationVerifyCodePost],
+    },
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(await canvas.findByRole('button', {name: 'Send code'}));
+    expect(await canvas.findByText('No permission to perform this action.')).toBeVisible();
   },
 };
 
@@ -47,5 +68,19 @@ export const InvalidCodeFlow = {
     await userEvent.click(canvas.getByRole('button', {name: 'Verify'}));
 
     expect(await canvas.findByText('Not a valid verification code')).toBeVisible();
+  },
+};
+
+export const ArbitraryVerificationErrorFlow = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(await canvas.findByRole('button', {name: 'Send code'}));
+    const codeInput = await canvas.findByLabelText('Enter the six-character code');
+    expect(codeInput).toBeVisible();
+    await userEvent.type(codeInput, 'NOPERM'); // mock returns 403
+    await userEvent.click(canvas.getByRole('button', {name: 'Verify'}));
+
+    expect(await canvas.findByText('No permission to perform this action.')).toBeVisible();
   },
 };

--- a/src/components/EmailVerification/EmailVerificationForm.stories.js
+++ b/src/components/EmailVerification/EmailVerificationForm.stories.js
@@ -4,7 +4,7 @@ import {BASE_URL} from 'api-mocks';
 import {ConfigDecorator} from 'story-utils/decorators';
 
 import {EmailVerificationForm} from '.';
-import {mockEmailVerificationPost} from './mocks';
+import {mockEmailVerificationPost, mockEmailVerificationVerifyCodePost} from './mocks';
 
 export default {
   title: 'Private API / Email verification / Modal content',
@@ -17,7 +17,7 @@ export default {
   },
   parameters: {
     msw: {
-      handlers: [mockEmailVerificationPost],
+      handlers: [mockEmailVerificationPost, mockEmailVerificationVerifyCodePost],
     },
   },
 };

--- a/src/components/EmailVerification/EmailVerificationForm.stories.js
+++ b/src/components/EmailVerification/EmailVerificationForm.stories.js
@@ -1,0 +1,37 @@
+import {expect, userEvent, within} from '@storybook/test';
+
+import {BASE_URL} from 'api-mocks';
+import {ConfigDecorator} from 'story-utils/decorators';
+
+import EmailVerificationForm from './EmailVerificationForm';
+import {mockEmailVerificationPost} from './mocks';
+
+export default {
+  title: 'Private API / Email verification / Modal content',
+  component: EmailVerificationForm,
+  decorators: [ConfigDecorator],
+  args: {
+    submissionUrl: `${BASE_URL}submissions/123`,
+    emailAddress: 'openforms@example.com',
+    componentKey: 'emailWithVerificationRequirement',
+  },
+  parameters: {
+    msw: {
+      handlers: [mockEmailVerificationPost],
+    },
+  },
+};
+
+export const Default = {};
+
+export const Flow = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(await canvas.findByRole('button', {name: 'Send code'}));
+    const codeInput = await canvas.findByLabelText('Enter the six-character code');
+    expect(codeInput).toBeVisible();
+    await userEvent.type(codeInput, 'ABCD12');
+    await userEvent.click(canvas.getByRole('button', {name: 'Verify'}));
+  },
+};

--- a/src/components/EmailVerification/EmailVerificationForm.stories.js
+++ b/src/components/EmailVerification/EmailVerificationForm.stories.js
@@ -35,3 +35,17 @@ export const Flow = {
     await userEvent.click(canvas.getByRole('button', {name: 'Verify'}));
   },
 };
+
+export const InvalidCodeFlow = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(await canvas.findByRole('button', {name: 'Send code'}));
+    const codeInput = await canvas.findByLabelText('Enter the six-character code');
+    expect(codeInput).toBeVisible();
+    await userEvent.type(codeInput, 'FAILME'); // mock returns validation error
+    await userEvent.click(canvas.getByRole('button', {name: 'Verify'}));
+
+    expect(await canvas.findByText('Not a valid verification code')).toBeVisible();
+  },
+};

--- a/src/components/EmailVerification/EmailVerificationForm.stories.js
+++ b/src/components/EmailVerification/EmailVerificationForm.stories.js
@@ -3,7 +3,7 @@ import {expect, userEvent, within} from '@storybook/test';
 import {BASE_URL} from 'api-mocks';
 import {ConfigDecorator} from 'story-utils/decorators';
 
-import EmailVerificationForm from './EmailVerificationForm';
+import {EmailVerificationForm} from '.';
 import {mockEmailVerificationPost} from './mocks';
 
 export default {

--- a/src/components/EmailVerification/EmailVerificationForm.stories.js
+++ b/src/components/EmailVerification/EmailVerificationForm.stories.js
@@ -37,7 +37,8 @@ export const HappyFlow = {
     await userEvent.click(await canvas.findByRole('button', {name: 'Send code'}));
     const codeInput = await canvas.findByLabelText('Enter the six-character code');
     expect(codeInput).toBeVisible();
-    await userEvent.type(codeInput, 'ABCD12');
+    await userEvent.type(codeInput, 'abcd12');
+    expect(codeInput).toHaveValue('ABCD12'); // automatically convert to uppercase
     await userEvent.click(canvas.getByRole('button', {name: 'Verify'}));
   },
 };

--- a/src/components/EmailVerification/EmailVerificationModal.js
+++ b/src/components/EmailVerification/EmailVerificationModal.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import Body from 'components/Body';
@@ -15,6 +15,12 @@ const EmailVerificationModal = ({
   emailAddress,
 }) => {
   const [isVerified, setIsVerified] = useState(false);
+
+  useEffect(() => {
+    // once the modal closes, reset the internal state
+    if (!isOpen && isVerified) setIsVerified(false);
+  }, [isOpen, isVerified, setIsVerified]);
+
   return (
     <Modal
       title={

--- a/src/components/EmailVerification/EmailVerificationModal.js
+++ b/src/components/EmailVerification/EmailVerificationModal.js
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import Modal from 'components/modals/Modal';
+
+import EmailVerificationForm from './EmailVerificationForm';
+
+const EmailVerificationModal = ({
+  isOpen,
+  closeModal,
+  submissionUrl,
+  componentKey,
+  emailAddress,
+}) => (
+  <Modal
+    title={
+      <FormattedMessage
+        description="Email verification modal title"
+        defaultMessage="Email address verification"
+      />
+    }
+    isOpen={isOpen}
+    closeModal={closeModal}
+  >
+    <EmailVerificationForm
+      submissionUrl={submissionUrl}
+      componentKey={componentKey}
+      emailAddress={emailAddress}
+    />
+  </Modal>
+);
+
+EmailVerificationModal.propTypes = {
+  /**
+   * Modal open/closed state.
+   */
+  isOpen: PropTypes.bool.isRequired,
+  /**
+   * Callback function to close the modal
+   *
+   * Invoked on ESC keypress or clicking the "X" to close the modal.
+   */
+  closeModal: PropTypes.func.isRequired,
+  submissionUrl: PropTypes.string.isRequired,
+  componentKey: PropTypes.string.isRequired,
+  emailAddress: PropTypes.string.isRequired,
+};
+
+export default EmailVerificationModal;

--- a/src/components/EmailVerification/EmailVerificationModal.js
+++ b/src/components/EmailVerification/EmailVerificationModal.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 
+import Body from 'components/Body';
 import Modal from 'components/modals/Modal';
 
 import EmailVerificationForm from './EmailVerificationForm';
@@ -12,24 +13,31 @@ const EmailVerificationModal = ({
   submissionUrl,
   componentKey,
   emailAddress,
-}) => (
-  <Modal
-    title={
-      <FormattedMessage
-        description="Email verification modal title"
-        defaultMessage="Email address verification"
-      />
-    }
-    isOpen={isOpen}
-    closeModal={closeModal}
-  >
-    <EmailVerificationForm
-      submissionUrl={submissionUrl}
-      componentKey={componentKey}
-      emailAddress={emailAddress}
-    />
-  </Modal>
-);
+}) => {
+  const [isVerified, setIsVerified] = useState(false);
+  return (
+    <Modal
+      title={
+        <FormattedMessage
+          description="Email verification modal title"
+          defaultMessage="Email address verification"
+        />
+      }
+      isOpen={isOpen}
+      closeModal={closeModal}
+    >
+      {!isVerified && (
+        <EmailVerificationForm
+          submissionUrl={submissionUrl}
+          componentKey={componentKey}
+          emailAddress={emailAddress}
+          onVerified={() => setIsVerified(true)}
+        />
+      )}
+      <div aria-live="polite">{isVerified && <VerificationSuccess />}</div>
+    </Modal>
+  );
+};
 
 EmailVerificationModal.propTypes = {
   /**
@@ -46,5 +54,15 @@ EmailVerificationModal.propTypes = {
   componentKey: PropTypes.string.isRequired,
   emailAddress: PropTypes.string.isRequired,
 };
+
+const VerificationSuccess = () => (
+  <Body modifiers={['big']}>
+    <FormattedMessage
+      description="Text displayed after successful email verification"
+      defaultMessage={`The email address has now been verified. You can close this
+      window and continue with the rest of the form.`}
+    />
+  </Body>
+);
 
 export default EmailVerificationModal;

--- a/src/components/EmailVerification/EmailVerificationModal.stories.js
+++ b/src/components/EmailVerification/EmailVerificationModal.stories.js
@@ -1,0 +1,27 @@
+import {fn} from '@storybook/test';
+
+import {BASE_URL} from 'api-mocks';
+import {ConfigDecorator} from 'story-utils/decorators';
+
+import {EmailVerificationModal} from '.';
+import {mockEmailVerificationPost} from './mocks';
+
+export default {
+  title: 'Private API / Email verification / Modal',
+  component: EmailVerificationModal,
+  decorators: [ConfigDecorator],
+  args: {
+    isOpen: true,
+    closeModal: fn(),
+    submissionUrl: `${BASE_URL}submissions/123`,
+    emailAddress: 'openforms@example.com',
+    componentKey: 'emailWithVerificationRequirement',
+  },
+  parameters: {
+    msw: {
+      handlers: [mockEmailVerificationPost],
+    },
+  },
+};
+
+export const Default = {};

--- a/src/components/EmailVerification/EmailVerificationModal.stories.js
+++ b/src/components/EmailVerification/EmailVerificationModal.stories.js
@@ -4,7 +4,7 @@ import {BASE_URL} from 'api-mocks';
 import {ConfigDecorator} from 'story-utils/decorators';
 
 import {EmailVerificationModal} from '.';
-import {mockEmailVerificationPost} from './mocks';
+import {mockEmailVerificationPost, mockEmailVerificationVerifyCodePost} from './mocks';
 
 export default {
   title: 'Private API / Email verification / Modal',
@@ -19,7 +19,7 @@ export default {
   },
   parameters: {
     msw: {
-      handlers: [mockEmailVerificationPost],
+      handlers: [mockEmailVerificationPost, mockEmailVerificationVerifyCodePost],
     },
   },
 };

--- a/src/components/EmailVerification/EnterCodeButton.js
+++ b/src/components/EmailVerification/EnterCodeButton.js
@@ -1,0 +1,23 @@
+import {useFormikContext} from 'formik';
+import {FormattedMessage} from 'react-intl';
+
+import {OFButton} from 'components/Button';
+import Loader from 'components/Loader';
+
+const EnterCodeButton = () => {
+  const {isSubmitting} = useFormikContext();
+  return (
+    <OFButton type="submit" appearance="primary-action-button" disabled={isSubmitting}>
+      {isSubmitting ? (
+        <Loader modifiers={['centered', 'only-child', 'small', 'gray']} />
+      ) : (
+        <FormattedMessage
+          description="Email verification: verify code button text"
+          defaultMessage="Verify"
+        />
+      )}
+    </OFButton>
+  );
+};
+
+export default EnterCodeButton;

--- a/src/components/EmailVerification/ModeField.js
+++ b/src/components/EmailVerification/ModeField.js
@@ -1,0 +1,34 @@
+import {useIntl} from 'react-intl';
+
+import {RadioField} from 'components/forms';
+
+const ModeField = () => {
+  const intl = useIntl();
+  return (
+    <RadioField
+      name="mode"
+      label={intl.formatMessage({
+        description: 'Email verification mode selection label',
+        defaultMessage: 'What would you like to do?',
+      })}
+      options={[
+        {
+          value: 'sendCode',
+          label: intl.formatMessage({
+            description: 'Email verification mode selection: send code label',
+            defaultMessage: 'Receive a verification code',
+          }),
+        },
+        {
+          value: 'enterCode',
+          label: intl.formatMessage({
+            description: 'Email verification mode selection: enter code label',
+            defaultMessage: 'Enter the verification code',
+          }),
+        },
+      ]}
+    />
+  );
+};
+
+export default ModeField;

--- a/src/components/EmailVerification/SendCodeButton.js
+++ b/src/components/EmailVerification/SendCodeButton.js
@@ -7,7 +7,6 @@ import {ConfigContext} from 'Context';
 import {post} from 'api';
 import {OFButton} from 'components/Button';
 import Loader from 'components/Loader';
-import {ValidationError} from 'errors';
 
 const createVerification = async (baseUrl, {submissionUrl, componentKey, emailAddress}) => {
   await post(`${baseUrl}submissions/email-verifications`, {
@@ -17,7 +16,7 @@ const createVerification = async (baseUrl, {submissionUrl, componentKey, emailAd
   });
 };
 
-const SendCodeButton = ({submissionUrl, componentKey, emailAddress}) => {
+const SendCodeButton = ({submissionUrl, componentKey, emailAddress, onError}) => {
   const {baseUrl} = useContext(ConfigContext);
   const [isSending, setIsSending] = useState(false);
   const {setFieldValue} = useFormikContext();
@@ -34,13 +33,7 @@ const SendCodeButton = ({submissionUrl, componentKey, emailAddress}) => {
             emailAddress,
           });
         } catch (e) {
-          if (e instanceof ValidationError) {
-            // TODO: set in formik state
-            console.error(e.invalidParams);
-          } else {
-            // TODO: catch and display error instead, now it's (silently) suppressed
-            throw e;
-          }
+          onError(e);
         } finally {
           setIsSending(false);
         }
@@ -65,6 +58,7 @@ SendCodeButton.propTypes = {
   submissionUrl: PropTypes.string.isRequired,
   componentKey: PropTypes.string.isRequired,
   emailAddress: PropTypes.string.isRequired,
+  onError: PropTypes.func.isRequired,
 };
 
 export default SendCodeButton;

--- a/src/components/EmailVerification/SendCodeButton.js
+++ b/src/components/EmailVerification/SendCodeButton.js
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+import {FormattedMessage} from 'react-intl';
+
+import {OFButton} from 'components/Button';
+import Loader from 'components/Loader';
+
+const SendCodeButton = ({isSending, onSendCode}) => (
+  <OFButton
+    type="button"
+    appearance="primary-action-button"
+    onClick={onSendCode}
+    disabled={isSending}
+  >
+    {isSending ? (
+      <Loader modifiers={['centered', 'only-child', 'small', 'gray']} />
+    ) : (
+      <FormattedMessage
+        description="Email verification: send code button text"
+        defaultMessage="Send code"
+      />
+    )}
+  </OFButton>
+);
+
+SendCodeButton.propTypes = {
+  isSending: PropTypes.bool.isRequired,
+  onSendCode: PropTypes.func.isRequired,
+};
+
+export default SendCodeButton;

--- a/src/components/EmailVerification/SendCodeButton.js
+++ b/src/components/EmailVerification/SendCodeButton.js
@@ -1,30 +1,70 @@
+import {useFormikContext} from 'formik';
 import PropTypes from 'prop-types';
+import {useContext, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 
+import {ConfigContext} from 'Context';
+import {post} from 'api';
 import {OFButton} from 'components/Button';
 import Loader from 'components/Loader';
+import {ValidationError} from 'errors';
 
-const SendCodeButton = ({isSending, onSendCode}) => (
-  <OFButton
-    type="button"
-    appearance="primary-action-button"
-    onClick={onSendCode}
-    disabled={isSending}
-  >
-    {isSending ? (
-      <Loader modifiers={['centered', 'only-child', 'small', 'gray']} />
-    ) : (
-      <FormattedMessage
-        description="Email verification: send code button text"
-        defaultMessage="Send code"
-      />
-    )}
-  </OFButton>
-);
+const createVerification = async (baseUrl, {submissionUrl, componentKey, emailAddress}) => {
+  await post(`${baseUrl}submissions/email-verifications`, {
+    submission: submissionUrl,
+    componentKey,
+    email: emailAddress,
+  });
+};
+
+const SendCodeButton = ({submissionUrl, componentKey, emailAddress}) => {
+  const {baseUrl} = useContext(ConfigContext);
+  const [isSending, setIsSending] = useState(false);
+  const {setFieldValue} = useFormikContext();
+  return (
+    <OFButton
+      type="button"
+      appearance="primary-action-button"
+      onClick={async () => {
+        setIsSending(true);
+        try {
+          await createVerification(baseUrl, {
+            submissionUrl,
+            componentKey,
+            emailAddress,
+          });
+        } catch (e) {
+          if (e instanceof ValidationError) {
+            // TODO: set in formik state
+            console.error(e.invalidParams);
+          } else {
+            // TODO: catch and display error instead, now it's (silently) suppressed
+            throw e;
+          }
+        } finally {
+          setIsSending(false);
+        }
+
+        setFieldValue('mode', 'enterCode');
+      }}
+      disabled={!emailAddress || isSending}
+    >
+      {isSending ? (
+        <Loader modifiers={['centered', 'only-child', 'small', 'gray']} />
+      ) : (
+        <FormattedMessage
+          description="Email verification: send code button text"
+          defaultMessage="Send code"
+        />
+      )}
+    </OFButton>
+  );
+};
 
 SendCodeButton.propTypes = {
-  isSending: PropTypes.bool.isRequired,
-  onSendCode: PropTypes.func.isRequired,
+  submissionUrl: PropTypes.string.isRequired,
+  componentKey: PropTypes.string.isRequired,
+  emailAddress: PropTypes.string.isRequired,
 };
 
 export default SendCodeButton;

--- a/src/components/EmailVerification/index.js
+++ b/src/components/EmailVerification/index.js
@@ -1,0 +1,1 @@
+export {default as EmailVerificationForm} from './EmailVerificationForm';

--- a/src/components/EmailVerification/index.js
+++ b/src/components/EmailVerification/index.js
@@ -1,1 +1,2 @@
 export {default as EmailVerificationForm} from './EmailVerificationForm';
+export {default as EmailVerificationModal} from './EmailVerificationModal';

--- a/src/components/EmailVerification/mocks.js
+++ b/src/components/EmailVerification/mocks.js
@@ -10,26 +10,56 @@ export const mockEmailVerificationPost = rest.post(
   }
 );
 
+export const mockEmailVerificationErrorPost = rest.post(
+  `${BASE_URL}submissions/email-verifications`,
+  async (req, res, ctx) => {
+    return res(
+      ctx.status(403),
+      ctx.json({
+        type: 'PermissonDenied',
+        code: 'permission_denied',
+        title: 'Permission denied',
+        status: 403,
+        detail: 'No permission to perform this action.',
+        instance: 'urn:5678',
+      })
+    );
+  }
+);
+
+const codeToStatus = {
+  FAILME: 400,
+  NOPERM: 403,
+};
+
+const statusToBody = {
+  400: {
+    type: 'BadRequest',
+    code: 'bad_request',
+    title: 'Bad request',
+    status: 400,
+    detail: 'Data invalid',
+    instance: 'urn:1234',
+    invalidParams: [{name: 'code', code: 'invalid', reason: 'Not a valid verification code'}],
+  },
+  403: {
+    type: 'PermissonDenied',
+    code: 'permission_denied',
+    title: 'Permission denied',
+    status: 403,
+    detail: 'No permission to perform this action.',
+    instance: 'urn:5678',
+  },
+};
+
 export const mockEmailVerificationVerifyCodePost = rest.post(
   `${BASE_URL}submissions/email-verifications/verify`,
   async (req, res, ctx) => {
     const {componentKey, email, code} = await req.json();
 
-    const statusCode = code !== 'FAILME' ? 200 : 400;
-    const responseData =
-      statusCode === 200
-        ? {componentKey, email}
-        : {
-            type: 'BadRequest',
-            code: 'bad_request',
-            title: 'Bad request',
-            status: 400,
-            detail: 'Data invalid',
-            instance: 'urn:1234',
-            invalidParams: [
-              {name: 'code', code: 'invalid', reason: 'Not a valid verification code'},
-            ],
-          };
+    const statusCode = codeToStatus?.[code] ?? 200;
+
+    const responseData = statusCode === 200 ? {componentKey, email} : statusToBody[statusCode];
     return res(ctx.status(statusCode), ctx.json(responseData));
   }
 );

--- a/src/components/EmailVerification/mocks.js
+++ b/src/components/EmailVerification/mocks.js
@@ -9,3 +9,27 @@ export const mockEmailVerificationPost = rest.post(
     return res(ctx.json({componentKey, email}));
   }
 );
+
+export const mockEmailVerificationVerifyCodePost = rest.post(
+  `${BASE_URL}submissions/email-verifications/verify`,
+  async (req, res, ctx) => {
+    const {componentKey, email, code} = await req.json();
+
+    const statusCode = code !== 'FAILME' ? 200 : 400;
+    const responseData =
+      statusCode === 200
+        ? {componentKey, email}
+        : {
+            type: 'BadRequest',
+            code: 'bad_request',
+            title: 'Bad request',
+            status: 400,
+            detail: 'Data invalid',
+            instance: 'urn:1234',
+            invalidParams: [
+              {name: 'code', code: 'invalid', reason: 'Not a valid verification code'},
+            ],
+          };
+    return res(ctx.status(statusCode), ctx.json(responseData));
+  }
+);

--- a/src/components/EmailVerification/mocks.js
+++ b/src/components/EmailVerification/mocks.js
@@ -1,0 +1,11 @@
+import {rest} from 'msw';
+
+import {BASE_URL} from 'api-mocks';
+
+export const mockEmailVerificationPost = rest.post(
+  `${BASE_URL}submissions/email-verifications`,
+  async (req, res, ctx) => {
+    const {componentKey, email} = await req.json();
+    return res(ctx.json({componentKey, email}));
+  }
+);

--- a/src/components/Errors/ErrorBoundary.js
+++ b/src/components/Errors/ErrorBoundary.js
@@ -39,14 +39,18 @@ class ErrorBoundary extends React.Component {
       return children;
     }
 
-    const ErrorComponent = ERROR_TYPE_MAP[error.name] || GenericError;
-    const Wrapper = useCard ? Card : 'div';
-    return <ErrorComponent wrapper={Wrapper} error={error} />;
+    return <DisplayError useCard={useCard} error={error} />;
   }
 }
 
 ErrorBoundary.propTypes = {
   useCard: PropTypes.bool,
+};
+
+const DisplayError = ({error, useCard = false}) => {
+  const ErrorComponent = ERROR_TYPE_MAP[error.name] || GenericError;
+  const Wrapper = useCard ? Card : 'div';
+  return <ErrorComponent wrapper={Wrapper} error={error} />;
 };
 
 const GenericError = ({wrapper: Wrapper, error}) => {
@@ -156,5 +160,5 @@ const ERROR_TYPE_MAP = {
   ServiceUnavailable: ServiceUnavailableError,
 };
 
-export {logError};
+export {logError, DisplayError};
 export default ErrorBoundary;

--- a/src/components/FormStep/FormStep.stories.js
+++ b/src/components/FormStep/FormStep.stories.js
@@ -1,11 +1,13 @@
-import {expect, fn, within} from '@storybook/test';
+import {expect, fn, userEvent, within} from '@storybook/test';
 import produce from 'immer';
 import {getWorker} from 'msw-storybook-addon';
 import {withRouter} from 'storybook-addon-remix-react-router';
 import {v4 as uuid4} from 'uuid';
 
 import {buildForm, buildSubmission} from 'api-mocks';
+import {mockEmailVerificationPost} from 'components/EmailVerification/mocks';
 import {AnalyticsToolsDecorator, ConfigDecorator} from 'story-utils/decorators';
+import {sleep} from 'utils';
 
 import FormStep from '.';
 import {
@@ -65,7 +67,8 @@ const render = ({
   worker.resetHandlers();
   worker.use(
     mockSubmissionStepGet(submissionStepDetailBody),
-    mockSubmissionLogicCheckPost(submission, submissionStepDetailBody)
+    mockSubmissionLogicCheckPost(submission, submissionStepDetailBody),
+    mockEmailVerificationPost
   );
   return (
     <FormStep
@@ -214,5 +217,42 @@ export const govmetricEnabled = {
 
     const abortButton = await canvas.findByRole('button', {name: 'Afbreken'});
     await expect(abortButton).toBeVisible();
+  },
+};
+
+export const EmailVerification = {
+  render,
+  args: {
+    formioConfiguration: {
+      display: 'form',
+      components: [
+        {
+          type: 'email',
+          key: 'email',
+          label: 'Email address',
+          description: 'Email component requiring verification',
+          openForms: {
+            requireVerification: true,
+          },
+        },
+      ],
+    },
+    form: buildForm(),
+    submission: buildSubmission(),
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    // Formio...
+    await sleep(500);
+
+    const emailInput = await canvas.findByLabelText('Email address');
+    await userEvent.type(emailInput, 'openforms@example.com');
+    await userEvent.click(canvas.getByRole('button', {name: 'Verify'}));
+
+    const modal = await canvas.findByRole('dialog');
+    expect(modal).toBeVisible();
+    await userEvent.click(within(modal).getByRole('button', {name: 'Send code'}));
+    expect(await within(modal).findByLabelText('Enter the six-character code')).toBeVisible();
   },
 };

--- a/src/components/Summary/Summary.stories.js
+++ b/src/components/Summary/Summary.stories.js
@@ -328,40 +328,16 @@ export const MultipleRequiredStatements = {
         const submitButton = canvas.getByRole('button', {name: 'Confirm'});
         expect(submitButton).toHaveAttribute('aria-disabled', 'true');
 
-        // Clicking 'submit' without checking the statements results in all the warnings being
-        // displayed
-        await userEvent.click(submitButton);
-        expect(
-          await canvas.findByText('Je moet akkoord gaan met het privacybeleid om door te gaan')
-        ).toBeVisible();
-        expect(
-          await canvas.findByText(
-            'Je moet verklaren dat het formulier naar waarheid ingevuld is om door te gaan'
-          )
-        ).toBeVisible();
-
         // Accepting the privacy policy makes one warning disappear
         const checkboxPrivacy = canvas.getByLabelText(
           /I accept the privacy policy and consent to the processing of my personal data/
         );
         await userEvent.click(checkboxPrivacy);
-        await canvas.findByText(
-          'Je moet verklaren dat het formulier naar waarheid ingevuld is om door te gaan'
-        );
-        expect(
-          canvas.queryByText('Je moet akkoord gaan met het privacybeleid om door te gaan')
-        ).toBeNull();
 
         // Accepting the truth declaration makes the second warning disappear and the 'submit'
         // button is no longer disabled
         const checkboxTruth = canvas.getByLabelText('I responded very honestly.');
         await userEvent.click(checkboxTruth);
-        expect(
-          canvas.queryByText('Je moet akkoord gaan met het privacybeleid om door te gaan')
-        ).toBeNull();
-        expect(
-          canvas.queryByText('Je moet akkoord gaan met het privacybeleid om door te gaan')
-        ).toBeNull();
 
         expect(submitButton).toHaveAttribute('aria-disabled', 'false');
       }

--- a/src/components/modals/Modal.js
+++ b/src/components/modals/Modal.js
@@ -1,10 +1,13 @@
 import PropTypes from 'prop-types';
-import React, {useEffect} from 'react';
+import React, {createContext, useContext, useEffect} from 'react';
 import {useIntl} from 'react-intl';
 import ReactModal from 'react-modal';
 
 import FAIcon from 'components/FAIcon';
 import {getBEMClassName} from 'utils';
+
+export const ModalContext = createContext({});
+ModalContext.displayName = 'ModalContext';
 
 const usePreventScroll = open => {
   useEffect(() => {
@@ -30,12 +33,15 @@ const Modal = ({
 }) => {
   usePreventScroll(isOpen);
   const intl = useIntl();
+  const {parentSelector, ariaHideApp} = useContext(ModalContext);
   return (
     <ReactModal
       isOpen={isOpen}
       onRequestClose={closeModal}
       className={getBEMClassName('react-modal__content', contentModifiers)}
       overlayClassName={getBEMClassName('react-modal__overlay')}
+      parentSelector={parentSelector}
+      ariaHideApp={ariaHideApp}
       {...props}
     >
       <header className={getBEMClassName('react-modal__header')}>

--- a/src/formio/components/Email.js
+++ b/src/formio/components/Email.js
@@ -37,6 +37,27 @@ class Email extends Formio.Components.components.email {
     // ... and we finally restore the type to email.
     input.setAttribute('type', 'email');
   }
+
+  attach(element) {
+    this.loadRefs(element, {
+      verifyButton: 'multiple',
+    });
+    return super.attach(element);
+  }
+
+  attachElement(element, index) {
+    const promise = super.attachElement(element, index);
+
+    const verifyButton = this.refs.verifyButton[index];
+    this.addEventListener(verifyButton, 'click', () => {
+      const key = this.component.key;
+      const email = this.getValueAt(index) || '';
+      const callback = this.options.ofContext?.verifyEmailCallback;
+      callback && callback({key, email});
+    });
+
+    return promise;
+  }
 }
 
 export default Email;

--- a/src/formio/components/Email.stories.js
+++ b/src/formio/components/Email.stories.js
@@ -32,3 +32,30 @@ export const Email = {
     label: 'E-mailadres',
   },
 };
+
+export const EmailWithVerification = {
+  render: SingleFormioComponent,
+  args: {
+    key: 'email',
+    label: 'Email address requiring verification',
+    extraComponentProperties: {
+      openForms: {
+        requireVerification: true,
+      },
+    },
+  },
+};
+
+export const MultipleEmailWithVerification = {
+  render: SingleFormioComponent,
+  args: {
+    key: 'email',
+    label: 'Email address requiring verification',
+    extraComponentProperties: {
+      multiple: true,
+      openForms: {
+        requireVerification: true,
+      },
+    },
+  },
+};

--- a/src/formio/components/Email.stories.js
+++ b/src/formio/components/Email.stories.js
@@ -1,3 +1,5 @@
+import {fn} from '@storybook/test';
+
 import {withUtrechtDocument} from 'story-utils/decorators';
 
 import {SingleFormioComponent} from './story-util';
@@ -43,6 +45,9 @@ export const EmailWithVerification = {
         requireVerification: true,
       },
     },
+    ofContext: {
+      verifyEmailCallback: fn(),
+    },
   },
 };
 
@@ -56,6 +61,9 @@ export const MultipleEmailWithVerification = {
       openForms: {
         requireVerification: true,
       },
+    },
+    ofContext: {
+      verifyEmailCallback: fn(),
     },
   },
 };

--- a/src/formio/components/story-util.js
+++ b/src/formio/components/story-util.js
@@ -6,7 +6,12 @@ import {useIntl} from 'react-intl';
 import {ConfigContext, FormioTranslations} from 'Context';
 import {PREFIX} from 'formio/constants';
 
-const RenderFormioForm = ({configuration, submissionData = {}, evalContext = {}}) => {
+const RenderFormioForm = ({
+  configuration,
+  submissionData = {},
+  evalContext = {},
+  ofContext = {},
+}) => {
   const config = useContext(ConfigContext);
   const formioTranslations = useContext(FormioTranslations);
   const intl = useIntl();
@@ -29,6 +34,7 @@ const RenderFormioForm = ({configuration, submissionData = {}, evalContext = {}}
         intl,
         ofContext: {
           submissionUuid: '426c8d33-6dcb-4578-8208-f17071a4aebe',
+          ...ofContext,
         },
       }}
     />
@@ -43,6 +49,7 @@ export const SingleFormioComponent = ({
   extraComponentProperties = {},
   submissionData = {},
   evalContext = {},
+  ofContext = {},
 }) => {
   // in case this is used as a react component, allow using an alias, because React
   // reserves the key 'prop'
@@ -53,13 +60,15 @@ export const SingleFormioComponent = ({
       configuration={{type: 'form', components: [component]}}
       submissionData={submissionData}
       evalContext={evalContext}
+      ofContext={ofContext}
     />
   );
 };
 
-export const MultipleFormioComponents = ({components, evalContext = {}}) => (
+export const MultipleFormioComponents = ({components, evalContext = {}, ofContext = {}}) => (
   <RenderFormioForm
     configuration={{type: 'form', components: components}}
     evalContext={evalContext}
+    ofContext={ofContext}
   />
 );

--- a/src/formio/templates/field.ejs
+++ b/src/formio/templates/field.ejs
@@ -46,7 +46,11 @@
 
 <!-- leaf nodes -->
 {% } else { %}
-  <div class="utrecht-form-field utrecht-form-field--{{ctx.component.type}} utrecht-form-field--openforms">
+  <div class="utrecht-form-field
+              utrecht-form-field--{{ctx.component.type}}
+              utrecht-form-field--openforms
+              {% if (ctx.component?.openForms?.requireVerification) { %}utrecht-form-field--has-button{% } %}
+  ">
     {% if (!ctx.label.hidden && ctx.label.labelPosition !== 'bottom') { %}
       {{ ctx.labelMarkup }}
     {% } %}

--- a/src/formio/templates/text.ejs
+++ b/src/formio/templates/text.ejs
@@ -38,3 +38,9 @@
 {% if (ctx.prefix || ctx.suffix) { %}
 </div>
 {% } %}
+
+{% if (ctx.component?.openForms?.requireVerification) { %}
+<button ref="verify-button" class="utrecht-button utrecht-button--primary-action">
+  {{ctx.t('Verify')}}
+</button>
+{% } %}

--- a/src/formio/templates/text.ejs
+++ b/src/formio/templates/text.ejs
@@ -40,6 +40,16 @@
 {% } %}
 
 {% if (ctx.component?.openForms?.requireVerification) { %}
+
+<div class="utrecht-alert utrecht-alert--warning">
+  <div class="utrecht-alert__icon">
+    <i class="fa fas fa-exclamation-triangle"></i>
+  </div>
+  <div class="utrecht-alert__message">
+    {{ctx.t('You must verify this email address to continue.')}}
+  </div>
+</div>
+
 <button ref="verifyButton" class="utrecht-button utrecht-button--primary-action">
   {{ctx.t('Verify')}}
 </button>

--- a/src/formio/templates/text.ejs
+++ b/src/formio/templates/text.ejs
@@ -40,7 +40,7 @@
 {% } %}
 
 {% if (ctx.component?.openForms?.requireVerification) { %}
-<button ref="verify-button" class="utrecht-button utrecht-button--primary-action">
+<button ref="verifyButton" class="utrecht-button utrecht-button--primary-action">
   {{ctx.t('Verify')}}
 </button>
 {% } %}

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -495,6 +495,12 @@
       "value": "Are you sure that you want to logout?"
     }
   ],
+  "Dvt0Fv": [
+    {
+      "type": 0,
+      "value": "The email address has now been verified. You can close this window and continue with the rest of the form."
+    }
+  ],
   "DxbUkA": [
     {
       "type": 0,

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -571,6 +571,12 @@
       "value": "House number addition must be up to four letters and digits."
     }
   ],
+  "EZ7myd": [
+    {
+      "type": 0,
+      "value": "Email address verification"
+    }
+  ],
   "GbPef0": [
     {
       "type": 0,

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -583,6 +583,12 @@
       "value": "Email address verification"
     }
   ],
+  "FDy8nr": [
+    {
+      "type": 0,
+      "value": "The verification code may only contain letters (A-Z) and numbers (0-9)."
+    }
+  ],
   "GbPef0": [
     {
       "type": 0,
@@ -1351,6 +1357,12 @@
     {
       "type": 0,
       "value": "Your payment is received and processed."
+    }
+  ],
+  "c0Ry9H": [
+    {
+      "type": 0,
+      "value": "The verification code must contain exactly six characters."
     }
   ],
   "cBsrax": [

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -55,6 +55,26 @@
       "value": "Log out"
     }
   ],
+  "1+Q55M": [
+    {
+      "type": 0,
+      "value": "You are verifying the email address "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "emailAddress"
+        }
+      ],
+      "type": 8,
+      "value": "link"
+    },
+    {
+      "type": 0,
+      "value": ". First, we need to send you a verification code on this email address. Then, you need to enter the code to confirm it."
+    }
+  ],
   "1hdvgS": [
     {
       "type": 0,
@@ -107,6 +127,12 @@
     {
       "type": 0,
       "value": "Bad"
+    }
+  ],
+  "4tPKAs": [
+    {
+      "type": 0,
+      "value": "Verify"
     }
   ],
   "5uh2hS": [
@@ -981,6 +1007,12 @@
       "value": "Extend"
     }
   ],
+  "R7k4JC": [
+    {
+      "type": 0,
+      "value": "Enter the six-character code"
+    }
+  ],
   "RJ+0F/": [
     {
       "type": 0,
@@ -1451,6 +1483,12 @@
       "value": "The email address where you will receive the resume link."
     }
   ],
+  "ixMIBJ": [
+    {
+      "type": 0,
+      "value": "What would you like to do?"
+    }
+  ],
   "jAZped": [
     {
       "type": 0,
@@ -1609,6 +1647,12 @@
       "value": "You must provide a postcode."
     }
   ],
+  "lQY+Zm": [
+    {
+      "type": 0,
+      "value": "Enter the verification code"
+    }
+  ],
   "lVNV/d": [
     {
       "type": 0,
@@ -1619,6 +1663,12 @@
     {
       "type": 0,
       "value": "Product"
+    }
+  ],
+  "lmWBQT": [
+    {
+      "type": 0,
+      "value": "The code is exactly six characters long and consists of only uppercase letters and numbers."
     }
   ],
   "lq29t6": [
@@ -1865,6 +1915,12 @@
       "value": "Log in to co-sign the form"
     }
   ],
+  "qyWfE+": [
+    {
+      "type": 0,
+      "value": "Receive a verification code"
+    }
+  ],
   "r1L6Zj": [
     {
       "type": 0,
@@ -1875,6 +1931,12 @@
     {
       "type": 0,
       "value": "Postcode must be four digits followed by two letters (e.g. 1234 AB)."
+    }
+  ],
+  "riuSfc": [
+    {
+      "type": 0,
+      "value": "Send code"
     }
   ],
   "sSmY1N": [

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -495,6 +495,12 @@
       "value": "Ben je zeker dat je wil uitloggen?"
     }
   ],
+  "Dvt0Fv": [
+    {
+      "type": 0,
+      "value": "The email address has now been verified. You can close this window and continue with the rest of the form."
+    }
+  ],
   "DxbUkA": [
     {
       "type": 0,

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -55,6 +55,26 @@
       "value": "Uitloggen"
     }
   ],
+  "1+Q55M": [
+    {
+      "type": 0,
+      "value": "You are verifying the email address "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "emailAddress"
+        }
+      ],
+      "type": 8,
+      "value": "link"
+    },
+    {
+      "type": 0,
+      "value": ". First, we need to send you a verification code on this email address. Then, you need to enter the code to confirm it."
+    }
+  ],
   "1hdvgS": [
     {
       "type": 0,
@@ -107,6 +127,12 @@
     {
       "type": 0,
       "value": "Slecht"
+    }
+  ],
+  "4tPKAs": [
+    {
+      "type": 0,
+      "value": "Verify"
     }
   ],
   "5uh2hS": [
@@ -981,6 +1007,12 @@
       "value": "Verlengen"
     }
   ],
+  "R7k4JC": [
+    {
+      "type": 0,
+      "value": "Enter the six-character code"
+    }
+  ],
   "RJ+0F/": [
     {
       "type": 0,
@@ -1455,6 +1487,12 @@
       "value": "Het e-mailadres waarop je de link ontvangt om het formulier te hervatten."
     }
   ],
+  "ixMIBJ": [
+    {
+      "type": 0,
+      "value": "What would you like to do?"
+    }
+  ],
   "jAZped": [
     {
       "type": 0,
@@ -1613,6 +1651,12 @@
       "value": "Postcode is verplicht."
     }
   ],
+  "lQY+Zm": [
+    {
+      "type": 0,
+      "value": "Enter the verification code"
+    }
+  ],
   "lVNV/d": [
     {
       "type": 0,
@@ -1623,6 +1667,12 @@
     {
       "type": 0,
       "value": "Product"
+    }
+  ],
+  "lmWBQT": [
+    {
+      "type": 0,
+      "value": "The code is exactly six characters long and consists of only uppercase letters and numbers."
     }
   ],
   "lq29t6": [
@@ -1869,6 +1919,12 @@
       "value": "Log in om het formulier mede te ondertekenen"
     }
   ],
+  "qyWfE+": [
+    {
+      "type": 0,
+      "value": "Receive a verification code"
+    }
+  ],
   "r1L6Zj": [
     {
       "type": 0,
@@ -1879,6 +1935,12 @@
     {
       "type": 0,
       "value": "Postcode moet bestaan uit vier cijfers gevolgd door twee letters (bijv. 1234 AB)."
+    }
+  ],
+  "riuSfc": [
+    {
+      "type": 0,
+      "value": "Send code"
     }
   ],
   "sSmY1N": [

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -583,6 +583,12 @@
       "value": "Email address verification"
     }
   ],
+  "FDy8nr": [
+    {
+      "type": 0,
+      "value": "The verification code may only contain letters (A-Z) and numbers (0-9)."
+    }
+  ],
   "GbPef0": [
     {
       "type": 0,
@@ -1355,6 +1361,12 @@
     {
       "type": 0,
       "value": "De betaling is ontvangen en verwerkt."
+    }
+  ],
+  "c0Ry9H": [
+    {
+      "type": 0,
+      "value": "The verification code must contain exactly six characters."
     }
   ],
   "cBsrax": [

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -571,6 +571,12 @@
       "value": "Huisnummertoevoeging moet bestaan uit maximaal vier letters en cijfers."
     }
   ],
+  "EZ7myd": [
+    {
+      "type": 0,
+      "value": "Email address verification"
+    }
+  ],
   "GbPef0": [
     {
       "type": 0,

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -304,6 +304,11 @@
     "description": "ZOD error message when AddressNL house number addition does not match the house number addition regular expression",
     "originalDefault": "House number addition must be up to four letters and digits."
   },
+  "EZ7myd": {
+    "defaultMessage": "Email address verification",
+    "description": "Email verification modal title",
+    "originalDefault": "Email address verification"
+  },
   "GbPef0": {
     "defaultMessage": "You must provide a house number.",
     "description": "ZOD error message when AddressNL postcode is provided but not houseNumber",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -314,6 +314,11 @@
     "description": "Email verification modal title",
     "originalDefault": "Email address verification"
   },
+  "FDy8nr": {
+    "defaultMessage": "The verification code may only contain letters (A-Z) and numbers (0-9).",
+    "description": "Validation error message for verification code pattern",
+    "originalDefault": "The verification code may only contain letters (A-Z) and numbers (0-9)."
+  },
   "GbPef0": {
     "defaultMessage": "You must provide a house number.",
     "description": "ZOD error message when AddressNL postcode is provided but not houseNumber",
@@ -648,6 +653,11 @@
     "defaultMessage": "Your payment is received and processed.",
     "description": "payment registered status",
     "originalDefault": "Your payment is received and processed."
+  },
+  "c0Ry9H": {
+    "defaultMessage": "The verification code must contain exactly six characters.",
+    "description": "Validation error message for verification codes with length != 6",
+    "originalDefault": "The verification code must contain exactly six characters."
   },
   "cBsrax": {
     "defaultMessage": "House letter",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -19,6 +19,11 @@
     "description": "Log out button text",
     "originalDefault": "Log out"
   },
+  "1+Q55M": {
+    "defaultMessage": "You are verifying the email address <link>{emailAddress}</link>. First, we need to send you a verification code on this email address. Then, you need to enter the code to confirm it.",
+    "description": "Email verification modal body text",
+    "originalDefault": "You are verifying the email address <link>{emailAddress}</link>. First, we need to send you a verification code on this email address. Then, you need to enter the code to confirm it."
+  },
   "1hdvgS": {
     "defaultMessage": "Something went wrong while presenting the login option. Please contact the municipality.",
     "description": "Co-sign auth option not available on form",
@@ -63,6 +68,11 @@
     "defaultMessage": "Bad",
     "description": "GovMetric rating text",
     "originalDefault": "Bad"
+  },
+  "4tPKAs": {
+    "defaultMessage": "Verify",
+    "description": "Email verification: verify code button text",
+    "originalDefault": "Verify"
   },
   "5uh2hS": {
     "defaultMessage": "Appointment cancellation failed",
@@ -479,6 +489,11 @@
     "description": "Extend session button (in modal)",
     "originalDefault": "Extend"
   },
+  "R7k4JC": {
+    "defaultMessage": "Enter the six-character code",
+    "description": "Email verification: code input field label",
+    "originalDefault": "Enter the six-character code"
+  },
   "RJ+0F/": {
     "defaultMessage": "Yes",
     "description": "'True' display",
@@ -719,6 +734,11 @@
     "description": "Form save modal email field help text",
     "originalDefault": "The email address where you will receive the resume link."
   },
+  "ixMIBJ": {
+    "defaultMessage": "What would you like to do?",
+    "description": "Email verification mode selection label",
+    "originalDefault": "What would you like to do?"
+  },
   "jAZped": {
     "defaultMessage": "Sorry - this form is no longer available",
     "description": "'Deactivated form' error title",
@@ -784,6 +804,11 @@
     "description": "ZOD error message when AddressNL houseNumber is provided but not postcode",
     "originalDefault": "You must provide a postcode."
   },
+  "lQY+Zm": {
+    "defaultMessage": "Enter the verification code",
+    "description": "Email verification mode selection: enter code label",
+    "originalDefault": "Enter the verification code"
+  },
   "lVNV/d": {
     "defaultMessage": "House number addition",
     "description": "Label for addressNL houseNumberAddition input",
@@ -793,6 +818,11 @@
     "defaultMessage": "Product",
     "description": "Appointments products step page title",
     "originalDefault": "Product"
+  },
+  "lmWBQT": {
+    "defaultMessage": "The code is exactly six characters long and consists of only uppercase letters and numbers.",
+    "description": "Email verification: code input field description",
+    "originalDefault": "The code is exactly six characters long and consists of only uppercase letters and numbers."
   },
   "lq29t6": {
     "defaultMessage": "Are you sure that you want to abort this submission? You will lose your progress if you continue.",
@@ -874,6 +904,11 @@
     "description": "Log in to co-sign the form title",
     "originalDefault": "Log in to co-sign the form"
   },
+  "qyWfE+": {
+    "defaultMessage": "Receive a verification code",
+    "description": "Email verification mode selection: send code label",
+    "originalDefault": "Receive a verification code"
+  },
   "r1L6Zj": {
     "defaultMessage": "Suspending the form failed, please try again later",
     "description": "Modal suspending form failed message",
@@ -883,6 +918,11 @@
     "defaultMessage": "Postcode must be four digits followed by two letters (e.g. 1234 AB).",
     "description": "ZOD error message when AddressNL postcode does not match the postcode regular expression",
     "originalDefault": "Postcode must be four digits followed by two letters (e.g. 1234 AB)."
+  },
+  "riuSfc": {
+    "defaultMessage": "Send code",
+    "description": "Email verification: send code button text",
+    "originalDefault": "Send code"
   },
   "sSmY1N": {
     "defaultMessage": "Find address",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -264,6 +264,11 @@
     "description": "log out confirmation prompt",
     "originalDefault": "Are you sure that you want to logout?"
   },
+  "Dvt0Fv": {
+    "defaultMessage": "The email address has now been verified. You can close this window and continue with the rest of the form.",
+    "description": "Text displayed after successful email verification",
+    "originalDefault": "The email address has now been verified. You can close this window and continue with the rest of the form."
+  },
   "DxbUkA": {
     "defaultMessage": "Er is een fout opgetreden bij het inloggen met {service}. Probeer het later opnieuw.",
     "description": "Auth error message",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -19,6 +19,11 @@
     "description": "Log out button text",
     "originalDefault": "Log out"
   },
+  "1+Q55M": {
+    "defaultMessage": "You are verifying the email address <link>{emailAddress}</link>. First, we need to send you a verification code on this email address. Then, you need to enter the code to confirm it.",
+    "description": "Email verification modal body text",
+    "originalDefault": "You are verifying the email address <link>{emailAddress}</link>. First, we need to send you a verification code on this email address. Then, you need to enter the code to confirm it."
+  },
   "1hdvgS": {
     "defaultMessage": "Er is iets fout gegaan bij het presenteren van de inlogopties. Neem alstublieft contact met ons op.",
     "description": "Co-sign auth option not available on form",
@@ -63,6 +68,11 @@
     "defaultMessage": "Slecht",
     "description": "GovMetric rating text",
     "originalDefault": "Bad"
+  },
+  "4tPKAs": {
+    "defaultMessage": "Verify",
+    "description": "Email verification: verify code button text",
+    "originalDefault": "Verify"
   },
   "5uh2hS": {
     "defaultMessage": "Afspraak annuleren mislukt",
@@ -486,6 +496,11 @@
     "description": "Extend session button (in modal)",
     "originalDefault": "Extend"
   },
+  "R7k4JC": {
+    "defaultMessage": "Enter the six-character code",
+    "description": "Email verification: code input field label",
+    "originalDefault": "Enter the six-character code"
+  },
   "RJ+0F/": {
     "defaultMessage": "Ja",
     "description": "'True' display",
@@ -728,6 +743,11 @@
     "description": "Form save modal email field help text",
     "originalDefault": "The email address where you will receive the resume link."
   },
+  "ixMIBJ": {
+    "defaultMessage": "What would you like to do?",
+    "description": "Email verification mode selection label",
+    "originalDefault": "What would you like to do?"
+  },
   "jAZped": {
     "defaultMessage": "Onze excuses - dit formulier is niet langer beschikbaar",
     "description": "'Deactivated form' error title",
@@ -795,6 +815,11 @@
     "description": "ZOD error message when AddressNL houseNumber is provided but not postcode",
     "originalDefault": "You must provide a postcode."
   },
+  "lQY+Zm": {
+    "defaultMessage": "Enter the verification code",
+    "description": "Email verification mode selection: enter code label",
+    "originalDefault": "Enter the verification code"
+  },
   "lVNV/d": {
     "defaultMessage": "Huisnummertoevoeging",
     "description": "Label for addressNL houseNumberAddition input",
@@ -805,6 +830,11 @@
     "description": "Appointments products step page title",
     "isTranslated": true,
     "originalDefault": "Product"
+  },
+  "lmWBQT": {
+    "defaultMessage": "The code is exactly six characters long and consists of only uppercase letters and numbers.",
+    "description": "Email verification: code input field description",
+    "originalDefault": "The code is exactly six characters long and consists of only uppercase letters and numbers."
   },
   "lq29t6": {
     "defaultMessage": "Ben je zeker dat je deze formulierinzending wilt afbreken? Je verliest alle voortgang als je bevestigt.",
@@ -886,6 +916,11 @@
     "description": "Log in to co-sign the form title",
     "originalDefault": "Log in to co-sign the form"
   },
+  "qyWfE+": {
+    "defaultMessage": "Receive a verification code",
+    "description": "Email verification mode selection: send code label",
+    "originalDefault": "Receive a verification code"
+  },
   "r1L6Zj": {
     "defaultMessage": "Het pauzeren van het formulier is mislukt. Probeer het later opnieuw.",
     "description": "Modal suspending form failed message",
@@ -895,6 +930,11 @@
     "defaultMessage": "Postcode moet bestaan uit vier cijfers gevolgd door twee letters (bijv. 1234 AB).",
     "description": "ZOD error message when AddressNL postcode does not match the postcode regular expression",
     "originalDefault": "Postcode must be four digits followed by two letters (e.g. 1234 AB)."
+  },
+  "riuSfc": {
+    "defaultMessage": "Send code",
+    "description": "Email verification: send code button text",
+    "originalDefault": "Send code"
   },
   "sSmY1N": {
     "defaultMessage": "Zoek adres",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -267,6 +267,11 @@
     "description": "log out confirmation prompt",
     "originalDefault": "Are you sure that you want to logout?"
   },
+  "Dvt0Fv": {
+    "defaultMessage": "The email address has now been verified. You can close this window and continue with the rest of the form.",
+    "description": "Text displayed after successful email verification",
+    "originalDefault": "The email address has now been verified. You can close this window and continue with the rest of the form."
+  },
   "DxbUkA": {
     "defaultMessage": "Er is een fout opgetreden bij het inloggen met {service}. Probeer het later opnieuw.",
     "description": "Auth error message",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -318,6 +318,11 @@
     "description": "Email verification modal title",
     "originalDefault": "Email address verification"
   },
+  "FDy8nr": {
+    "defaultMessage": "The verification code may only contain letters (A-Z) and numbers (0-9).",
+    "description": "Validation error message for verification code pattern",
+    "originalDefault": "The verification code may only contain letters (A-Z) and numbers (0-9)."
+  },
   "GbPef0": {
     "defaultMessage": "Huisnummer is verplicht.",
     "description": "ZOD error message when AddressNL postcode is provided but not houseNumber",
@@ -657,6 +662,11 @@
     "defaultMessage": "De betaling is ontvangen en verwerkt.",
     "description": "payment registered status",
     "originalDefault": "Your payment is received and processed."
+  },
+  "c0Ry9H": {
+    "defaultMessage": "The verification code must contain exactly six characters.",
+    "description": "Validation error message for verification codes with length != 6",
+    "originalDefault": "The verification code must contain exactly six characters."
   },
   "cBsrax": {
     "defaultMessage": "Huisletter",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -308,6 +308,11 @@
     "description": "ZOD error message when AddressNL house number addition does not match the house number addition regular expression",
     "originalDefault": "House number addition must be up to four letters and digits."
   },
+  "EZ7myd": {
+    "defaultMessage": "Email address verification",
+    "description": "Email verification modal title",
+    "originalDefault": "Email address verification"
+  },
   "GbPef0": {
     "defaultMessage": "Huisnummer is verplicht.",
     "description": "ZOD error message when AddressNL postcode is provided but not houseNumber",

--- a/src/scss/components/_form-field.scss
+++ b/src/scss/components/_form-field.scss
@@ -6,8 +6,8 @@
     div[ref='element'],
     .openforms-multi-value-row__input {
       display: flex;
-      flex-direction: row;
-      gap: var(--of-utrecht-form-field-with-button-gap, 20px);
+      flex-direction: column;
+      gap: var(--of-utrecht-form-field-with-button-gap, 10px);
     }
   }
 }

--- a/src/scss/components/_form-field.scss
+++ b/src/scss/components/_form-field.scss
@@ -1,5 +1,17 @@
 @use 'microscope-sass/lib/bem';
 
+// Proper alignment of verify button and email input
+.utrecht-form-field {
+  @include bem.modifier('has-button') {
+    div[ref='element'],
+    .openforms-multi-value-row__input {
+      display: flex;
+      flex-direction: row;
+      gap: var(--of-utrecht-form-field-with-button-gap, 20px);
+    }
+  }
+}
+
 // Overrides of the utrecht form field styles for our own theme
 .openforms-theme {
   .utrecht-form-field {

--- a/src/story-utils/decorators.js
+++ b/src/story-utils/decorators.js
@@ -8,6 +8,7 @@ import {BASE_URL, buildForm} from 'api-mocks';
 import Card from 'components/Card';
 import {LiteralsProvider} from 'components/Literal';
 import {SubmissionStatusContext} from 'components/PostCompletionViews';
+import {ModalContext} from 'components/modals/Modal';
 
 export const ConfigDecorator = (Story, {parameters}) => {
   const defaults = {
@@ -165,3 +166,15 @@ export const withSubmissionPollInfo = (Story, {parameters, args}) => {
     </SubmissionStatusContext.Provider>
   );
 };
+
+export const withModalDecorator = Story => (
+  <ModalContext.Provider
+    value={{
+      // only for storybook integration, do not use this in real apps!
+      parentSelector: () => document.getElementById('storybook-root'),
+      ariaHideApp: false,
+    }}
+  >
+    <Story />
+  </ModalContext.Provider>
+);


### PR DESCRIPTION
Partially closes open-formulieren/open-forms#4542

The formio component (email) is extended so that a verify button is render, which triggers a modal to perform the actual verification.

TODO:

- [x] Implement verification of the actual code
- [x] Handle validation errors
- [x] Handle flow when no (valid) e-mail address is entered yet