### PR TITLE
Fix date field value normalization to date from datetime

### DIFF
--- a/src/formio/components/DateField.js
+++ b/src/formio/components/DateField.js
@@ -6,14 +6,6 @@ import {setErrorAttributes} from '../utils';
 
 const DateTimeField = Formio.Components.components.datetime;
 
-const extractDate = value => {
-  if (!value) {
-    // multiple values has null instead of empty str
-    return '';
-  }
-  return value.substring(0, 10);
-};
-
 class DateField extends DateTimeField {
   constructor(component, options, data) {
     // GH#5240
@@ -60,26 +52,6 @@ class DateField extends DateTimeField {
       setErrorAttributes(targetElements, hasErrors, hasMessages, this.refs.messageContainer.id);
     }
     return super.setErrorClasses(targetElements, dirty, hasErrors, hasMessages);
-  }
-
-  beforeSubmit() {
-    // The field itself should prevent any invalid dates from being passed in
-    // so we are not checking that here
-    if (this._data[this.component.key]) {
-      let currentValue = this._data[this.component.key];
-      // normalize to list
-      if (!this.component.multiple) currentValue = [currentValue];
-
-      // strip off the time part
-      currentValue = currentValue.map(val => extractDate(val));
-
-      // format back to single/multiple
-      if (!this.component.multiple) currentValue = currentValue[0];
-
-      // assign back to internal data structure
-      this._data[this.component.key] = currentValue;
-    }
-    super.beforeSubmit();
   }
 }
 

--- a/src/formio/components/DateField.js
+++ b/src/formio/components/DateField.js
@@ -16,6 +16,14 @@ const extractDate = value => {
 
 class DateField extends DateTimeField {
   constructor(component, options, data) {
+    // GH#5240
+    // override the date format of the calendar widget to always emit dates instead
+    // of datetimes so that backend validation doesn't choke on datetimes when dates
+    // are expected.
+    if (!component.customOptions) {
+      component.customOptions = {allowInvalidPreload: true};
+    }
+    component.customOptions.dateFormat = 'yyyy-MM-dd';
     super(component, options, data);
 
     if (component.datePicker.minDate || component.datePicker.maxDate) {


### PR DESCRIPTION
Closes open-formulieren/open-forms#5240
Closes open-formulieren/open-forms#4820

Fixed the serialization of the calendar value to an actual proper date string instead of datetime, which now also works with suspending forms. Talk about an old bug...

@viktorvanwijk I think this one can also be included in the patch releases still :)