### PR TITLE
AddressNL component validation triggers on page load

### DIFF
--- a/src/formio/components/AddressNL.jsx
+++ b/src/formio/components/AddressNL.jsx
@@ -35,7 +35,7 @@ export default class AddressNL extends Field {
         label: 'Address NL',
         input: true,
         key: 'addressNL',
-        defaultValue: {},
+        defaultValue: this.emptyValue,
         validateOn: 'blur',
         deriveAddress: false,
         layout: 'doubleColumn',
@@ -68,7 +68,7 @@ export default class AddressNL extends Field {
     return AddressNL.schema();
   }
 
-  get emptyValue() {
+  static get emptyValue() {
     return {
       postcode: '',
       houseNumber: '',
@@ -147,7 +147,7 @@ export default class AddressNL extends Field {
 
   renderReact() {
     const required = this.component?.validate?.required || false;
-    const initialValues = {...this.emptyValue, ...this.dataValue};
+    const initialValues = {...AddressNL.emptyValue, ...this.dataValue};
 
     this.reactRoot.render(
       <IntlProvider {...this.options.intl}>


### PR DESCRIPTION
Partly closes: open-formulieren/open-forms#4699

This is regarding one of the issues described in the [OF#4699](open-formulieren/open-forms#4699) ticket:
> Sometimes the component validation triggers right after loading. The best way i can trigger this, is by making the component required and opening the frontend in incognito

The problem that caused this issues, was the default value of the addressNL component. This didn't conform to the expected value, which triggered a validation even before the user touched the form.

By setting the default value to an empty address this initial validation doesn't trigger