### PR TITLE
Implement soft required validation

### DIFF
--- a/src/formio/components/FileField.js
+++ b/src/formio/components/FileField.js
@@ -4,7 +4,7 @@ import {Formio} from 'react-formio';
 
 import {CSRFToken} from 'headers';
 
-import {applyPrefix, setErrorAttributes} from '../utils';
+import {applyPrefix, linkToSoftRequiredDisplay, setErrorAttributes} from '../utils';
 
 const addCSRFToken = xhr => {
   const csrfTokenValue = CSRFToken.getValue();
@@ -291,9 +291,13 @@ class FileField extends Formio.Components.components.file {
     return super.validatePattern(file, val);
   }
 
-  setErrorClasses(elements, dirty, hasErrors, hasMessages) {
+  _getTargetElements() {
     const input = this.refs.fileBrowse;
-    const targetElements = input ? [input] : [];
+    return input ? [input] : [];
+  }
+
+  setErrorClasses(elements, dirty, hasErrors, hasMessages) {
+    const targetElements = this._getTargetElements();
     setErrorAttributes(targetElements, hasErrors, hasMessages, this.refs.messageContainer.id);
     return super.setErrorClasses(targetElements, dirty, hasErrors, hasMessages);
   }
@@ -313,7 +317,12 @@ class FileField extends Formio.Components.components.file {
       return false;
     }
 
-    return super.checkComponentValidity(data, dirty, row, options);
+    const result = super.checkComponentValidity(data, dirty, row, options);
+
+    const targetElements = this._getTargetElements();
+    linkToSoftRequiredDisplay(targetElements, this);
+
+    return result;
   }
 
   deleteFile(fileInfo) {

--- a/src/formio/components/SoftRequiredErrors.js
+++ b/src/formio/components/SoftRequiredErrors.js
@@ -39,9 +39,11 @@ class SoftRequiredErrors extends FormioContentField {
     if (!missingFieldLabels.length) return '';
 
     const missingFieldsMarkup = this.renderTemplate('missingFields', {labels: missingFieldLabels});
-    return this.interpolate(this.component.html, {
+    const content = this.interpolate(this.component.html, {
       missingFields: missingFieldsMarkup,
     });
+
+    return `<div id="${this.id}-content">${content}</div>`;
   }
 }
 

--- a/src/formio/components/SoftRequiredErrors.js
+++ b/src/formio/components/SoftRequiredErrors.js
@@ -1,0 +1,34 @@
+import {Formio} from 'react-formio';
+
+const FormioContentField = Formio.Components.components.content;
+
+class SoftRequiredErrors extends FormioContentField {
+  static schema(...extend) {
+    return FormioContentField.schema(
+      {
+        type: 'softRequiredErrors',
+        key: 'softRequiredErrors',
+        label: '', // not displayed anyway
+      },
+      ...extend
+    );
+  }
+
+  constructor(component, options, data) {
+    component.refreshOnChange = true;
+    super(component, options, data);
+  }
+
+  get content() {
+    const missingFieldLabels = ['Foo', 'Bar'];
+
+    if (!missingFieldLabels.length) return '';
+
+    const missingFieldsMarkup = this.renderTemplate('missingFields', {labels: missingFieldLabels});
+    return this.interpolate(this.component.html, {
+      missingFields: missingFieldsMarkup,
+    });
+  }
+}
+
+export default SoftRequiredErrors;

--- a/src/formio/components/SoftRequiredErrors.js
+++ b/src/formio/components/SoftRequiredErrors.js
@@ -43,7 +43,20 @@ class SoftRequiredErrors extends FormioContentField {
       missingFields: missingFieldsMarkup,
     });
 
-    return `<div id="${this.id}-content">${content}</div>`;
+    return `
+      <div
+        id="${this.id}-content"
+        class="utrecht-alert utrecht-alert--warning openforms-soft-required-errors"
+        role="status"
+      >
+        <div class="utrecht-alert__icon">
+          <i class="fa fas fa-exclamation-triangle"></i>
+        </div>
+        <div class="utrecht-alert__message">
+          ${content}
+        </div>
+      </div>
+    `;
   }
 }
 

--- a/src/formio/components/SoftRequiredErrors.js
+++ b/src/formio/components/SoftRequiredErrors.js
@@ -1,3 +1,4 @@
+import FormioUtils from 'formiojs/utils';
 import {Formio} from 'react-formio';
 
 const FormioContentField = Formio.Components.components.content;
@@ -20,7 +21,20 @@ class SoftRequiredErrors extends FormioContentField {
   }
 
   get content() {
-    const missingFieldLabels = ['Foo', 'Bar'];
+    // figure out which components use soft required validation
+    const softRequiredComponents = [];
+    FormioUtils.eachComponent(this.root.components, component => {
+      if (component.component.openForms?.softRequired) {
+        softRequiredComponents.push(component);
+      }
+    });
+
+    const missingFieldLabels = [];
+    // check which components have an empty value
+    for (const component of softRequiredComponents) {
+      const isEmpty = component.isEmpty();
+      if (isEmpty) missingFieldLabels.push(component.label);
+    }
 
     if (!missingFieldLabels.length) return '';
 

--- a/src/formio/components/SoftRequiredErrors.stories.js
+++ b/src/formio/components/SoftRequiredErrors.stories.js
@@ -1,5 +1,9 @@
-import {withUtrechtDocument} from 'story-utils/decorators';
+import {expect, userEvent, waitFor, within} from '@storybook/test';
 
+import {withUtrechtDocument} from 'story-utils/decorators';
+import {sleep} from 'utils';
+
+import {UPLOAD_URL, mockFileUploadDelete, mockFileUploadPost} from './FileField.mocks';
 import {MultipleFormioComponents} from './story-util';
 
 export default {
@@ -12,12 +16,17 @@ export default {
         type: 'file',
         key: 'file',
         storage: 'url',
-        url: '/dummy',
-        label: 'File',
+        url: UPLOAD_URL,
+        label: 'Soft required file',
         multiple: false,
         openForms: {softRequired: true},
       },
-      {type: 'textfield', key: 'textfield', label: 'Text', openForms: {softRequired: true}},
+      {
+        type: 'textfield',
+        key: 'textfield',
+        label: 'Soft required text',
+        openForms: {softRequired: true},
+      },
       {
         type: 'softRequiredErrors',
         html: `
@@ -37,7 +46,66 @@ export default {
   },
   parameters: {
     controls: {sort: 'requiredFirst'},
+    msw: {
+      handlers: [mockFileUploadPost, mockFileUploadDelete],
+    },
   },
 };
 
-export const Default = {};
+export const EmptyFields = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByText('Not all required fields are filled out. That can get expensive!');
+    const list = await canvas.findByRole('list', {name: 'Empty fields'});
+    const listItems = within(list).getAllByRole('listitem');
+    expect(listItems).toHaveLength(2);
+    const content = listItems.map(item => item.textContent);
+    expect(content).toEqual(['Soft required file', 'Soft required text']);
+  },
+};
+
+export const FillField = {
+  args: {
+    components: [
+      {
+        type: 'textfield',
+        key: 'textfield',
+        label: 'Soft required text',
+        openForms: {softRequired: true},
+      },
+      {
+        type: 'softRequiredErrors',
+        html: `
+        <p>Not all required fields are filled out. That can get expensive!</p>
+
+        {{ missingFields }}
+
+        <p>Are you sure you want to continue?</p>
+          `,
+      },
+    ],
+  },
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+    // formio... :thisisfine:
+    await sleep(100);
+
+    const ERROR_TEXT = 'Not all required fields are filled out. That can get expensive!';
+
+    await step('Initial state', async () => {
+      expect(await canvas.findByText(ERROR_TEXT)).toBeVisible();
+      const list = await canvas.findByRole('list', {name: 'Empty fields'});
+      const listItems = within(list).getAllByRole('listitem');
+      expect(listItems).toHaveLength(1);
+    });
+
+    await step('Fill out field and remove error', async () => {
+      const input = canvas.getByLabelText('Soft required text');
+      await userEvent.type(input, 'Not empty');
+      await waitFor(() => {
+        expect(canvas.queryByText(ERROR_TEXT)).toBeNull();
+      });
+    });
+  },
+};

--- a/src/formio/components/SoftRequiredErrors.stories.js
+++ b/src/formio/components/SoftRequiredErrors.stories.js
@@ -1,0 +1,43 @@
+import {withUtrechtDocument} from 'story-utils/decorators';
+
+import {MultipleFormioComponents} from './story-util';
+
+export default {
+  title: 'Form.io components / Custom / SoftRequiredErrors',
+  decorators: [withUtrechtDocument],
+  render: MultipleFormioComponents,
+  args: {
+    components: [
+      {
+        type: 'file',
+        key: 'file',
+        storage: 'url',
+        url: '/dummy',
+        label: 'File',
+        multiple: false,
+        openForms: {softRequired: true},
+      },
+      {type: 'textfield', key: 'textfield', label: 'Text', openForms: {softRequired: true}},
+      {
+        type: 'softRequiredErrors',
+        html: `
+        <p>Not all required fields are filled out. That can get expensive!</p>
+
+        {{ missingFields }}
+
+        <p>Are you sure you want to continue?</p>
+          `,
+      },
+    ],
+  },
+
+  argTypes: {
+    components: {table: {disable: true}},
+    evalContext: {table: {disable: true}},
+  },
+  parameters: {
+    controls: {sort: 'requiredFirst'},
+  },
+};
+
+export const Default = {};

--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -2,7 +2,7 @@ import debounce from 'lodash/debounce';
 import {Formio} from 'react-formio';
 
 import {get} from '../../api';
-import {setErrorAttributes} from '../utils';
+import {linkToSoftRequiredDisplay, setErrorAttributes} from '../utils';
 import enableValidationPlugins from '../validators/plugins';
 
 const POSTCODE_REGEX = /^[0-9]{4}\s?[a-zA-Z]{2}$/;
@@ -35,7 +35,11 @@ class TextField extends Formio.Components.components.textfield {
     if (this.component.validate.plugins && this.component.validate.plugins.length) {
       updatedOptions.async = true;
     }
-    return super.checkComponentValidity(data, dirty, row, updatedOptions);
+    const result = super.checkComponentValidity(data, dirty, row, updatedOptions);
+
+    linkToSoftRequiredDisplay(this.refs.input, this);
+
+    return result;
   }
 
   setErrorClasses(elements, dirty, hasErrors, hasMessages) {

--- a/src/formio/module.js
+++ b/src/formio/module.js
@@ -22,6 +22,7 @@ import PostcodeField from './components/PostcodeField';
 import Radio from './components/Radio';
 import Select from './components/Select';
 import Selectboxes from './components/Selectboxes';
+import SoftRequiredErrors from './components/SoftRequiredErrors';
 import TextArea from './components/TextArea';
 import TextField from './components/TextField';
 import TimeField from './components/TimeField';
@@ -55,6 +56,7 @@ const FormIOModule = {
     coSign: CoSignOld,
     cosign: Cosign,
     editgrid: EditGrid,
+    softRequiredErrors: SoftRequiredErrors,
   },
   providers: {
     storage: {url: CSRFEnabledUrl},

--- a/src/formio/templates/library.js
+++ b/src/formio/templates/library.js
@@ -10,6 +10,7 @@ import {default as FieldSetTemplate} from './fieldset.ejs';
 import {default as FileTemplate} from './file.ejs';
 import {default as LabelTemplate} from './label.ejs';
 import {default as MapTemplate} from './map.ejs';
+import {default as MissingFieldsTemplate} from './missingFields.ejs';
 import {default as MultiValueRowTemplate} from './multiValueRow.ejs';
 import {default as MultiValueTableTemplate} from './multiValueTable.ejs';
 import {default as RadioTemplate} from './radio.ejs';
@@ -20,6 +21,7 @@ import {default as TextTemplate} from './text.ejs';
 const OFLibrary = {
   component: {form: ComponentTemplate},
   field: {form: FieldTemplate}, // wrapper around the individual field types
+  missingFields: {form: MissingFieldsTemplate},
 
   button: {form: ButtonTemplate},
   checkbox: {form: CheckboxTemplate},

--- a/src/formio/templates/missingFields.ejs
+++ b/src/formio/templates/missingFields.ejs
@@ -1,0 +1,5 @@
+<ul class="utrecht-unordered-list">
+{% for (const label of ctx.labels) { %}
+  <li class="utrecht-unordered-list__item">{{ label }}</li>
+{% } %}
+</ul>

--- a/src/formio/templates/missingFields.ejs
+++ b/src/formio/templates/missingFields.ejs
@@ -1,7 +1,7 @@
 <span class="sr-only" id="{{ctx.id}}-missing-fields-header">
   {{ ctx.t('Empty fields') }}
 </span>
-<ul class="utrecht-unordered-list" aria-labelledby="{{ctx.id}}-missing-fields-header">
+<ul class="utrecht-unordered-list openforms-soft-required-errors__missing-fields" aria-labelledby="{{ctx.id}}-missing-fields-header">
 {% for (const label of ctx.labels) { %}
   <li class="utrecht-unordered-list__item">{{ label }}</li>
 {% } %}

--- a/src/formio/templates/missingFields.ejs
+++ b/src/formio/templates/missingFields.ejs
@@ -1,4 +1,7 @@
-<ul class="utrecht-unordered-list">
+<span class="sr-only" id="{{ctx.id}}-missing-fields-header">
+  {{ ctx.t('Empty fields') }}
+</span>
+<ul class="utrecht-unordered-list" aria-labelledby="{{ctx.id}}-missing-fields-header">
 {% for (const label of ctx.labels) { %}
   <li class="utrecht-unordered-list__item">{{ label }}</li>
 {% } %}

--- a/src/formio/utils.js
+++ b/src/formio/utils.js
@@ -19,26 +19,61 @@ const escapeHtml = source => {
 const getAriaDescriptions = element =>
   (element.getAttribute('aria-describedby') || '').split(' ').filter(description => !!description);
 
+/**
+ * Set or remove description IDs from the element's `aria-describedby` attribute.
+ * @param  {HTMLElement} element        The element to update.
+ * @param  {string[]} descriptionIds    Element IDs to set or remove.
+ * @param  {'present' | 'absent'} state Desired state
+ * @return {void}
+ */
+const updateAriaDescriptions = (element, descriptionIds, state) => {
+  let ariaDescriptions = getAriaDescriptions(element);
+
+  switch (state) {
+    case 'absent': {
+      ariaDescriptions = ariaDescriptions.filter(
+        description => !descriptionIds.includes(description)
+      );
+      break;
+    }
+    case 'present': {
+      const idsToAdd = descriptionIds.filter(
+        description => !ariaDescriptions.includes(description)
+      );
+      ariaDescriptions.push(...idsToAdd);
+      break;
+    }
+    default: {
+      throw new Error(`Unknown state: ${state}`);
+    }
+  }
+
+  if (ariaDescriptions.length > 0) {
+    element.setAttribute('aria-describedby', ariaDescriptions.join(' '));
+  } else {
+    element.removeAttribute('aria-describedby');
+  }
+};
+
+/**
+ * Update the accessible error attributes for the input elements
+ * @param  {HTMLElement[]}  elements
+ * @param  {Boolean} hasErrors
+ * @param  {Boolean} hasMessages
+ * @param  {string}  messageContainerId
+ * @return {void}
+ */
 const setErrorAttributes = (elements, hasErrors, hasMessages, messageContainerId) => {
   // Update the attributes 'aria-invalid' and 'aria-describedby' using hasErrors
   elements.forEach(element => {
-    let ariaDescriptions = getAriaDescriptions(element);
+    const desiredState =
+      hasErrors & hasMessages
+        ? // The input has an error, but the error message isn't yet part of the ariaDescriptions
+          'present'
+        : // The input doesn't have an error, but the error message is still a part of the ariaDescriptions
+          'absent';
 
-    if (hasErrors && hasMessages && !ariaDescriptions.includes(messageContainerId)) {
-      // The input has an error, but the error message isn't yet part of the ariaDescriptions
-      ariaDescriptions.push(messageContainerId);
-    }
-
-    if (!hasErrors && ariaDescriptions.includes(messageContainerId)) {
-      // The input doesn't have an error, but the error message is still a part of the ariaDescriptions
-      ariaDescriptions = ariaDescriptions.filter(description => description !== messageContainerId);
-    }
-
-    if (ariaDescriptions.length > 0) {
-      element.setAttribute('aria-describedby', ariaDescriptions.join(' '));
-    } else {
-      element.removeAttribute('aria-describedby');
-    }
+    updateAriaDescriptions(element, [messageContainerId], desiredState);
 
     if (hasErrors) {
       element.setAttribute('aria-invalid', 'true');
@@ -64,22 +99,7 @@ const linkToSoftRequiredDisplay = (elements, component) => {
 
   // Update the attribute 'aria-describedby' based on whether the component is empty
   elements.forEach(element => {
-    let ariaDescriptions = getAriaDescriptions(element);
-
-    softRequiredIds.forEach(id => {
-      if (isEmpty && !ariaDescriptions.includes(id)) {
-        ariaDescriptions.push(id);
-      }
-      if (!isEmpty && ariaDescriptions.includes(id)) {
-        ariaDescriptions = ariaDescriptions.filter(description => description !== id);
-      }
-    });
-
-    if (ariaDescriptions.length > 0) {
-      element.setAttribute('aria-describedby', ariaDescriptions.join(' '));
-    } else {
-      element.removeAttribute('aria-describedby');
-    }
+    updateAriaDescriptions(element, softRequiredIds, isEmpty ? 'present' : 'absent');
   });
 };
 

--- a/src/scss/components/_soft-required-errors.scss
+++ b/src/scss/components/_soft-required-errors.scss
@@ -1,0 +1,17 @@
+@use 'microscope-sass/lib/bem';
+
+@import '~microscope-sass/lib/typography';
+
+.openforms-soft-required-errors {
+  // apply all wysiwyg styling
+  // TODO: parametrize this with design tokens -> check with NL DS how to approach this
+  @include wysiwyg;
+
+  // unset, takes the utrecht-alert--warning by default, but can be overridden if desired
+  color: var(--of-soft-required-errors-color);
+  background-color: var(--of-soft-required-errors-background-color);
+
+  @include bem.element('missing-fields') {
+    font-weight: var(--of-soft-required-errors-missing-fields-font-weight, 600);
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -72,3 +72,4 @@
 @import './scss/components/input-container';
 @import './scss/components/authentication-errors';
 @import './scss/components/govmetric_snippet';
+@import './scss/components/soft-required-errors';


### PR DESCRIPTION
Closes open-formulieren/open-forms#4546

This went better than I had anticipated.

* Implement 'content' component variant for the soft required validation errors
* Styled it as a common/regular warning alert
* Added escape hatches for background color/font color/font-weight in case it needs to look different from a regular alert
* Ensured accessibility (linked list header, form fields refer back to content)
* Added stories and unit tests
* Checked the template interpolation/rendering for XSS, seems to be okay.

Final tasks to wrap this up:

* Update formio translations in the backend
* Review documentation if anything extra is needed