### PR TITLE
Configure Vite to build the SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /storybook-static
 /build
 /dist
+/dist-vite
 /lib
 /esm
 *.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@
 
 # production
 /storybook-static
-/build
 /dist
 /dist-vite
 /lib

--- a/build/plugins.mts
+++ b/build/plugins.mts
@@ -1,0 +1,35 @@
+import lodashTemplate from 'lodash/template';
+
+// inspired on https://dev.to/koistya/using-ejs-with-vite-48id and
+// https://github.com/difelice/ejs-loader/blob/master/index.js
+export const ejsPlugin = () => ({
+  name: 'compile-ejs',
+  async transform(src: string, id: string) {
+    const options = {
+      variable: 'ctx',
+      evaluate: /\{%([\s\S]+?)%\}/g,
+      interpolate: /\{\{([\s\S]+?)\}\}/g,
+      escape: /\{\{\{([\s\S]+?)\}\}\}/g,
+    };
+    if (id.endsWith('.ejs')) {
+      // @ts-ignore
+      const code = lodashTemplate(src, options);
+      return {code: `export default ${code}`, map: null};
+    }
+  },
+});
+
+export const cjsTokens = () => ({
+  name: 'process-cjs-tokens',
+  async transform(src, id) {
+    if (
+      id.endsWith('/design-tokens/dist/tokens.js') ||
+      id.endsWith('node_modules/@utrecht/design-tokens/dist/tokens.cjs')
+    ) {
+      return {
+        code: src.replace('module.exports = ', 'export default '),
+        map: null,
+      };
+    }
+  },
+});

--- a/build/utils.mts
+++ b/build/utils.mts
@@ -1,0 +1,15 @@
+import {dependencies, peerDependencies} from '../package.json';
+
+const externalPackages = [
+  ...Object.keys(dependencies || {}),
+  ...Object.keys(peerDependencies || {}),
+  'formiojs',
+  'lodash',
+  '@formio/vanilla-text-mask',
+  '@babel/runtime',
+  '@utrecht/component-library-react',
+];
+
+// Creating regexes of the packages to make sure subpaths of the
+// packages are also treated as external
+export const packageRegexes = externalPackages.map(packageName => new RegExp(`^${packageName}(/.*)?`));

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "start": "npm run build:design-tokens && node scripts/start.js",
     "build": "node scripts/build.js && npm run build:esm",
     "build:esm": "rimraf dist/esm && NODE_ENV=production babel --no-babelrc --config-file ./.babelrc.esm-build --ignore 'src/**/*.spec.js','src/**/fixtures/**','src/setupTests.js','src/reportWebVitals.js' src --out-dir dist/esm",
+    "build:vite": "BUILD_TARGET=umd vite build && BUILD_TARGET=esm vite build",
     "test": "TZ=Europe/Amsterdam vitest",
     "test:storybook": "test-storybook --coverage",
     "clean": "rimraf dist/*",

--- a/src/formio/components/Number.js
+++ b/src/formio/components/Number.js
@@ -1,5 +1,5 @@
 import {maskInput} from '@formio/vanilla-text-mask';
-import {set} from 'lodash';
+import set from 'lodash/set';
 import {Formio} from 'react-formio';
 
 import {setErrorAttributes} from '../utils';

--- a/src/formio/validators/plugins.js
+++ b/src/formio/validators/plugins.js
@@ -1,4 +1,4 @@
-import {isEmpty} from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import {post} from '../../api';
 

--- a/src/sdk.jsx
+++ b/src/sdk.jsx
@@ -1,5 +1,6 @@
 import ProtectedEval from '@formio/protected-eval';
 import 'flatpickr';
+import lodash from 'lodash';
 import {fixIconUrls as fixLeafletIconUrls} from 'map';
 import React from 'react';
 import {createRoot} from 'react-dom/client';
@@ -22,6 +23,11 @@ import {getVersion} from 'utils';
 import OpenFormsModule from './formio/module';
 import OFLibrary from './formio/templates';
 import './styles.scss';
+
+// lodash must be bundled for Formio templates to work properly...
+if (typeof window !== 'undefined') {
+  window._ = lodash;
+}
 
 // use protected eval to not rely on unsafe-eval (CSP)
 Formio.use(ProtectedEval);


### PR DESCRIPTION
Depends on #758 to be merged first.

Should be a big milestone in #724 _provided everything still works as expected_

* Set up Vite so it can produce the UMD bundle like CRA/webpack did/does
* Set up Vite to produce a similar ESM build (but with less bugs than CRA/babel setup)

**TODO**

- [x] Properly test this

In a different PR we can then setup ESLint and swap out CRA with Vite :eyes: 

Tested this locally with a form that had a file upload component, optional text fields and date picker, all seems to work as expected. I've also tested the appointment form flow and it also works as expected. Once Open Forms 3.0 is released, this should be good to merge!