### PR TITLE
AddressNL unreliable validation fix

### DIFF
--- a/src/formio/components/AddressNL.jsx
+++ b/src/formio/components/AddressNL.jsx
@@ -35,7 +35,15 @@ export default class AddressNL extends Field {
         label: 'Address NL',
         input: true,
         key: 'addressNL',
-        defaultValue: this.emptyValue,
+        defaultValue: {
+          postcode: '',
+          houseNumber: '',
+          houseLetter: '',
+          houseNumberAddition: '',
+          city: '',
+          streetName: '',
+          secretStreetCity: '',
+        },
         validateOn: 'blur',
         deriveAddress: false,
         layout: 'doubleColumn',
@@ -68,7 +76,7 @@ export default class AddressNL extends Field {
     return AddressNL.schema();
   }
 
-  static get emptyValue() {
+  get emptyValue() {
     return {
       postcode: '',
       houseNumber: '',
@@ -152,7 +160,7 @@ export default class AddressNL extends Field {
       return;
     }
     const required = this.component?.validate?.required || false;
-    const initialValues = {...AddressNL.emptyValue, ...this.dataValue};
+    const initialValues = {...this.emptyValue, ...this.dataValue};
 
     this.reactRoot.render(
       <IntlProvider {...this.options.intl}>


### PR DESCRIPTION
Make sure that `get emptyValue()` stays a regular function. Making the `get emptyValue()` static results into weird validation issues, broken e2e tests, and general unpleasant behavior.