### PR TITLE
:bug: [open-formulieren/open-forms#4546] Properly pass initial_data_reference

### DIFF
--- a/src/components/FormStart/index.js
+++ b/src/components/FormStart/index.js
@@ -124,7 +124,7 @@ const FormStart = ({form, submission, onFormStart, onDestroySession, initialData
           <LoginOptions
             form={form}
             onFormStart={onFormStart}
-            extraParams={{initial_data_reference: initialDataReference}}
+            extraNextParams={{initial_data_reference: initialDataReference}}
           />
         )}
       </Card>

--- a/src/components/FormStart/tests.spec.js
+++ b/src/components/FormStart/tests.spec.js
@@ -112,6 +112,6 @@ it('Form start page with initial_data_reference', async () => {
   const loginLink = await screen.findByRole('link', {name: 'Login with DigiD'});
   expect(loginLink).toHaveAttribute(
     'href',
-    'https://openforms.nl/auth/form-name/digid/start?initial_data_reference=1234&next=http%3A%2F%2Flocalhost%2F%3F_start%3D1'
+    'https://openforms.nl/auth/form-name/digid/start?next=http%3A%2F%2Flocalhost%2F%3F_start%3D1%26initial_data_reference%3D1234'
   );
 });

--- a/src/components/LoginOptions/index.js
+++ b/src/components/LoginOptions/index.js
@@ -9,7 +9,7 @@ import Types from 'types';
 
 import LoginOptionsDisplay from './LoginOptionsDisplay';
 
-const LoginOptions = ({form, onFormStart, extraParams = {}}) => {
+const LoginOptions = ({form, onFormStart, extraNextParams = {}}) => {
   const config = useContext(ConfigContext);
 
   const loginAsYourselfOptions = [];
@@ -18,7 +18,7 @@ const LoginOptions = ({form, onFormStart, extraParams = {}}) => {
 
   form.loginOptions.forEach(option => {
     let readyOption = {...option};
-    readyOption.url = getLoginUrl(option, extraParams);
+    readyOption.url = getLoginUrl(option, {}, extraNextParams);
     readyOption.label = (
       <FormattedMessage
         description="Login button label"
@@ -82,6 +82,7 @@ LoginOptions.propTypes = {
   form: Types.Form.isRequired,
   onFormStart: PropTypes.func.isRequired,
   extraParams: PropTypes.object,
+  extraNextParams: PropTypes.object,
 };
 
 export default LoginOptions;

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -24,9 +24,8 @@ const isLastStep = (currentStepIndex, submission) => {
   return currentStepIndex === submission.steps.length - 1;
 };
 
-const getLoginUrl = (loginOption, extraParams = {}) => {
+const getLoginUrl = (loginOption, extraParams = {}, extraNextParams = {}) => {
   if (loginOption.url === '#') return loginOption.url;
-
   const nextUrl = new URL(window.location.href);
 
   const queryParams = Array.from(nextUrl.searchParams.keys());
@@ -39,6 +38,7 @@ const getLoginUrl = (loginOption, extraParams = {}) => {
   if (!loginUrl.searchParams.has('coSignSubmission')) {
     nextUrl.searchParams.set(START_FORM_QUERY_PARAM, '1');
   }
+  Object.entries(extraNextParams).map(([key, value]) => nextUrl.searchParams.set(key, value));
   loginUrl.searchParams.set('next', nextUrl.toString());
   return loginUrl.toString();
 };


### PR DESCRIPTION
needed for https://github.com/open-formulieren/open-forms/pull/4696

previously this was added as a query param to the login URL, but to pass it correctly to the backend it should be added to the nextUrl query params on the login URL