### PR TITLE
Updating address autocomplete endpoint

### DIFF
--- a/src/formio/components/TextField.js
+++ b/src/formio/components/TextField.js
@@ -57,7 +57,7 @@ class TextField extends Formio.Components.components.textfield {
   get setLocationData() {
     if (!this._debouncedSetLocationData) {
       this._debouncedSetLocationData = debounce((postcode, house_number, key) => {
-        get(`${this.options.baseUrl}location/get-street-name-and-city`, {postcode, house_number})
+        get(`${this.options.baseUrl}geo/address-autocomplete`, {postcode, house_number})
           .then(result => {
             if (result[key]) {
               this.setValue(result[key]);

--- a/src/formio/components/TextField.mocks.js
+++ b/src/formio/components/TextField.mocks.js
@@ -3,6 +3,6 @@ import {HttpResponse, http} from 'msw';
 import {BASE_URL} from 'api-mocks';
 
 export const mockAddressAutoCompleteGet = (street = 'Keizersgracht', city = 'Amsterdam') =>
-  http.get(`${BASE_URL}location/get-street-name-and-city`, () => {
+  http.get(`${BASE_URL}geo/address-autocomplete`, () => {
     return HttpResponse.json({streetName: street, city});
   });

--- a/src/jstests/formio/components/textfield.mocks.js
+++ b/src/jstests/formio/components/textfield.mocks.js
@@ -3,6 +3,6 @@ import {HttpResponse, http} from 'msw';
 import {BASE_URL} from 'api-mocks';
 
 export const mockLocationGet = result =>
-  http.get(`${BASE_URL}location/get-street-name-and-city`, () => {
+  http.get(`${BASE_URL}geo/address-autocomplete`, () => {
     return HttpResponse.json(result);
   });


### PR DESCRIPTION
Part of open-formulieren/open-forms#3283

Open Forms will no longer support api/v2/location/get-street-name-and-city, so we should use the new endpoint.