### PR TITLE
Build and distribute ESM bundle (next to UMD/ESM package)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,10 @@
   },
   "scripts": {
     "start": "npm run build:design-tokens && vite",
-    "build": "BUILD_TARGET=umd vite build && BUILD_TARGET=esm vite build",
+    "build": "npm run build:umd && npm run build:esm && npm run build:esm-bundle",
+    "build:umd": "BUILD_TARGET=umd vite build",
+    "build:esm": "BUILD_TARGET=esm vite build",
+    "build:esm-bundle": "BUILD_TARGET=esm-bundle vite build",
     "test": "TZ=Europe/Amsterdam vitest",
     "test:storybook": "test-storybook --coverage",
     "prepare-package": "node bin/prepare-package.mjs",


### PR DESCRIPTION
Partly closes #76

Vite/Rollup doesn't support chunking when bundling with UMD (which results in `window.OpenForms` being available), but when generating an ESM bundle this does work.

This adds a build/compile step which produces an experimental (un-optimized) ESM bundle to the build artifact so that our backend can start opting in to `<script type="module">...</script>` to initialize the SDK instead of using the UMD bundle. If that works as expected, I want to manage the chunks to avoid loading unused stuff (appointments, map...) unless they are actually used.