### PR TITLE
Fit map to geometry bounds

### DIFF
--- a/src/components/Map/LeafletMap.jsx
+++ b/src/components/Map/LeafletMap.jsx
@@ -185,6 +185,8 @@ const EnsureTestId = () => {
 };
 
 const Geometry = ({geoJsonGeometry, featureGroupRef}) => {
+  const map = useMap();
+
   useEffect(() => {
     if (!featureGroupRef.current) {
       // If there is no feature group, nothing should be done...
@@ -201,7 +203,14 @@ const Geometry = ({geoJsonGeometry, featureGroupRef}) => {
     // Add the `geoJsonGeometry` data as shape.
     const layer = Leaflet.GeoJSON.geometryToLayer(geoJsonGeometry);
     featureGroupRef.current.addLayer(layer);
-  }, [featureGroupRef, geoJsonGeometry]);
+
+    // For marker/point elements the zooming doesn't provide any functionality, as it
+    // cannot be outside the bounds.
+    if (geoJsonGeometry.type !== 'Point') {
+      // Update map zoom to fit the shape
+      map.fitBounds(Leaflet.geoJSON(geoJsonGeometry).getBounds(), {padding: [1, 1]});
+    }
+  }, [featureGroupRef, geoJsonGeometry, map]);
 
   return null;
 };


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#5191

This ensures that the map shows the entire geometry shape in the summary view. Additionally, this re-fits the map when the user draws a shape.