### PR TITLE
Missing leaflet map translation

### DIFF
--- a/src/components/Map/translations.js
+++ b/src/components/Map/translations.js
@@ -66,6 +66,13 @@ const leafletEditToolbarMessages = defineMessages({
   },
 });
 
+const leafletEditHandlersMessages = defineMessages({
+  RemoveTitle: {
+    description: 'Edit handlers remove tooltip.',
+    defaultMessage: 'Click on a shape to remove.',
+  },
+});
+
 const leafletDrawToolbarMessages = defineMessages({
   actionsText: {
     description: 'Draw toolbar cancel button message.',
@@ -157,6 +164,13 @@ const applyLeafletTranslations = intl => {
     buttons: {
       remove: intl.formatMessage(leafletEditToolbarMessages.remove),
       removeDisabled: intl.formatMessage(leafletEditToolbarMessages.removeDisabled),
+    },
+  };
+  Leaflet.drawLocal.edit.handlers = {
+    remove: {
+      tooltip: {
+        text: intl.formatMessage(leafletEditHandlersMessages.RemoveTitle),
+      },
     },
   };
   Leaflet.drawLocal.draw.toolbar = {

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -2437,6 +2437,12 @@
       "value": "Click first point to finish shape"
     }
   ],
+  "w6Z2/m": [
+    {
+      "type": 0,
+      "value": "Click on a shape to remove."
+    }
+  ],
   "wwsWUp": [
     {
       "type": 0,

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -2441,6 +2441,12 @@
       "value": "Klik op het eerste punt, om de veelhoek te voltooien"
     }
   ],
+  "w6Z2/m": [
+    {
+      "type": 0,
+      "value": "Click on a shape to remove."
+    }
+  ],
   "wwsWUp": [
     {
       "type": 0,

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1149,6 +1149,11 @@
     "description": "Draw handler polygon tooltip end.",
     "originalDefault": "Click first point to finish shape"
   },
+  "w6Z2/m": {
+    "defaultMessage": "Click on a shape to remove.",
+    "description": "Edit handlers remove tooltip.",
+    "originalDefault": "Click on a shape to remove."
+  },
   "wwsWUp": {
     "defaultMessage": "How do you rate this form?",
     "description": "GovMetric snippet header",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -1161,6 +1161,11 @@
     "description": "Draw handler polygon tooltip end.",
     "originalDefault": "Click first point to finish shape"
   },
+  "w6Z2/m": {
+    "defaultMessage": "Click on a shape to remove.",
+    "description": "Edit handlers remove tooltip.",
+    "originalDefault": "Click on a shape to remove."
+  },
   "wwsWUp": {
     "defaultMessage": "Wat vind je van dit formulier?",
     "description": "GovMetric snippet header",


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#5191

Added a missing leaflet map translation for when a user is removing the drawn shapes.