### PR TITLE
open-formulieren/open-forms#5132 Handling failed Yivi login attempts

### DIFF
--- a/src/components/auth/AuthenticationError.spec.tsx
+++ b/src/components/auth/AuthenticationError.spec.tsx
@@ -81,3 +81,27 @@ it('Renders eIDAS cancel login error', () => {
 
   expect(screen.getByText('Je hebt het inloggen met eIDAS geannuleerd.')).toBeVisible();
 });
+
+it('Renders Yivi default error', () => {
+  render(
+    <IntlProvider locale="nl" messages={messagesNL}>
+      <AuthenticationError parameter="_yivi-message" errorCode="error" />
+    </IntlProvider>
+  );
+
+  expect(
+    screen.getByText(
+      'Er is een fout opgetreden bij het inloggen met Yivi. Probeer het later opnieuw.'
+    )
+  ).toBeVisible();
+});
+
+it('Renders Yivi cancel login error', () => {
+  render(
+    <IntlProvider locale="nl" messages={messagesNL}>
+      <AuthenticationError parameter="_yivi-message" errorCode="login-cancelled" />
+    </IntlProvider>
+  );
+
+  expect(screen.getByText('Je hebt het inloggen met Yivi geannuleerd.')).toBeVisible();
+});

--- a/src/components/auth/AuthenticationErrors/index.jsx
+++ b/src/components/auth/AuthenticationErrors/index.jsx
@@ -8,6 +8,7 @@ const MAPPING_PARAMS_SERVICE = {
   '_digid-message': 'DigiD',
   '_eherkenning-message': 'EHerkenning',
   '_eidas-message': 'eIDAS',
+  '_yivi-message': 'Yivi',
 };
 
 const CANCEL_LOGIN_PARAM = 'login-cancelled';

--- a/src/components/auth/constants.ts
+++ b/src/components/auth/constants.ts
@@ -3,7 +3,11 @@
  */
 export type AuthErrorCode = 'login-cancelled' | 'error';
 
-export type MessageParamName = '_digid-message' | '_eherkenning-message' | '_eidas-message';
+export type MessageParamName =
+  | '_digid-message'
+  | '_eherkenning-message'
+  | '_eidas-message'
+  | '_yivi-message';
 
 // Uses a list of tuples instead of a mapping for type safety in the consuming code,
 // as otherwise the union information is lost through Object.keys|entries
@@ -11,4 +15,5 @@ export const MAPPING_PARAMS_SERVICE: [MessageParamName, string][] = [
   ['_digid-message', 'DigiD'],
   ['_eherkenning-message', 'EHerkenning'],
   ['_eidas-message', 'eIDAS'],
+  ['_yivi-message', 'Yivi'],
 ];


### PR DESCRIPTION
Making sure that failed Yivi login attempts (due to general errors or the user canceling) are handled correctly by the SDK, by showing an appropriate error message.