### PR TITLE
[OF#5192] Fix buttons styling after refactor

### DIFF
--- a/src/components/Button/OFButton.jsx
+++ b/src/components/Button/OFButton.jsx
@@ -1,11 +1,12 @@
 import {Button as UtrechtButton} from '@utrecht/component-library-react';
+import clsx from 'clsx';
 import PropTypes from 'prop-types';
 
 // Temporary until the aria-disabled is set on the Utrecht button
 const OFButton = ({disabled, children, ...extraProps}) => {
   const {onClick: onClickHandler, ...otherProps} = extraProps;
 
-  if (disabled) otherProps.className = 'utrecht-button--disabled';
+  otherProps.className = clsx(otherProps.className, {'utrecht-button--disabled': disabled});
 
   const onClick = event => {
     if (disabled) {


### PR DESCRIPTION
Closes open-formulieren/open-forms#5192 partly

This has to do with the `disabled` submit button