### PR TITLE
Don't offer to re-use submission for (new) initial data reference

### DIFF
--- a/src/hooks/useRecycleSubmission.js
+++ b/src/hooks/useRecycleSubmission.js
@@ -5,10 +5,18 @@ import {useAsync, useLocalStorage} from 'react-use';
 import {ConfigContext} from 'Context';
 import {apiCall} from 'api';
 
+import useInitialDataReference from './useInitialDataReference';
+
 const useRecycleSubmission = (form, currentSubmission, onSubmissionLoaded, onError = () => {}) => {
   const location = useLocation();
   const config = useContext(ConfigContext);
   const [params] = useSearchParams();
+
+  // see open-formulieren/open-forms#5266 - when the user re-opens the tab/browser with
+  // an initial data reference in the URL parameters, while there is still a submission
+  // reference, this causes the (new) initial data reference to be ignored.
+  const {initialDataReference} = useInitialDataReference();
+
   // XXX: use sessionStorage instead of localStorage for this, so that it's scoped to
   // a single tab/window?
   let [submissionId, setSubmissionId, removeSubmissionId] = useLocalStorage(form.uuid, '');
@@ -16,6 +24,15 @@ const useRecycleSubmission = (form, currentSubmission, onSubmissionLoaded, onErr
   // If no submissionID is in the localStorage see if one can be retrieved from the query param
   if (!submissionId) {
     submissionId = params.get('submission_uuid');
+  }
+
+  // see open-formulieren/open-forms#5266 - if we have both an initial data reference
+  // (extracted from the query parameters) and a submission ID, discard the submission ID. The
+  // query parameter is passed along just long enough to be able to send it to the submission
+  // create, after which it's "baked in" on the server side. The presence of this parameters
+  // therefore implies that we should discard any existing submissions for the same form.
+  if (initialDataReference && submissionId) {
+    submissionId = undefined;
   }
 
   const url = submissionId ? `${config.baseUrl}submissions/${submissionId}` : null;


### PR DESCRIPTION
Fixes open-formulieren/open-forms#5266

The presence of an initial data reference parameter implies it's a new reference, which would invalidate any existing submissions stored in the local storage. So, the easiest (but not most elegant) patch for the observed problem is to ignore any existing submission ID from the local storage (or session storage, if you will) when this query param is present.

This works because the parameter is only used to bootstrap the process and kept around long enough to be able to send it with the submission create call. After that, it's no longer passed around in the URL, and navigating back to the form start step while on step 2 or further will present the 'continue or reset' screen as usual because the parameter is missing.

When the parameter is present, it's because of the user clicking a link or manually pasting the link back into the browser, at which point we can reasonably assume they're trying to start a new form submission.

This patch does not interfere with hitting F5 anywhere in the form, even refreshing on the start page again has the expected behaviour, since a submission still needs to be created then.