### PR TITLE
Accessible file upload link

### DIFF
--- a/src/formio/components/FileField.stories.js
+++ b/src/formio/components/FileField.stories.js
@@ -129,7 +129,7 @@ export const OneAllowedFileType = {
     await sleep(200); // formio needs time to bind click events...
     const canvas = within(canvasElement);
     // Click on browse to make the input node injected in the dom
-    const browseLink = canvas.getByRole('link', {name: 'uploadFile'});
+    const browseLink = canvas.getByRole('link', {name: 'browseFile'});
     // This opens the file dialog, but without it the input node is not injected into the DOM
     await userEvent.click(browseLink);
 
@@ -167,7 +167,7 @@ export const MultipleAllowedFileTypes = {
     await sleep(200); // formio needs time to bind click events...
     const canvas = within(canvasElement);
     // Click on browse to make the input node injected in the dom
-    const browseLink = canvas.getByRole('link', {name: 'uploadFile'});
+    const browseLink = canvas.getByRole('link', {name: 'browseFile'});
     await userEvent.click(browseLink);
 
     // Upload a file of the wrong type

--- a/src/formio/templates/file.ejs
+++ b/src/formio/templates/file.ejs
@@ -90,7 +90,7 @@
 
         {{ctx.t('or')}}
 
-        <a id="{{ctx.instance.id}}-{{ctx.component.key}}" href="#" ref="fileBrowse" class="browse utrecht-link utrecht-link--openforms">{{ctx.t('uploadFile', {fileFieldLabel: ctx.component.label})}}</a>
+        <a id="{{ctx.instance.id}}-{{ctx.component.key}}" href="#" ref="fileBrowse" class="browse utrecht-link utrecht-link--openforms" aria-label="{% if (ctx.component.multiple) { %} {{ctx.t('browseFiles', {fileFieldLabel: ctx.component.label})}} {% } else { %} {{ctx.t('browseFile', {fileFieldLabel: ctx.component.label})}} {% } %}">{{ctx.t('browse')}}</a>
 
         {% if (ctx.component.multiple) { %}
           {{ctx.t('to attach files.')}}


### PR DESCRIPTION
The upload link uses the 'old' content (i.e. "browse"). With aria-label the additional context (about what kind of file/files are expected) is added