### PR TITLE
Missing map shapes in summary step

### DIFF
--- a/src/components/Map/types.jsx
+++ b/src/components/Map/types.jsx
@@ -1,0 +1,17 @@
+import PropTypes from 'prop-types';
+
+export const GeoJsonGeometry = PropTypes.oneOfType([
+  PropTypes.shape({
+    type: PropTypes.oneOf(['Point']).isRequired,
+    coordinates: PropTypes.arrayOf(PropTypes.number).isRequired,
+  }),
+  PropTypes.shape({
+    type: PropTypes.oneOf(['LineString']).isRequired,
+    coordinates: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)).isRequired,
+  }),
+  PropTypes.shape({
+    type: PropTypes.oneOf(['Polygon']).isRequired,
+    coordinates: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)))
+      .isRequired,
+  }),
+]);


### PR DESCRIPTION
Part of open-formulieren/open-forms#5038

Because the geoJsonGeometry is available before the featureGroupRef is set, can the useEffect hook not draw the map shapes.

This fix makes sure that featureGroupRef is set, so that map shapes can be drawn