### PR TITLE
Dropping support for browser translations

### DIFF
--- a/src/sdk.jsx
+++ b/src/sdk.jsx
@@ -138,6 +138,11 @@ class OpenForm {
   async init() {
     ReactModal.setAppElement(this.targetNode);
 
+    // Fixing an issue where browser (in particular Chrome) translations change the DOM
+    // tree, causing React to lose track of DOM nodes and crashing the SDK.
+    // See https://github.com/open-formulieren/open-forms/issues/5242
+    this.targetNode.setAttribute('translate', 'no');
+
     this.url = `${this.baseUrl}forms/${this.formId}`;
     this.targetNode.textContent = `Loading form...`;
     this.baseTitle = document.title;


### PR DESCRIPTION
Closes: open-formulieren/open-forms#5242

Browser translations, in participle the translation functions of Chrome, change the DOM tree when translating texts. This causes React to lose track of certain DOM nodes, which leads to the SDK throwing errors and crashing.

This solution ensures that no SDK content can be translated. With this we lose some accessibility, but this seems to be the only reliable solution that would "solve" the issue for any and all browsers and translation plugins.