### PR TITLE
:bookmark: Bump to version to 2.4.0 and update the release notes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 2.4.0-beta.0
+current_version = 2.4.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<pre>[a-z]+)\.(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{pre}.{build}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,40 @@
 SDK Changelog
 =============
 
+2.4.0 (2024-10-02)
+==================
+
+Feature release
+
+There are no changes compared to the beta version. Continue reading for the full
+changelog, which includes the alpha and beta release notes.
+
+.. warning:: SDK 2.4.0 requires the backend API version 2.8.0 or newer.
+
+New features
+------------
+
+* [#4542] Email address components now support a verification flow to prove ownership of
+  and access to the provided email address.
+* [#4545] Added an optional introduction page before the form start page.
+* [#4543] You can now optionally enable a short progress summary for a form, describing
+  the current step number and total step count.
+* [#4515] Updated Dutch translations from formal to informal variant.
+* [#4397] Added support for an 'initial data reference' parameter so that form fields
+  can be pre-populated from existing data.
+
+Bugfixes
+--------
+
+* Fixed the click action not being properly suppressed on disabled buttons.
+* Fixed the modal close button/icon not being accessible.
+
+Project maintenance
+-------------------
+
+* Improved the handling of modals in Storybook.
+* Bumped some libraries for their latest security fixes.
+
 2.4.0-beta.0 (2024-09-16)
 ==========================
 

--- a/README.NL.rst
+++ b/README.NL.rst
@@ -2,7 +2,7 @@
 Open Formulieren SDK
 ====================
 
-:Version: 2.4.0-beta.0
+:Version: 2.4.0
 :Source: https://github.com/open-formulieren/open-forms-sdk
 :Keywords: e-Formulieren, Common Ground, FormIO, API
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Open Forms SDK
 ==============
 
-:Version: 2.4.0-beta.0
+:Version: 2.4.0
 :Source: https://github.com/open-formulieren/open-forms-sdk
 :Keywords: e-Formulieren, Common Ground, FormIO, API
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-formulieren/sdk",
-  "version": "2.4.0-beta.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-formulieren/sdk",
-      "version": "2.4.0-beta.0",
+      "version": "2.4.0",
       "license": "EUPL-1.2",
       "workspaces": [
         "design-tokens"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-formulieren/sdk",
-  "version": "2.4.0-beta.0",
+  "version": "2.4.0",
   "private": true,
   "main": "dist/open-forms-sdk.js",
   "exports": {

--- a/publiccode.yaml
+++ b/publiccode.yaml
@@ -7,7 +7,7 @@ publiccodeYmlVersion: '0.2'
 name: Open Forms SDK
 url: 'http://github.com/open-formulieren/open-forms-sdk.git'
 softwareType: standalone/frontend
-softwareVersion: 2.4.0-beta.0
+softwareVersion: 2.4.0
 releaseDate: 't.b.d.'
 logo: 'https://github.com/open-formulieren/open-forms/blob/master/docs/logo.svg'
 platforms:


### PR DESCRIPTION
Nothing changed compared to the beta. The release notes are the combination of the alpha and beta release notes.