### PR TITLE
Fix unexpected initial data reference behaviour

### DIFF
--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -5,25 +5,13 @@ import {Document} from '@utrecht/component-library-react';
  * Storybook does not have a before/after cleanup cycle, and localStorage would in
  * these situations break story/test isolation.
  *
+ * Also, the submission ID is persisted in the sessionStorage once a submission is started, and we
+ * need to clear it for stories.
+ *
  * This decorator is applied to every story to reset the storage state.
  */
 export const withClearSessionStorage: Decorator = Story => {
   window.sessionStorage.clear();
-  return <Story />;
-};
-
-/**
- * Submission ID is persisted in the localStorage once a submission is started, and we
- * need to clear it for stories.
- *
- * The storage key is the form UUID, the default from api-mocks/form is
- * 'e450890a-4166-410e-8d64-0a54ad30ba01'. You can specify another key via parameters
- * or args.
- */
-export const withClearSubmissionLocalStorage: Decorator = (Story, {args, parameters}) => {
-  const formId =
-    args?.formId ?? parameters?.localStorage?.formId ?? 'e450890a-4166-410e-8d64-0a54ad30ba01';
-  window.localStorage.removeItem(formId);
   return <Story />;
 };
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -20,11 +20,7 @@ import OpenFormsModule from 'formio/module';
 import OFLibrary from 'formio/templates';
 import {withModalDecorator} from 'story-utils/decorators';
 
-import {
-  withClearSessionStorage,
-  withClearSubmissionLocalStorage,
-  withUtrechtDocument,
-} from './decorators';
+import {withClearSessionStorage, withUtrechtDocument} from './decorators';
 import {allModes} from './modes.mjs';
 import {reactIntl} from './reactIntl.mjs';
 import ThemeProvider from './theme';
@@ -51,7 +47,6 @@ export default {
   decorators: [
     withThemeProvider(ThemeProvider),
     withClearSessionStorage,
-    withClearSubmissionLocalStorage,
     withModalDecorator,
     withUtrechtDocument,
   ],

--- a/src/components/CoSign/Cosign.spec.jsx
+++ b/src/components/CoSign/Cosign.spec.jsx
@@ -13,11 +13,11 @@ import cosignRoutes from 'routes/cosign';
 import Cosign from './Cosign';
 
 beforeEach(() => {
-  localStorage.clear();
+  sessionStorage.clear();
 });
 
 afterEach(() => {
-  localStorage.clear();
+  sessionStorage.clear();
 });
 
 const TEST_FORM = buildForm({

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -13,6 +13,7 @@ import {START_FORM_QUERY_PARAM} from 'components/constants';
 import {flagActiveSubmission, flagNoActiveSubmission} from 'data/submissions';
 import useAutomaticRedirect from 'hooks/useAutomaticRedirect';
 import useFormContext from 'hooks/useFormContext';
+import useInitialDataReference from 'hooks/useInitialDataReference';
 import usePageViews from 'hooks/usePageViews';
 import useRecycleSubmission from 'hooks/useRecycleSubmission';
 
@@ -36,6 +37,7 @@ const Form = () => {
   const prevLocale = usePrevious(intl.locale);
   const {state: routerState} = useLocation();
   const confirmationMatch = useMatch('/bevestiging');
+  const {addInitialDataReference} = useInitialDataReference();
 
   // extract the declared properties and configuration
   const config = useContext(ConfigContext);
@@ -79,7 +81,7 @@ const Form = () => {
     await destroy(`${config.baseUrl}authentication/${submission.id}/session`);
     removeSubmissionId();
     setSubmission(null);
-    navigate('/');
+    navigate(addInitialDataReference('/'));
   };
 
   // handle redirect from payment provider to render appropriate page and include the

--- a/src/components/Form.spec.jsx
+++ b/src/components/Form.spec.jsx
@@ -281,3 +281,50 @@ test('Submitting form with payment requirement', async () => {
 
   expect(await screen.findByText('A payment is required for this product.')).toBeVisible();
 });
+
+test('Starting a form with the same initial data reference', async () => {
+  const user = userEvent.setup();
+  const form = buildForm();
+  mswServer.use(
+    mockAnalyticsToolConfigGet(),
+    mockSubmissionGet(),
+    mockSubmissionPost(),
+    mockSubmissionStepGet()
+  );
+  // Start a form with initial data reference 'foo'
+  render(<Wrapper form={form} initialEntry="/startpagina?initial_data_reference=foo" />);
+  const startButton = await screen.findByRole('button', {name: 'Begin'});
+  expect(startButton).toBeVisible();
+
+  // Clicking the start button starts the submission and ensures it is saved in the storage
+  await user.click(startButton);
+  expect(await screen.findByRole('heading', {name: 'Step 1'})).toBeVisible();
+
+  // Start a form with initial data reference 'foo' again and ensure a new submission cannot be
+  // started
+  render(<Wrapper form={form} initialEntry="/startpagina?initial_data_reference=foo" />);
+  expect(screen.queryByRole('button', {name: 'Begin'})).toBeNull();
+});
+
+test('Starting a form with a different initial data reference', async () => {
+  const user = userEvent.setup();
+  const form = buildForm();
+  mswServer.use(
+    mockAnalyticsToolConfigGet(),
+    mockSubmissionGet(),
+    mockSubmissionPost(),
+    mockSubmissionStepGet()
+  );
+  // Start a form with initial data reference 'foo'
+  render(<Wrapper form={form} initialEntry="/startpagina?initial_data_reference=foo" />);
+  const startButton = await screen.findByRole('button', {name: 'Begin'});
+  expect(startButton).toBeVisible();
+
+  // Clicking the start button starts the submission and ensures it is saved in the storage
+  await user.click(startButton);
+  expect(await screen.findByRole('heading', {name: 'Step 1'})).toBeVisible();
+
+  // Start a form with initial data reference 'bar' and ensure a submission can be started
+  render(<Wrapper form={form} initialEntry="/startpagina?initial_data_reference=bar" />);
+  expect(await screen.findByRole('button', {name: 'Begin'})).toBeVisible();
+});

--- a/src/components/Form.spec.jsx
+++ b/src/components/Form.spec.jsx
@@ -29,7 +29,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  localStorage.clear();
+  sessionStorage.clear();
 });
 
 afterEach(() => {
@@ -37,7 +37,7 @@ afterEach(() => {
     vi.runOnlyPendingTimers();
     vi.useRealTimers();
   }
-  localStorage.clear();
+  sessionStorage.clear();
 });
 
 afterAll(() => {

--- a/src/components/SubmissionProvider.jsx
+++ b/src/components/SubmissionProvider.jsx
@@ -40,7 +40,7 @@ SubmissionProvider.propTypes = {
    */
   onDestroySession: PropTypes.func.isRequired,
   /**
-   * Callback to remove the submission reference (it's ID) from the local storage.
+   * Callback to remove the submission reference (it's ID) from the session storage.
    */
   removeSubmissionId: PropTypes.func.isRequired,
 };

--- a/src/hooks/useRecycleSubmission.js
+++ b/src/hooks/useRecycleSubmission.js
@@ -1,17 +1,27 @@
 import {useContext} from 'react';
-import {useLocation, useSearchParams} from 'react-router';
+import {useLocation, useMatch, useSearchParams} from 'react-router';
 import {useAsync, useLocalStorage} from 'react-use';
 
 import {ConfigContext} from 'Context';
 import {apiCall} from 'api';
+import useInitialDataReference from 'hooks/useInitialDataReference';
 
 const useRecycleSubmission = (form, currentSubmission, onSubmissionLoaded, onError = () => {}) => {
   const location = useLocation();
   const config = useContext(ConfigContext);
   const [params] = useSearchParams();
-  // XXX: use sessionStorage instead of localStorage for this, so that it's scoped to
-  // a single tab/window?
-  let [submissionId, setSubmissionId, removeSubmissionId] = useLocalStorage(form.uuid, '');
+  const {initialDataReference: referenceFromUrl} = useInitialDataReference();
+  const homePageMatch = useMatch('/startpagina');
+  const introductionPageMatch = useMatch('/introductie');
+
+  // We only care about the initial data reference from the URL when we are on the introduction or
+  // starting page
+  const initialDataReference =
+    homePageMatch || introductionPageMatch
+      ? referenceFromUrl
+      : currentSubmission?.initialDataReference;
+  const storageKey = initialDataReference ? form.uuid + initialDataReference : form.uuid;
+  let [submissionId, setSubmissionId, removeSubmissionId] = useLocalStorage(storageKey, '');
 
   // If no submissionID is in the localStorage see if one can be retrieved from the query param
   if (!submissionId) {


### PR DESCRIPTION
Closes open-formulieren/open-forms#5266

**Changes:**
* Initial data reference is now used together with the form ID as a storage key
* Switched from local storage to session storage to keep submissions contained within a single tab