### PR TITLE
:art: Use button-group-css isolated package

### DIFF
--- a/src/scss/components/_button-group.scss
+++ b/src/scss/components/_button-group.scss
@@ -3,7 +3,7 @@
  */
 @use 'microscope-sass/lib/bem';
 
-@import '@utrecht/components/button-group';
+@import '@utrecht/button-group-css';
 
 .utrecht-button-group {
   // A button group used in an edit grid item


### PR DESCRIPTION
The @utrecht/button-group-react package pulls in the button-group-css dependency which keeps implementation + styles in sync. So, we can use the new CSS package in favour of the (outdated and no longer published) @utrecht/components package.