### PR TITLE
Rework map delete button functionality

### DIFF
--- a/src/components/Map/LeafletControl.tsx
+++ b/src/components/Map/LeafletControl.tsx
@@ -1,0 +1,99 @@
+import clsx from 'clsx';
+import L from 'leaflet';
+import {createRef, useEffect, useState} from 'react';
+import {useMap} from 'react-leaflet';
+
+interface ControlProps {
+  position: L.ControlPosition;
+  children: React.ReactNode;
+}
+
+const POSITION_CLASSES = {
+  bottomleft: 'leaflet-bottom leaflet-left',
+  bottomright: 'leaflet-bottom leaflet-right',
+  topleft: 'leaflet-top leaflet-left',
+  topright: 'leaflet-top leaflet-right',
+};
+
+const LeafletControl: React.FC<ControlProps> = ({position, children}) => {
+  const [portalRoot, setPortalRoot] = useState<HTMLElement>(document.createElement('div'));
+  const controlContainerRef = createRef<HTMLDivElement>();
+  const map = useMap();
+
+  /**
+   * Whenever the control container ref is created, ensure the click/scroll propagation
+   * is removed. This way click/scroll events do not bubble down to the map.
+   */
+  useEffect(() => {
+    if (controlContainerRef.current !== null) {
+      L.DomEvent.disableClickPropagation(controlContainerRef.current);
+      L.DomEvent.disableScrollPropagation(controlContainerRef.current);
+    }
+  }, [controlContainerRef]);
+
+  /**
+   * Mount the component to the position container of the map component.
+   */
+  useEffect(() => {
+    const mapContainer = map.getContainer();
+    const targetDiv = mapContainer.getElementsByClassName(POSITION_CLASSES[position]);
+    setPortalRoot(targetDiv[0] as HTMLElement);
+  }, [map, position]);
+
+  /**
+   * Whenever the portal root is complete, append the control container to the portal
+   * root.
+   */
+  useEffect(() => {
+    if (portalRoot && controlContainerRef.current) {
+      portalRoot.append(controlContainerRef.current);
+    }
+  }, [controlContainerRef, portalRoot]);
+
+  return (
+    <div ref={controlContainerRef} className="leaflet-bar leaflet-draw-toolbar leaflet-control">
+      {children}
+    </div>
+  );
+};
+
+interface LeafletControlButtonProps {
+  onClick: () => void;
+  disabled?: boolean;
+  extraClassName?: string;
+  ariaLabel: string;
+  ariaContent: string;
+}
+
+const LeafletControlButton: React.FC<LeafletControlButtonProps> = ({
+  onClick,
+  disabled,
+  extraClassName,
+  ariaLabel,
+  ariaContent,
+}) => {
+  return (
+    <>
+      {/* The leaflet styling rules need this to be an anchor element */}
+      {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+      <a
+        href="#"
+        onClick={onClick}
+        className={clsx(
+          'leaflet-control-button',
+          {
+            'leaflet-disabled': disabled,
+          },
+          extraClassName
+        )}
+        aria-disabled={disabled}
+        aria-label={ariaLabel}
+      >
+        <span className="sr-only">{ariaContent}</span>
+      </a>
+    </>
+  );
+};
+
+export default LeafletControl;
+export {LeafletControl, LeafletControlButton};

--- a/src/components/Map/translations.js
+++ b/src/components/Map/translations.js
@@ -32,30 +32,6 @@ const leafletGestureHandlingText = defineMessages({
 });
 
 const leafletEditToolbarMessages = defineMessages({
-  saveText: {
-    description: 'Edit toolbar save message.',
-    defaultMessage: 'Save',
-  },
-  saveTitle: {
-    description: 'Edit toolbar save tooltip.',
-    defaultMessage: 'Save changes',
-  },
-  cancelText: {
-    description: 'Edit toolbar cancel message.',
-    defaultMessage: 'Cancel',
-  },
-  cancelTitle: {
-    description: 'Edit toolbar cancel tooltip.',
-    defaultMessage: 'Cancel changes',
-  },
-  clearAllText: {
-    description: 'Edit toolbar clearAll message.',
-    defaultMessage: 'Remove all',
-  },
-  clearAllTitle: {
-    description: 'Edit toolbar clearAll tooltip.',
-    defaultMessage: 'Remove all shapes',
-  },
   remove: {
     description: 'Edit toolbar remove button tooltip.',
     defaultMessage: 'Remove shapes',
@@ -139,26 +115,6 @@ const leafletDrawHandlerMessages = defineMessages({
 const applyLeafletTranslations = intl => {
   // We have to do the translations via Leaflet
   // https://github.com/alex3165/react-leaflet-draw/issues/179
-  Leaflet.drawLocal.edit.toolbar = {
-    actions: {
-      save: {
-        text: intl.formatMessage(leafletEditToolbarMessages.saveText),
-        title: intl.formatMessage(leafletEditToolbarMessages.saveTitle),
-      },
-      cancel: {
-        text: intl.formatMessage(leafletEditToolbarMessages.cancelText),
-        title: intl.formatMessage(leafletEditToolbarMessages.cancelTitle),
-      },
-      clearAll: {
-        text: intl.formatMessage(leafletEditToolbarMessages.clearAllText),
-        title: intl.formatMessage(leafletEditToolbarMessages.clearAllTitle),
-      },
-    },
-    buttons: {
-      remove: intl.formatMessage(leafletEditToolbarMessages.remove),
-      removeDisabled: intl.formatMessage(leafletEditToolbarMessages.removeDisabled),
-    },
-  };
   Leaflet.drawLocal.draw.toolbar = {
     actions: {
       text: intl.formatMessage(leafletDrawToolbarMessages.actionsText),
@@ -199,4 +155,9 @@ const applyLeafletTranslations = intl => {
   };
 };
 
-export {searchControlMessages, leafletGestureHandlingText, applyLeafletTranslations};
+export {
+  searchControlMessages,
+  leafletEditToolbarMessages,
+  leafletGestureHandlingText,
+  applyLeafletTranslations,
+};

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -181,12 +181,6 @@
       "value": "Loading..."
     }
   ],
-  "4ZOmtU": [
-    {
-      "type": 0,
-      "value": "Save changes"
-    }
-  ],
   "4gPdgK": [
     {
       "type": 0,
@@ -779,12 +773,6 @@
       "value": "Inloggen bij deze organisatie is niet gelukt. Probeert u het later nog een keer. Lukt het nog steeds niet? Log in bij Mijn DigiD. Zo controleert u of uw DigiD goed werkt. Mogelijk is er een storing bij de organisatie waar u inlogt."
     }
   ],
-  "HY6Irs": [
-    {
-      "type": 0,
-      "value": "Cancel changes"
-    }
-  ],
   "HgLr1F": [
     {
       "type": 0,
@@ -1105,12 +1093,6 @@
       "value": "Payment"
     }
   ],
-  "N2sZnS": [
-    {
-      "type": 0,
-      "value": "Save"
-    }
-  ],
   "Op4orj": [
     {
       "type": 0,
@@ -1341,12 +1323,6 @@
       "value": "."
     }
   ],
-  "U5+FHP": [
-    {
-      "type": 0,
-      "value": "Cancel"
-    }
-  ],
   "UyEKdQ": [
     {
       "type": 0,
@@ -1565,12 +1541,6 @@
     {
       "type": 0,
       "value": "Contact details"
-    }
-  ],
-  "bRtoG6": [
-    {
-      "type": 0,
-      "value": "Remove all"
     }
   ],
   "bgfiRG": [
@@ -2237,6 +2207,12 @@
       "value": "Log in to co-sign the form"
     }
   ],
+  "qPBMwn": [
+    {
+      "type": 0,
+      "value": "Are you sure you want to delete your drawn shape?"
+    }
+  ],
   "qyWfE+": [
     {
       "type": 0,
@@ -2283,12 +2259,6 @@
     {
       "type": 0,
       "value": "Find address"
-    }
-  ],
-  "sYb+eZ": [
-    {
-      "type": 0,
-      "value": "Remove all shapes"
     }
   ],
   "senRv3": [

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -181,12 +181,6 @@
       "value": "Opties ophalen..."
     }
   ],
-  "4ZOmtU": [
-    {
-      "type": 0,
-      "value": "Wijzigingen opslaan"
-    }
-  ],
   "4gPdgK": [
     {
       "type": 0,
@@ -779,12 +773,6 @@
       "value": "Inloggen bij deze organisatie is niet gelukt. Probeert u het later nog een keer. Lukt het nog steeds niet? Log in bij Mijn DigiD. Zo controleert u of uw DigiD goed werkt. Mogelijk is er een storing bij de organisatie waar u inlogt."
     }
   ],
-  "HY6Irs": [
-    {
-      "type": 0,
-      "value": "Wijzigingen annuleren"
-    }
-  ],
   "HgLr1F": [
     {
       "type": 0,
@@ -1105,12 +1093,6 @@
       "value": "Betalen"
     }
   ],
-  "N2sZnS": [
-    {
-      "type": 0,
-      "value": "Opslaan"
-    }
-  ],
   "Op4orj": [
     {
       "type": 0,
@@ -1341,12 +1323,6 @@
       "value": " lang zijn."
     }
   ],
-  "U5+FHP": [
-    {
-      "type": 0,
-      "value": "Annuleer"
-    }
-  ],
   "UyEKdQ": [
     {
       "type": 0,
@@ -1569,12 +1545,6 @@
     {
       "type": 0,
       "value": "Je gegevens"
-    }
-  ],
-  "bRtoG6": [
-    {
-      "type": 0,
-      "value": "Verwijder alles"
     }
   ],
   "bgfiRG": [
@@ -2241,6 +2211,12 @@
       "value": "Log in om het formulier mede te ondertekenen"
     }
   ],
+  "qPBMwn": [
+    {
+      "type": 0,
+      "value": "Are you sure you want to delete your drawn shape?"
+    }
+  ],
   "qyWfE+": [
     {
       "type": 0,
@@ -2287,12 +2263,6 @@
     {
       "type": 0,
       "value": "Zoek adres"
-    }
-  ],
-  "sYb+eZ": [
-    {
-      "type": 0,
-      "value": "Verwijder alle vormen van de kaart"
     }
   ],
   "senRv3": [

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -79,11 +79,6 @@
     "description": "(Async) select options loading message",
     "originalDefault": "Loading..."
   },
-  "4ZOmtU": {
-    "defaultMessage": "Save changes",
-    "description": "Edit toolbar save tooltip.",
-    "originalDefault": "Save changes"
-  },
   "4gPdgK": {
     "defaultMessage": "Bad",
     "description": "GovMetric rating text",
@@ -409,11 +404,6 @@
     "description": "DigiD error message. MUST BE THIS EXACT STRING!",
     "originalDefault": "Inloggen bij deze organisatie is niet gelukt. Probeert u het later nog een keer. Lukt het nog steeds niet? Log in bij Mijn DigiD. Zo controleert u of uw DigiD goed werkt. Mogelijk is er een storing bij de organisatie waar u inlogt."
   },
-  "HY6Irs": {
-    "defaultMessage": "Cancel changes",
-    "description": "Edit toolbar cancel tooltip.",
-    "originalDefault": "Cancel changes"
-  },
   "HgLr1F": {
     "defaultMessage": "Cancel",
     "description": "Draw toolbar cancel button message.",
@@ -544,11 +534,6 @@
     "description": "Payment page title",
     "originalDefault": "Payment"
   },
-  "N2sZnS": {
-    "defaultMessage": "Save",
-    "description": "Edit toolbar save message.",
-    "originalDefault": "Save"
-  },
   "Op4orj": {
     "defaultMessage": "No shapes to remove",
     "description": "Edit toolbar remove button disabled tooltip.",
@@ -638,11 +623,6 @@
     "defaultMessage": "String must contain {exact, select, true {exactly} other {{inclusive, select, true {at least} other {more than}}} } {minimum, plural, one {{minimum} character} other {{minimum} characters}}.",
     "description": "ZOD 'too_small' error message, for strings",
     "originalDefault": "String must contain {exact, select, true {exactly} other {{inclusive, select, true {at least} other {more than}}} } {minimum, plural, one {{minimum} character} other {{minimum} characters}}."
-  },
-  "U5+FHP": {
-    "defaultMessage": "Cancel",
-    "description": "Edit toolbar cancel message.",
-    "originalDefault": "Cancel"
   },
   "UyEKdQ": {
     "defaultMessage": "Product {number}/{total}",
@@ -748,11 +728,6 @@
     "defaultMessage": "Contact details",
     "description": "Appointments: contact details step title",
     "originalDefault": "Contact details"
-  },
-  "bRtoG6": {
-    "defaultMessage": "Remove all",
-    "description": "Edit toolbar clearAll message.",
-    "originalDefault": "Remove all"
   },
   "bgfiRG": {
     "defaultMessage": "You've started the payment process.",
@@ -1064,6 +1039,11 @@
     "description": "Log in to co-sign the form title",
     "originalDefault": "Log in to co-sign the form"
   },
+  "qPBMwn": {
+    "defaultMessage": "Are you sure you want to delete your drawn shape?",
+    "description": "Leaflet map's delete confirmation message",
+    "originalDefault": "Are you sure you want to delete your drawn shape?"
+  },
   "qyWfE+": {
     "defaultMessage": "Receive a verification code",
     "description": "Email verification mode selection: send code label",
@@ -1093,11 +1073,6 @@
     "defaultMessage": "Find address",
     "description": "The leaflet map's input fields placeholder message.",
     "originalDefault": "Enter address, please"
-  },
-  "sYb+eZ": {
-    "defaultMessage": "Remove all shapes",
-    "description": "Edit toolbar clearAll tooltip.",
-    "originalDefault": "Remove all shapes"
   },
   "senRv3": {
     "defaultMessage": "You're about to cancel your appointment on <b>{date}</b> at <b>{time}</b>. Please fill out your email address for verification purposes.",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -79,11 +79,6 @@
     "description": "(Async) select options loading message",
     "originalDefault": "Loading..."
   },
-  "4ZOmtU": {
-    "defaultMessage": "Wijzigingen opslaan",
-    "description": "Edit toolbar save tooltip.",
-    "originalDefault": "Save changes"
-  },
   "4gPdgK": {
     "defaultMessage": "Slecht",
     "description": "GovMetric rating text",
@@ -414,11 +409,6 @@
     "isTranslated": true,
     "originalDefault": "Inloggen bij deze organisatie is niet gelukt. Probeert u het later nog een keer. Lukt het nog steeds niet? Log in bij Mijn DigiD. Zo controleert u of uw DigiD goed werkt. Mogelijk is er een storing bij de organisatie waar u inlogt."
   },
-  "HY6Irs": {
-    "defaultMessage": "Wijzigingen annuleren",
-    "description": "Edit toolbar cancel tooltip.",
-    "originalDefault": "Cancel changes"
-  },
   "HgLr1F": {
     "defaultMessage": "Annuleer",
     "description": "Draw toolbar cancel button message.",
@@ -551,11 +541,6 @@
     "description": "Payment page title",
     "originalDefault": "Payment"
   },
-  "N2sZnS": {
-    "defaultMessage": "Opslaan",
-    "description": "Edit toolbar save message.",
-    "originalDefault": "Save"
-  },
   "Op4orj": {
     "defaultMessage": "Geen vormen om te verwijderen",
     "description": "Edit toolbar remove button disabled tooltip.",
@@ -645,11 +630,6 @@
     "defaultMessage": "De tekst moet {exact, select, true {exact} other {{inclusive, select, true {minstens} other {meer dan}}} } {minimum, plural, one {{minimum} karakter} other {{minimum} karakters}} lang zijn.",
     "description": "ZOD 'too_small' error message, for strings",
     "originalDefault": "String must contain {exact, select, true {exactly} other {{inclusive, select, true {at least} other {more than}}} } {minimum, plural, one {{minimum} character} other {{minimum} characters}}."
-  },
-  "U5+FHP": {
-    "defaultMessage": "Annuleer",
-    "description": "Edit toolbar cancel message.",
-    "originalDefault": "Cancel"
   },
   "UyEKdQ": {
     "defaultMessage": "Product {number}/{total}",
@@ -757,11 +737,6 @@
     "defaultMessage": "Je gegevens",
     "description": "Appointments: contact details step title",
     "originalDefault": "Contact details"
-  },
-  "bRtoG6": {
-    "defaultMessage": "Verwijder alles",
-    "description": "Edit toolbar clearAll message.",
-    "originalDefault": "Remove all"
   },
   "bgfiRG": {
     "defaultMessage": "Je hebt de betaling gestart.",
@@ -1076,6 +1051,11 @@
     "description": "Log in to co-sign the form title",
     "originalDefault": "Log in to co-sign the form"
   },
+  "qPBMwn": {
+    "defaultMessage": "Are you sure you want to delete your drawn shape?",
+    "description": "Leaflet map's delete confirmation message",
+    "originalDefault": "Are you sure you want to delete your drawn shape?"
+  },
   "qyWfE+": {
     "defaultMessage": "Een bevestigingscode ontvangen",
     "description": "Email verification mode selection: send code label",
@@ -1105,11 +1085,6 @@
     "defaultMessage": "Zoek adres",
     "description": "The leaflet map's input fields placeholder message.",
     "originalDefault": "Enter address, please"
-  },
-  "sYb+eZ": {
-    "defaultMessage": "Verwijder alle vormen van de kaart",
-    "description": "Edit toolbar clearAll tooltip.",
-    "originalDefault": "Remove all shapes"
   },
   "senRv3": {
     "defaultMessage": "Je staat op het punt je afspraak op <b>{date}</b> om <b>{time}</b> te annuleren. Vul je e-mailadres in ter controle.",


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#5191

The delete button will no-longer show the delete-menu, instead it will just immediately remove the shape from the map. With that, I've also removed the translations for this delete-menu, as it no-longer will be shown.

### Extra context/thought process
The comment on open-formulieren/open-forms#5191 suggests relabeling the "save" (confirm delete action) button. While working on that, i took a look if could do anything more to make the deletion more expected/understandable. Unfortunately we cannot control what the sub-menu items do, or which sub-menu items are shown, so that idea quickly died...

When reading the open-formulieren/open-forms#5191 comments again, I thought of another approach: what if the delete button just deletes the drawn shape? This solution seemed the simplest, for us as developers but also for end-users, so thats what this PR contains.