### PR TITLE
Ensure anonymous form start button is not displayed for cosign start

### DIFF
--- a/src/components/CoSign/CosignStart.jsx
+++ b/src/components/CoSign/CosignStart.jsx
@@ -68,7 +68,7 @@ const CosignStart = () => {
 
         <LoginOptions
           // hide the normal login options, and only display the cosign login options
-          form={{...form, loginOptions: []}}
+          form={{...form, loginOptions: [], loginRequired: true}}
           // dummy - we don't actually start a new submission, but the next URL is baked
           // into the login URLs.
           onFormStart={() => {}}

--- a/src/components/CoSign/CosignStart.stories.js
+++ b/src/components/CoSign/CosignStart.stories.js
@@ -49,3 +49,13 @@ export default {
 export const Default = {
   name: 'CosignStart',
 };
+
+export const LoginOptional = {
+  parameters: {
+    formContext: {
+      form: {
+        loginRequired: false,
+      },
+    },
+  },
+};


### PR DESCRIPTION
Closes open-formulieren/open-forms#5195

Cosign always requires users to authenticate and whether the form can be started anonymously or not has no influence on the cosign start options.