### PR TITLE
Display backend validation errors when submitting the form

### DIFF
--- a/src/api-mocks/submissions.js
+++ b/src/api-mocks/submissions.js
@@ -102,7 +102,7 @@ export const mockSubmissionSummaryGet = () =>
           data: [
             {
               name: SUBMISSION_STEP_DETAILS.formStep.configuration.components[0].label,
-              value: 'Compnent 1 value',
+              value: 'Component 1 value',
               component: SUBMISSION_STEP_DETAILS.formStep.configuration.components[0],
             },
           ],
@@ -117,6 +117,22 @@ export const mockSubmissionCompletePost = () =>
     HttpResponse.json({
       statusUrl: `${BASE_URL}submissions/${SUBMISSION_DETAILS.id}/super-random-token/status`,
     })
+  );
+
+export const mockSubmissionCompleteInvalidPost = invalidParams =>
+  http.post(`${BASE_URL}submissions/:uuid/_complete`, () =>
+    HttpResponse.json(
+      {
+        type: 'http://localhost:8000/fouten/ValidationError/',
+        code: 'invalid',
+        title: 'Does not validate.',
+        status: 400,
+        detail: '',
+        instance: 'urn:uuid:41e0174a-efc2-4cc0-9bf2-8366242a4e75',
+        invalidParams,
+      },
+      {status: 400}
+    )
   );
 
 /**

--- a/src/components/CoSign/Cosign.spec.jsx
+++ b/src/components/CoSign/Cosign.spec.jsx
@@ -103,5 +103,5 @@ test('Load submission summary after backend authentication', async () => {
 
   await screen.findByRole('heading', {name: 'Check and co-sign submission', level: 1});
   // wait for summary to load from the backend
-  await screen.findByText('Compnent 1 value');
+  await screen.findByText('Component 1 value');
 });

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -1,6 +1,6 @@
 import {useContext, useEffect, useState} from 'react';
 import {useIntl} from 'react-intl';
-import {Navigate, Outlet, useLocation, useNavigate, useSearchParams} from 'react-router';
+import {Navigate, Outlet, useLocation, useMatch, useNavigate, useSearchParams} from 'react-router';
 import {usePrevious} from 'react-use';
 
 import {ConfigContext} from 'Context';
@@ -35,6 +35,7 @@ const Form = () => {
   const intl = useIntl();
   const prevLocale = usePrevious(intl.locale);
   const {state: routerState} = useLocation();
+  const confirmationMatch = useMatch('/bevestiging');
 
   // extract the declared properties and configuration
   const config = useContext(ConfigContext);
@@ -102,10 +103,18 @@ const Form = () => {
     return <Loader modifiers={['centered']} />;
   }
 
+  // don't render the PI if the form is configured to never display the progress
+  // indicator, or we're on the final confirmation page
+  const showProgressIndicator = form.showProgressIndicator && !confirmationMatch;
+
   // render the container for the router and necessary context providers for deeply
   // nested child components
   return (
-    <FormDisplay progressIndicator={<FormProgressIndicator submission={submission} />}>
+    <FormDisplay
+      progressIndicator={
+        showProgressIndicator ? <FormProgressIndicator submission={submission} /> : null
+      }
+    >
       <AnalyticsToolsConfigProvider>
         <SubmissionProvider
           submission={submission}

--- a/src/components/FormProgressIndicator.jsx
+++ b/src/components/FormProgressIndicator.jsx
@@ -1,5 +1,5 @@
 import {useIntl} from 'react-intl';
-import {matchPath, useLocation, useMatch} from 'react-router';
+import {matchPath, useLocation} from 'react-router';
 
 import ProgressIndicator from 'components/ProgressIndicator';
 import {addFixedSteps, getStepsInfo} from 'components/ProgressIndicator/utils';
@@ -76,14 +76,7 @@ const getMobileStepTitle = (intl, pathname, form) => {
 const FormProgressIndicator = ({submission}) => {
   const form = useFormContext();
   const {pathname: currentPathname, state: routerState} = useLocation();
-  const confirmationMatch = useMatch('/bevestiging');
   const intl = useIntl();
-
-  // don't render anything if the form is configured to never display the progress
-  // indicator, or we're on the final confirmation page
-  if (!form.showProgressIndicator || confirmationMatch) {
-    return null;
-  }
 
   // otherwise collect the necessary information to render the PI.
   const isCompleted = !!routerState?.statusUrl;

--- a/src/components/Summary/GenericSummary.jsx
+++ b/src/components/Summary/GenericSummary.jsx
@@ -34,8 +34,10 @@ const GenericSummary = ({
 
   return (
     <Card title={title}>
-      {errors.map(error => (
-        <ErrorMessage key={error}>{error}</ErrorMessage>
+      {errors.map((error, index) => (
+        <div className="openforms-card__alert" key={`error-${index}`}>
+          <ErrorMessage>{error}</ErrorMessage>
+        </div>
       ))}
       <Formik
         initialValues={{privacyPolicyAccepted: false, statementOfTruthAccepted: false}}
@@ -102,7 +104,7 @@ GenericSummary.propTypes = {
   editStepText: PropTypes.string,
   isLoading: PropTypes.bool,
   isAuthenticated: PropTypes.bool,
-  errors: PropTypes.arrayOf(PropTypes.string),
+  errors: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.node, PropTypes.string])),
   prevPage: PropTypes.string,
   onSubmit: PropTypes.func.isRequired,
   onDestroySession: PropTypes.func.isRequired,

--- a/src/components/Summary/GenericSummary.jsx
+++ b/src/components/Summary/GenericSummary.jsx
@@ -29,7 +29,11 @@ const GenericSummary = ({
   const Wrapper = submissionAllowed === SUBMISSION_ALLOWED.yes ? Form : 'div';
 
   if (isLoading) {
-    return <Loader modifiers={['centered']} />;
+    return (
+      <Card title={title}>
+        <Loader modifiers={['centered']} />
+      </Card>
+    );
   }
 
   return (

--- a/src/components/Summary/SubmissionSummary.stories.jsx
+++ b/src/components/Summary/SubmissionSummary.stories.jsx
@@ -1,0 +1,101 @@
+import {expect, fn, userEvent, within} from '@storybook/test';
+import {withRouter} from 'storybook-addon-remix-react-router';
+
+import {buildForm} from 'api-mocks';
+import {
+  buildSubmission,
+  mockSubmissionCompleteInvalidPost,
+  mockSubmissionGet,
+  mockSubmissionSummaryGet,
+} from 'api-mocks/submissions';
+import SubmissionProvider from 'components/SubmissionProvider';
+import {ConfigDecorator, withForm} from 'story-utils/decorators';
+
+import SubmissionSummary from './SubmissionSummary';
+
+const form = buildForm();
+const submission = buildSubmission();
+
+export default {
+  title: 'Private API / SubmissionSummary',
+  component: SubmissionSummary,
+  decorators: [
+    (Story, {args}) => (
+      <SubmissionProvider
+        submission={args.submission}
+        onSubmissionObtained={fn()}
+        onDestroySession={fn()}
+        removeSubmissionId={fn()}
+      >
+        <Story />
+      </SubmissionProvider>
+    ),
+    withRouter,
+    ConfigDecorator,
+    withForm,
+  ],
+  args: {
+    form,
+    submission,
+  },
+  argTypes: {
+    form: {table: {disable: true}},
+    submission: {table: {disable: true}},
+  },
+  parameters: {
+    msw: {
+      handlers: {
+        loadSubmission: [mockSubmissionGet(submission), mockSubmissionSummaryGet()],
+      },
+    },
+  },
+};
+
+export const Overview = {};
+
+export const BackendValidationErrors = {
+  parameters: {
+    msw: {
+      handlers: {
+        completeSubmission: [
+          mockSubmissionCompleteInvalidPost([
+            {
+              name: 'steps.0.nonFieldErrors.0',
+              code: 'invalid',
+              reason: 'Your carpet is ugly.',
+            },
+            {
+              name: 'steps.0.nonFieldErrors.1',
+              code: 'invalid',
+              reason: "And your veg ain't in season.",
+            },
+            {
+              name: 'steps.0.data.component1',
+              code: 'existential-nightmare',
+              reason: 'I was waiting in line for ten whole minutes.',
+            },
+          ]),
+        ],
+      },
+    },
+  },
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+
+    await step('Submit form submission to backend', async () => {
+      await userEvent.click(
+        await canvas.findByRole('checkbox', {name: /I accept the privacy policy/})
+      );
+      await userEvent.click(canvas.getByRole('button', {name: 'Confirm'}));
+    });
+
+    await step('Check validation errors from backend', async () => {
+      const genericMessage = await canvas.findByText('There are problems with the submitted data.');
+      expect(genericMessage).toBeVisible();
+
+      expect(await canvas.findByText(/Your carpet is ugly/)).toBeVisible();
+      expect(await canvas.findByText(/And your veg/)).toBeVisible();
+      expect(await canvas.findByText(/I was waiting in line for ten whole minutes/)).toBeVisible();
+    });
+  },
+};

--- a/src/components/Summary/ValidationErrors.jsx
+++ b/src/components/Summary/ValidationErrors.jsx
@@ -1,0 +1,131 @@
+import {UnorderedList, UnorderedListItem} from '@utrecht/component-library-react';
+import PropTypes from 'prop-types';
+import {FormattedMessage, useIntl} from 'react-intl';
+
+const ErrorType = PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]);
+
+const normalizeError = error => (Array.isArray(error) ? error : [error]);
+
+const StepValidationErrors = ({errors, name, stepData}) => {
+  const intl = useIntl();
+  const {nonFieldErrors = [], data = {}} = errors;
+
+  const allErrorMessages = [...normalizeError(nonFieldErrors)];
+
+  // related the data errors to their matching components
+  Object.entries(data).map(([key, errorMessage]) => {
+    const normalizedErrorMessage = normalizeError(errorMessage);
+    const stepDataItem = stepData.find(item => item.component.key === key);
+
+    for (const error of normalizedErrorMessage) {
+      const message = intl.formatMessage(
+        {
+          description: 'Overview page, validation error message for step field.',
+          defaultMessage: "Field ''{label}'': {error}",
+        },
+        {
+          label: stepDataItem.name,
+          error: error,
+        }
+      );
+      allErrorMessages.push(message);
+    }
+  });
+
+  return (
+    <>
+      <FormattedMessage
+        description="Overview page, title before listing the validation errors for a step"
+        defaultMessage="Problems in form step ''{name}''"
+        values={{name}}
+      />
+      <UnorderedList className="utrecht-unordered-list--distanced">
+        {allErrorMessages.map(error => (
+          <UnorderedListItem key={error}>{error}</UnorderedListItem>
+        ))}
+      </UnorderedList>
+    </>
+  );
+};
+
+StepValidationErrors.propTypes = {
+  errors: PropTypes.shape({
+    nonFieldErrors: ErrorType,
+    // keys are the component key names
+    data: PropTypes.objectOf(ErrorType),
+  }).isRequired,
+  name: PropTypes.string.isRequired,
+  stepData: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object,
+        PropTypes.array,
+        PropTypes.number,
+        PropTypes.bool,
+      ]),
+      component: PropTypes.object.isRequired,
+    })
+  ).isRequired,
+};
+
+/**
+ * Render the validation errors received from the backend.
+ */
+const ValidationErrors = ({errors, summaryData}) => {
+  const {steps = []} = errors;
+  if (steps.length === 0) return null;
+  return (
+    <UnorderedList className="utrecht-unordered-list--distanced">
+      {steps.map((stepErrors, index) => (
+        <UnorderedListItem key={summaryData[index].slug}>
+          <StepValidationErrors
+            errors={stepErrors}
+            name={summaryData[index].name}
+            stepData={summaryData[index].data}
+          />
+        </UnorderedListItem>
+      ))}
+    </UnorderedList>
+  );
+};
+
+ValidationErrors.propTypes = {
+  /**
+   * Validation errors as reconstructed from the backend invalidParams
+   */
+  errors: PropTypes.shape({
+    steps: PropTypes.arrayOf(
+      PropTypes.shape({
+        nonFieldErrors: ErrorType,
+        // keys are the component key names
+        data: PropTypes.objectOf(ErrorType),
+      })
+    ),
+  }),
+  /**
+   * Array of summary data per step.
+   */
+  summaryData: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      slug: PropTypes.string.isRequired,
+      data: PropTypes.arrayOf(
+        PropTypes.shape({
+          name: PropTypes.string.isRequired,
+          value: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.object,
+            PropTypes.array,
+            PropTypes.number,
+            PropTypes.bool,
+          ]),
+          component: PropTypes.object.isRequired,
+        })
+      ).isRequired,
+    })
+  ),
+};
+
+export default ValidationErrors;

--- a/src/components/appointments/CreateAppointment/CreateAppointment.stories.jsx
+++ b/src/components/appointments/CreateAppointment/CreateAppointment.stories.jsx
@@ -6,8 +6,7 @@ import {FormContext} from 'Context';
 import {buildForm} from 'api-mocks';
 import {mockSubmissionPost, mockSubmissionProcessingStatusGet} from 'api-mocks/submissions';
 import {loadCalendarLocale} from 'components/forms/DateField/DatePickerCalendar';
-import {FUTURE_FLAGS, PROVIDER_FUTURE_FLAGS} from 'routes';
-import routes from 'routes';
+import routes, {FUTURE_FLAGS, PROVIDER_FUTURE_FLAGS} from 'routes';
 import {ConfigDecorator, LayoutDecorator} from 'story-utils/decorators';
 
 import {

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -663,6 +663,12 @@
       "value": "The verification code may only contain letters (A-Z) and numbers (0-9)."
     }
   ],
+  "FKWQuw": [
+    {
+      "type": 0,
+      "value": "Unfortunately, this form is currently unavailable due to an outage. Please try again later."
+    }
+  ],
   "FrFeZj": [
     {
       "type": 0,
@@ -1419,6 +1425,20 @@
       "value": "."
     }
   ],
+  "YwnY5d": [
+    {
+      "type": 0,
+      "value": "Problems in form step '"
+    },
+    {
+      "type": 1,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": "'"
+    }
+  ],
   "ZJoaby": [
     {
       "children": [
@@ -1585,6 +1605,24 @@
       "value": "Loading..."
     }
   ],
+  "eEC1P4": [
+    {
+      "type": 0,
+      "value": "Field '"
+    },
+    {
+      "type": 1,
+      "value": "label"
+    },
+    {
+      "type": 0,
+      "value": "': "
+    },
+    {
+      "type": 1,
+      "value": "error"
+    }
+  ],
   "eO6Ysb": [
     {
       "type": 0,
@@ -1661,6 +1699,12 @@
     {
       "type": 0,
       "value": "House letter must be a single letter."
+    }
+  ],
+  "hcw9Gf": [
+    {
+      "type": 0,
+      "value": "There are problems with the submitted data."
     }
   ],
   "hkZ8N1": [
@@ -2181,6 +2225,12 @@
     {
       "type": 0,
       "value": "Postcode must be four digits followed by two letters (e.g. 1234 AB)."
+    }
+  ],
+  "rWbce4": [
+    {
+      "type": 0,
+      "value": "Form unavailable"
     }
   ],
   "riuSfc": [

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -663,6 +663,12 @@
       "value": "De bevestigingscode bestaat uit hoofdletters (A-Z) en getallen (0-9)."
     }
   ],
+  "FKWQuw": [
+    {
+      "type": 0,
+      "value": "Unfortunately, this form is currently unavailable due to an outage. Please try again later."
+    }
+  ],
   "FrFeZj": [
     {
       "type": 0,
@@ -1419,6 +1425,20 @@
       "value": " zijn."
     }
   ],
+  "YwnY5d": [
+    {
+      "type": 0,
+      "value": "Problems in form step '"
+    },
+    {
+      "type": 1,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": "'"
+    }
+  ],
   "ZJoaby": [
     {
       "children": [
@@ -1589,6 +1609,24 @@
       "value": "Laden..."
     }
   ],
+  "eEC1P4": [
+    {
+      "type": 0,
+      "value": "Field '"
+    },
+    {
+      "type": 1,
+      "value": "label"
+    },
+    {
+      "type": 0,
+      "value": "': "
+    },
+    {
+      "type": 1,
+      "value": "error"
+    }
+  ],
   "eO6Ysb": [
     {
       "type": 0,
@@ -1665,6 +1703,12 @@
     {
       "type": 0,
       "value": "Huisletter moet een enkele letter zijn."
+    }
+  ],
+  "hcw9Gf": [
+    {
+      "type": 0,
+      "value": "There are problems with the submitted data."
     }
   ],
   "hkZ8N1": [
@@ -2185,6 +2229,12 @@
     {
       "type": 0,
       "value": "Postcode moet bestaan uit vier cijfers gevolgd door twee letters (bijv. 1234 AB)."
+    }
+  ],
+  "rWbce4": [
+    {
+      "type": 0,
+      "value": "Form unavailable"
     }
   ],
   "riuSfc": [

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -369,6 +369,11 @@
     "description": "Validation error message for verification code pattern",
     "originalDefault": "The verification code may only contain letters (A-Z) and numbers (0-9)."
   },
+  "FKWQuw": {
+    "defaultMessage": "Unfortunately, this form is currently unavailable due to an outage. Please try again later.",
+    "description": "Open Forms service unavailable error message",
+    "originalDefault": "Unfortunately, this form is currently unavailable due to an outage. Please try again later."
+  },
   "FrFeZj": {
     "defaultMessage": "You haven't entered an email address yet.",
     "description": "Email verification modal: warning that no email is specified",
@@ -714,6 +719,11 @@
     "description": "ZOD 'invalid_union_discriminator' error message",
     "originalDefault": "Invalid discriminator value. Expected {expected}."
   },
+  "YwnY5d": {
+    "defaultMessage": "Problems in form step ''{name}''",
+    "description": "Overview page, title before listing the validation errors for a step",
+    "originalDefault": "Problems in form step ''{name}''"
+  },
   "ZJoaby": {
     "defaultMessage": "<p>Thank you for cosigning. We have received your \"{formName}\" submission. {confirmationEmailEnabled, select, true {You will receive a confirmation email.} other {} }</p> <p>Do not forget to download your summary, we do not send it via email.</p>",
     "description": "Cosign confirmation page body",
@@ -804,6 +814,11 @@
     "description": "Loading content text",
     "originalDefault": "Loading..."
   },
+  "eEC1P4": {
+    "defaultMessage": "Field ''{label}'': {error}",
+    "description": "Overview page, validation error message for step field.",
+    "originalDefault": "Field ''{label}'': {error}"
+  },
   "eO6Ysb": {
     "defaultMessage": "Your payment is currently processing.",
     "description": "payment processing status",
@@ -858,6 +873,11 @@
     "defaultMessage": "House letter must be a single letter.",
     "description": "ZOD error message when AddressNL house letter does not match the house letter regular expression",
     "originalDefault": "House letter must be a single letter."
+  },
+  "hcw9Gf": {
+    "defaultMessage": "There are problems with the submitted data.",
+    "description": "Summary page generic validation error message",
+    "originalDefault": "There are problems with the submitted data."
   },
   "hkZ8N1": {
     "defaultMessage": "Invalid input.",
@@ -1078,6 +1098,11 @@
     "defaultMessage": "Postcode must be four digits followed by two letters (e.g. 1234 AB).",
     "description": "ZOD error message when AddressNL postcode does not match the postcode regular expression",
     "originalDefault": "Postcode must be four digits followed by two letters (e.g. 1234 AB)."
+  },
+  "rWbce4": {
+    "defaultMessage": "Form unavailable",
+    "description": "Open Forms service unavailable error title",
+    "originalDefault": "Form unavailable"
   },
   "riuSfc": {
     "defaultMessage": "Send code",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -373,6 +373,11 @@
     "description": "Validation error message for verification code pattern",
     "originalDefault": "The verification code may only contain letters (A-Z) and numbers (0-9)."
   },
+  "FKWQuw": {
+    "defaultMessage": "Unfortunately, this form is currently unavailable due to an outage. Please try again later.",
+    "description": "Open Forms service unavailable error message",
+    "originalDefault": "Unfortunately, this form is currently unavailable due to an outage. Please try again later."
+  },
   "FrFeZj": {
     "defaultMessage": "Je hebt nog geen e-mailadres ingevuld.",
     "description": "Email verification modal: warning that no email is specified",
@@ -722,6 +727,11 @@
     "description": "ZOD 'invalid_union_discriminator' error message",
     "originalDefault": "Invalid discriminator value. Expected {expected}."
   },
+  "YwnY5d": {
+    "defaultMessage": "Problems in form step ''{name}''",
+    "description": "Overview page, title before listing the validation errors for a step",
+    "originalDefault": "Problems in form step ''{name}''"
+  },
   "ZJoaby": {
     "defaultMessage": "<p>Bedankt voor het medeondertekenen. Wij hebben je inzending \"{formName}\" ontvangen. {confirmationEmailEnabled, select, true {Je ontvangt per mail een bevestiging.} other {} }</p> <p>Vergeet niet je aanvraag te downloaden, deze versturen wij niet per mail.</p>",
     "description": "Cosign confirmation page body",
@@ -813,6 +823,11 @@
     "description": "Loading content text",
     "originalDefault": "Loading..."
   },
+  "eEC1P4": {
+    "defaultMessage": "Field ''{label}'': {error}",
+    "description": "Overview page, validation error message for step field.",
+    "originalDefault": "Field ''{label}'': {error}"
+  },
   "eO6Ysb": {
     "defaultMessage": "De betaling wordt momenteel verwerkt.",
     "description": "payment processing status",
@@ -867,6 +882,11 @@
     "defaultMessage": "Huisletter moet een enkele letter zijn.",
     "description": "ZOD error message when AddressNL house letter does not match the house letter regular expression",
     "originalDefault": "House letter must be a single letter."
+  },
+  "hcw9Gf": {
+    "defaultMessage": "There are problems with the submitted data.",
+    "description": "Summary page generic validation error message",
+    "originalDefault": "There are problems with the submitted data."
   },
   "hkZ8N1": {
     "defaultMessage": "Ongeldige invoer.",
@@ -1090,6 +1110,11 @@
     "defaultMessage": "Postcode moet bestaan uit vier cijfers gevolgd door twee letters (bijv. 1234 AB).",
     "description": "ZOD error message when AddressNL postcode does not match the postcode regular expression",
     "originalDefault": "Postcode must be four digits followed by two letters (e.g. 1234 AB)."
+  },
+  "rWbce4": {
+    "defaultMessage": "Form unavailable",
+    "description": "Open Forms service unavailable error title",
+    "originalDefault": "Form unavailable"
   },
   "riuSfc": {
     "defaultMessage": "Verstuur code",

--- a/src/scss/components/_card.scss
+++ b/src/scss/components/_card.scss
@@ -47,4 +47,10 @@
       @include rows(0, margin-top);
     }
   }
+
+  @include bem.element('alert') {
+    &:not(:last-child) {
+      margin-block-end: 20px;
+    }
+  }
 }


### PR DESCRIPTION
Closes open-formulieren/open-forms#4510 - requires the backend PR to be merged as that changes the API endpoint used here.

I've opted to collect all the errors at the top and group them by step, rather than trying to weave this in the summary table. User research from Utrecht showed that this was the best way to show validation errors.

Ideally, there would be some aria-describedby options, but that requires a lot more work to link everything together.