### PR TITLE
Feature/5191 custom delete button

### DIFF
--- a/src/components/Map/LeafletMap.tsx
+++ b/src/components/Map/LeafletMap.tsx
@@ -21,6 +21,7 @@ import LayersControl from './LeafletMapLayersControl';
 import SearchControl, {type GeoSearchShowLocationEvent} from './LeafletMapSearchControl';
 import NearestAddress from './NearestAddress';
 import {DEFAULT_INTERACTIONS, DEFAULT_LAT_LNG, DEFAULT_ZOOM} from './constants';
+import {overloadLeafletDeleteControl} from './deleteControl';
 import {CRS_RD, TILE_LAYER_RD, initialize} from './init';
 import {
   applyLeafletTranslations,
@@ -97,6 +98,10 @@ const LeafletMap: React.FC<LeafletMapProps> = ({
   useEffect(() => {
     applyLeafletTranslations(intl);
   }, [intl]);
+
+  useEffect(() => {
+    overloadLeafletDeleteControl(featureGroupRef, intl);
+  }, [featureGroupRef, intl]);
 
   const onFeatureCreate = (event: DrawEvents.Created) => {
     updateGeoJsonGeometry(event.layer);

--- a/src/components/Map/deleteControl.ts
+++ b/src/components/Map/deleteControl.ts
@@ -1,7 +1,7 @@
 import * as Leaflet from 'leaflet';
 import {FeatureGroup as LeafletFeatureGroup} from 'leaflet';
 import type {RefObject} from 'react';
-import {IntlShape} from 'react-intl';
+import type {IntlShape} from 'react-intl';
 
 /**
  * Overload the Leaflet-Draw delete control, to support "one-click" deletion of all

--- a/src/components/Map/deleteControl.ts
+++ b/src/components/Map/deleteControl.ts
@@ -1,0 +1,46 @@
+import * as Leaflet from 'leaflet';
+import {FeatureGroup as LeafletFeatureGroup} from 'leaflet';
+import type {RefObject} from 'react';
+import {IntlShape} from 'react-intl';
+
+/**
+ * Overload the Leaflet-Draw delete control, to support "one-click" deletion of all
+ * shapes.
+ *
+ * Update the "onclick" functionality of the Leaflet-Draw delete control to remove the
+ * "delete menu" popup. Instead, just delete all shapes. To prevent accidental deletion,
+ * a confirmation message will appear.
+ *
+ * @param featureGroupRef React ref to the FeatureGroup component
+ * @param intl React-intl instance
+ */
+const overloadLeafletDeleteControl = (
+  featureGroupRef: RefObject<LeafletFeatureGroup>,
+  intl: IntlShape
+) => {
+  const deleteShapeConfirmMessage = intl.formatMessage({
+    description: 'Leaflet map: delete drawn shape confirmation message',
+    defaultMessage: 'Are you sure you want to delete your drawn shape?',
+  });
+  Leaflet.EditToolbar.Delete.include({
+    enable: function () {
+      if (!window.confirm(deleteShapeConfirmMessage)) return;
+
+      const featureGroup = featureGroupRef.current;
+      if (!featureGroup) return;
+
+      // Collect all current layers/shapes
+      const layers = new Leaflet.LayerGroup();
+      featureGroup.eachLayer((layer: Leaflet.Layer) => layers.addLayer(layer));
+
+      // Delete all shapes
+      featureGroup.clearLayers();
+
+      // Trigger "shapes deleted" Leaflet event, and mark control as disabled.
+      this._map.fire(Leaflet.Draw.Event.DELETED, {layers});
+      this.disable();
+    },
+  });
+};
+
+export {overloadLeafletDeleteControl};

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -1953,6 +1953,12 @@
       "value": "Times are in your local time"
     }
   ],
+  "h2LzuB": [
+    {
+      "type": 0,
+      "value": "Are you sure you want to delete your drawn shape?"
+    }
+  ],
   "hFqzG6": [
     {
       "type": 0,

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -1905,6 +1905,12 @@
       "value": "Je wordt op dit tijdstip op de afspraak verwacht"
     }
   ],
+  "h2LzuB": [
+    {
+      "type": 0,
+      "value": "Are you sure you want to delete your drawn shape?"
+    }
+  ],
   "hFqzG6": [
     {
       "type": 0,

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -904,6 +904,11 @@
     "description": "Appoinments: time select help text",
     "originalDefault": "Times are in your local time"
   },
+  "h2LzuB": {
+    "defaultMessage": "Are you sure you want to delete your drawn shape?",
+    "description": "Leaflet map: delete drawn shape confirmation message",
+    "originalDefault": "Are you sure you want to delete your drawn shape?"
+  },
   "hFqzG6": {
     "defaultMessage": "Current step in form {title}: {activeStepTitle}",
     "description": "Active step accessible label in mobile progress indicator",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -914,6 +914,11 @@
     "description": "Appoinments: time select help text",
     "originalDefault": "Times are in your local time"
   },
+  "h2LzuB": {
+    "defaultMessage": "Are you sure you want to delete your drawn shape?",
+    "description": "Leaflet map: delete drawn shape confirmation message",
+    "originalDefault": "Are you sure you want to delete your drawn shape?"
+  },
   "hFqzG6": {
     "defaultMessage": "Huidige stap in formulier {title}: {activeStepTitle}",
     "description": "Active step accessible label in mobile progress indicator",


### PR DESCRIPTION
Partly closes https://github.com/open-formulieren/open-forms/issues/5191

Re-using the Leaflet-Draw delete control to provide "single" click deletion.

The default Leaflet-Draw delete button opens a delete menu and requires multiple user input steps to remove a drawn shape from the map component. To improve the useability, the delete menu has been removed, allowing "single" click shape removal.

By clicking the delete button, a confirmation message will be shown to make sure that user data isn't accidentally removed. After confirming the removal, the drawn shape on the map is automatically removed.

## Technical note:
This is done by extending the Leaflet-Draw `Leaflet.EditToolbar.Delete` `enable` functionality. This changes the behaviour of "onclick" for the delete button.

React leaflet provides another solution for this, by defining and connection a custom controller https://react-leaflet.js.org/docs/v4/core-api/#createcontrolcomponent. This however has the drawback of unpredictable UI rendering, as the placement in the DOM is done by React leaflet, and the placement/order in the `.tsx` React component doesn't have any impact.

The other approach, which we use for most of our other custom controls, is to connect the controller directly via the `useMap` hook. This, for some reason, had some difficulty with correctly providing information about the current drawn shapes. In addition, the UI would be changed in a manner that would separate the "draw shape X" buttons and the delete button. By extending the Leaflet-Draw `Leaflet.EditToolbar.Delete` we keep the UI intact.

See https://github.com/open-formulieren/open-forms-sdk/pull/821/files#r2368521776 for further technical comments.