### PR TITLE
:rotating_light: Enable import linting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,14 @@ const config = [
     rules: {
       // normally this would be on, but we'll rather migrate to typescript
       'react/prop-types': 'off',
+      // let's test-drive it before adding it to our maykin recommended
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {
+          fixStyle: 'separate-type-imports',
+          prefer: 'type-imports',
+        },
+      ],
     },
   },
   // Unit tests

--- a/src/api-mocks/submissions.ts
+++ b/src/api-mocks/submissions.ts
@@ -4,7 +4,7 @@ import {HttpResponse, http} from 'msw';
 
 import type {SubmissionStep} from '@/data/submission-steps';
 import type {Submission} from '@/data/submissions';
-import {InvalidParam} from '@/errors';
+import type {InvalidParam} from '@/errors';
 import {sleep} from '@/utils';
 
 import {BASE_URL, getDefaultFactory} from './base';

--- a/src/components/CoSign/CosignCheck.tsx
+++ b/src/components/CoSign/CosignCheck.tsx
@@ -5,7 +5,7 @@ import {CosignSummary} from 'components/Summary';
 
 import {ConfigContext} from '@/Context';
 import {destroy} from '@/api';
-import {Submission} from '@/data/submissions';
+import type {Submission} from '@/data/submissions';
 import useFormContext from '@/hooks/useFormContext';
 
 import {useCosignContext} from './Context';

--- a/src/components/EditGrid/EditGrid.stories.tsx
+++ b/src/components/EditGrid/EditGrid.stories.tsx
@@ -1,5 +1,5 @@
 import {EditGrid} from '@open-formulieren/formio-renderer';
-import {Meta, StoryObj} from '@storybook/react';
+import type {Meta, StoryObj} from '@storybook/react';
 import {userEvent, within} from '@storybook/test';
 
 import Body from 'components/Body';

--- a/src/components/EmailVerification/EmailVerificationModal.stories.tsx
+++ b/src/components/EmailVerification/EmailVerificationModal.stories.tsx
@@ -1,4 +1,4 @@
-import {Meta, StoryObj} from '@storybook/react';
+import type {Meta, StoryObj} from '@storybook/react';
 import {fn} from '@storybook/test';
 
 import {ConfigDecorator} from 'story-utils/decorators';

--- a/src/components/EmailVerification/EmailVerificationModal.tsx
+++ b/src/components/EmailVerification/EmailVerificationModal.tsx
@@ -2,7 +2,8 @@ import {useEffect, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import Body from '@/components/Body';
-import Modal, {ModalCloseHandler} from '@/components/modals/Modal';
+import type {ModalCloseHandler} from '@/components/modals/Modal';
+import Modal from '@/components/modals/Modal';
 
 import EmailVerificationForm from './EmailVerificationForm';
 

--- a/src/components/Errors/ErrorBoundary.stories.tsx
+++ b/src/components/Errors/ErrorBoundary.stories.tsx
@@ -1,10 +1,10 @@
-import {Meta, StoryObj} from '@storybook/react';
+import type {Meta, StoryObj} from '@storybook/react';
 import {MemoryRouter} from 'react-router';
 
 import {PermissionDenied, ServiceUnavailable, UnprocessableEntity} from '@/errors';
 
 import ErrorBoundary from './ErrorBoundary';
-import {AnyError} from './types';
+import type {AnyError} from './types';
 
 // in JS, you actually *can* throw anything
 const Throw: React.FC<{error: AnyError}> = ({error}) => {

--- a/src/components/Errors/ErrorMessage.stories.ts
+++ b/src/components/Errors/ErrorMessage.stories.ts
@@ -1,4 +1,4 @@
-import {Meta, StoryObj} from '@storybook/react';
+import type {Meta, StoryObj} from '@storybook/react';
 
 import ErrorMessage, {ALERT_MODIFIERS} from './ErrorMessage';
 

--- a/src/components/Errors/types.ts
+++ b/src/components/Errors/types.ts
@@ -1,4 +1,4 @@
-import {APIError} from '@/errors';
+import type {APIError} from '@/errors';
 
 // you can pretty much throw anything in JS
 export type AnyError = Error | APIError | string | object;

--- a/src/components/ExistingSubmissionOptions/ExistingSubmissionOptions.tsx
+++ b/src/components/ExistingSubmissionOptions/ExistingSubmissionOptions.tsx
@@ -4,7 +4,7 @@ import {useNavigate} from 'react-router';
 
 import AbortButton from '@/components/AbortButton';
 import {OFButton} from '@/components/Button';
-import {Form} from '@/data/forms';
+import type {Form} from '@/data/forms';
 
 export interface ExistingSubmissionOptionsProps {
   form: Form;

--- a/src/components/FormStep/FormStepNavigationButtons.stories.tsx
+++ b/src/components/FormStep/FormStepNavigationButtons.stories.tsx
@@ -3,7 +3,7 @@ import {expect, within} from '@storybook/test';
 
 import {buildForm, buildSubmission} from '@/api-mocks';
 
-import FormStepNewRenderer from './FormStepNewRenderer';
+import type FormStepNewRenderer from './FormStepNewRenderer';
 import FormStepNewRendererStories from './FormStepNewRenderer.stories';
 
 export default {

--- a/src/components/FormStep/hooks.ts
+++ b/src/components/FormStep/hooks.ts
@@ -1,7 +1,8 @@
 import type {JSONObject} from '@open-formulieren/formio-renderer/types.js';
 import {useEffect, useRef, useState} from 'react';
 import {useParams} from 'react-router';
-import useAsync, {AsyncState} from 'react-use/esm/useAsync';
+import type {AsyncState} from 'react-use/esm/useAsync';
+import useAsync from 'react-use/esm/useAsync';
 
 import {get} from '@/api';
 import type {Form, MinimalFormStep} from '@/data/forms';

--- a/src/components/LanguageSelection/LanguageSelection.stories.tsx
+++ b/src/components/LanguageSelection/LanguageSelection.stories.tsx
@@ -7,7 +7,8 @@ import {IntlProvider} from 'react-intl';
 import {ConfigDecorator} from 'story-utils/decorators';
 
 import ErrorBoundary from '@/components/Errors/ErrorBoundary';
-import {I18NContext, I18NContextType} from '@/i18n';
+import type {I18NContextType} from '@/i18n';
+import {I18NContext} from '@/i18n';
 
 import LanguageSelection, {type LanguageInfo} from './LanguageSelection';
 import {

--- a/src/components/LanguageSelection/LanguageSelection.tsx
+++ b/src/components/LanguageSelection/LanguageSelection.tsx
@@ -1,4 +1,4 @@
-import {SupportedLocales} from '@open-formulieren/types';
+import type {SupportedLocales} from '@open-formulieren/types';
 import {ButtonGroup} from '@utrecht/button-group-react';
 import {Heading, LinkButton} from '@utrecht/component-library-react';
 import {Fragment, useContext, useId, useState} from 'react';

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type React from 'react';
 import {type LinkProps as RouterLinkProps, useHref, useLinkClickHandler} from 'react-router';
 
 import Anchor, {type AnchorProps} from '@/components/Anchor';

--- a/src/components/Map/LeafletMap.tsx
+++ b/src/components/Map/LeafletMap.tsx
@@ -1,6 +1,6 @@
 import type {MapComponentSchema} from '@open-formulieren/types';
 import * as Leaflet from 'leaflet';
-import {
+import type {
   Circle,
   CircleMarker,
   DrawEvents,

--- a/src/components/Map/LeafletMapSearchControl.tsx
+++ b/src/components/Map/LeafletMapSearchControl.tsx
@@ -1,4 +1,4 @@
-import {Control, LeafletEvent, Marker} from 'leaflet';
+import type {Control, LeafletEvent, Marker} from 'leaflet';
 import {GeoSearchControl} from 'leaflet-geosearch';
 import {useContext, useEffect} from 'react';
 import {useIntl} from 'react-intl';

--- a/src/components/StatementCheckboxes/StatementCheckbox.tsx
+++ b/src/components/StatementCheckboxes/StatementCheckbox.tsx
@@ -1,5 +1,5 @@
 import {Checkbox} from '@open-formulieren/formio-renderer';
-import {CheckboxComponentSchema} from '@open-formulieren/types';
+import type {CheckboxComponentSchema} from '@open-formulieren/types';
 import {useMemo} from 'react';
 import {defineMessages, useIntl} from 'react-intl';
 

--- a/src/components/Summary/FormStepSummary.tsx
+++ b/src/components/Summary/FormStepSummary.tsx
@@ -1,5 +1,5 @@
 import type {AnyComponentSchema} from '@open-formulieren/types';
-import {JSONValue} from '@open-formulieren/types/lib/types';
+import type {JSONValue} from '@open-formulieren/types/lib/types';
 import {
   DataList,
   DataListItem,

--- a/src/components/Summary/SubmissionSummary.tsx
+++ b/src/components/Summary/SubmissionSummary.tsx
@@ -1,5 +1,5 @@
-import {JSONObject} from '@open-formulieren/types/lib/types';
-import {FormikErrors} from 'formik';
+import type {JSONObject} from '@open-formulieren/types/lib/types';
+import type {FormikErrors} from 'formik';
 import {useContext, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useLocation, useNavigate} from 'react-router';

--- a/src/components/Summary/hooks.ts
+++ b/src/components/Summary/hooks.ts
@@ -1,6 +1,6 @@
 import {useContext} from 'react';
 import {useAsync} from 'react-use';
-import {AsyncState} from 'react-use/lib/useAsyncFn';
+import type {AsyncState} from 'react-use/lib/useAsyncFn';
 
 import {ConfigContext} from '@/Context';
 import {type StepSummaryData, type Submission, loadSummaryData} from '@/data/submissions';

--- a/src/components/auth/AuthenticationError.tsx
+++ b/src/components/auth/AuthenticationError.tsx
@@ -1,9 +1,11 @@
-import {IntlShape, useIntl} from 'react-intl';
+import type {IntlShape} from 'react-intl';
+import {useIntl} from 'react-intl';
 import {useSearchParams} from 'react-router';
 
 import ErrorMessage from '@/components/Errors/ErrorMessage';
 
-import {type AuthErrorCode, MAPPING_PARAMS_SERVICE, MessageParamName} from './constants';
+import type {AuthErrorCode, MessageParamName} from './constants';
+import {MAPPING_PARAMS_SERVICE} from './constants';
 
 /**
  * Check if there are any authentication error parameters in the query string and

--- a/src/components/formio/index.stories.ts
+++ b/src/components/formio/index.stories.ts
@@ -1,6 +1,6 @@
 import {FormioForm} from '@open-formulieren/formio-renderer';
-import {DateComponentSchema} from '@open-formulieren/types';
-import {Meta, StoryObj} from '@storybook/react';
+import type {DateComponentSchema} from '@open-formulieren/types';
+import type {Meta, StoryObj} from '@storybook/react';
 import {fn} from '@storybook/test';
 
 export default {

--- a/src/formio/components/Children/AddChildForm.stories.ts
+++ b/src/formio/components/Children/AddChildForm.stories.ts
@@ -1,4 +1,4 @@
-import {Meta, StoryObj} from '@storybook/react';
+import type {Meta, StoryObj} from '@storybook/react';
 import {expect, fn, userEvent, within} from '@storybook/test';
 
 import {ConfigDecorator} from 'story-utils/decorators';

--- a/src/formio/components/Children/AddChildForm.tsx
+++ b/src/formio/components/Children/AddChildForm.tsx
@@ -1,5 +1,5 @@
 import {FormioForm} from '@open-formulieren/formio-renderer';
-import {JSONObject} from '@open-formulieren/formio-renderer/types.js';
+import type {JSONObject} from '@open-formulieren/formio-renderer/types.js';
 import type {AnyComponentSchema} from '@open-formulieren/types';
 import {ButtonGroup} from '@utrecht/button-group-react';
 import {useContext, useMemo} from 'react';
@@ -9,7 +9,7 @@ import {FormContext} from '@/Context';
 
 import ChildrenSubmitButton from './ChildrenSubmitButton';
 import CHILDREN_COMPONENTS from './definition';
-import {ChildExtendedDetails} from './types';
+import type {ChildExtendedDetails} from './types';
 
 export interface AddChildrenFormProps {
   childValues: ChildExtendedDetails | null;

--- a/src/formio/components/Children/AddChildModal.stories.ts
+++ b/src/formio/components/Children/AddChildModal.stories.ts
@@ -1,10 +1,10 @@
-import {Meta, StoryObj} from '@storybook/react';
+import type {Meta, StoryObj} from '@storybook/react';
 import {fn} from '@storybook/test';
 
 import {ConfigDecorator} from 'story-utils/decorators';
 
 import AddChildModal from './AddChildModal';
-import Children from './Children';
+import type Children from './Children';
 
 export default {
   title: 'Private API / Children / Modal',

--- a/src/formio/components/Children/AddChildModal.tsx
+++ b/src/formio/components/Children/AddChildModal.tsx
@@ -3,7 +3,7 @@ import {FormattedMessage} from 'react-intl';
 import Modal from 'components/modals/Modal';
 
 import AddChildForm from './AddChildForm';
-import {ChildExtendedDetails} from './types';
+import type {ChildExtendedDetails} from './types';
 
 export interface AddChildrenModalProps {
   childValues: ChildExtendedDetails | null;

--- a/src/formio/components/Children/ChildrenForm.tsx
+++ b/src/formio/components/Children/ChildrenForm.tsx
@@ -9,7 +9,7 @@ import {
   TableRow,
 } from '@utrecht/component-library-react';
 import '@utrecht/table-css';
-import {UUID} from 'crypto';
+import type {UUID} from 'crypto';
 import {FormattedMessage, useIntl} from 'react-intl';
 
 import FAIcon from 'components/FAIcon';
@@ -17,7 +17,7 @@ import FAIcon from 'components/FAIcon';
 import {OFButton} from '@/components/Button';
 
 import CHILDREN_COMPONENTS from './definition';
-import {ChildExtendedDetails} from './types';
+import type {ChildExtendedDetails} from './types';
 
 export interface ChildrenComponentProps {
   childrenValues: ChildExtendedDetails[];

--- a/src/formio/components/Children/definition.ts
+++ b/src/formio/components/Children/definition.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AnyComponentSchema,
   BsnComponentSchema,
   DateComponentSchema,

--- a/src/formio/components/Children/types.ts
+++ b/src/formio/components/Children/types.ts
@@ -1,5 +1,5 @@
 import type {ChildDetails} from '@open-formulieren/types';
-import {UUID} from 'crypto';
+import type {UUID} from 'crypto';
 
 export interface ChildExtendedDetails extends ChildDetails {
   // distinguish a child added manually by the user (when no data was retreived from the

--- a/src/formio/components/Partners/AddPartnerForm.stories.ts
+++ b/src/formio/components/Partners/AddPartnerForm.stories.ts
@@ -1,4 +1,4 @@
-import {Meta, StoryObj} from '@storybook/react';
+import type {Meta, StoryObj} from '@storybook/react';
 import {expect, fn, userEvent, within} from '@storybook/test';
 
 import {ConfigDecorator} from 'story-utils/decorators';

--- a/src/formio/components/Partners/AddPartnerForm.tsx
+++ b/src/formio/components/Partners/AddPartnerForm.tsx
@@ -1,5 +1,5 @@
 import {FormioForm} from '@open-formulieren/formio-renderer';
-import {JSONObject} from '@open-formulieren/formio-renderer/types.js';
+import type {JSONObject} from '@open-formulieren/formio-renderer/types.js';
 import type {AnyComponentSchema, PartnerDetails} from '@open-formulieren/types';
 import {ButtonGroup} from '@utrecht/button-group-react';
 import {useContext, useMemo} from 'react';
@@ -9,7 +9,7 @@ import {FormContext} from '@/Context';
 
 import PartnerSubmitButton from './PartnerSubmitButton';
 import PARTNER_COMPONENTS from './definition';
-import {PartnerManuallyAdded} from './types';
+import type {PartnerManuallyAdded} from './types';
 
 export interface AddPartnerFormProps {
   partner: PartnerDetails | null;

--- a/src/formio/components/Partners/AddPartnerModal.stories.ts
+++ b/src/formio/components/Partners/AddPartnerModal.stories.ts
@@ -1,10 +1,10 @@
-import {Meta, StoryObj} from '@storybook/react';
+import type {Meta, StoryObj} from '@storybook/react';
 import {fn} from '@storybook/test';
 
 import {ConfigDecorator} from 'story-utils/decorators';
 
 import {AddPartnerModal} from './AddPartnerModal';
-import Partners from './Partners';
+import type Partners from './Partners';
 
 export default {
   title: 'Private API / Partners / Modal',

--- a/src/formio/components/Partners/PartnersForm.tsx
+++ b/src/formio/components/Partners/PartnersForm.tsx
@@ -5,7 +5,7 @@ import {FormattedMessage} from 'react-intl';
 import {OFButton} from '@/components/Button';
 
 import PARTNER_COMPONENTS from './definition';
-import {PartnerManuallyAdded} from './types';
+import type {PartnerManuallyAdded} from './types';
 
 export interface PartnersComponentProps {
   partners: PartnerDetails[];

--- a/src/formio/components/Partners/definition.ts
+++ b/src/formio/components/Partners/definition.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AnyComponentSchema,
   BsnComponentSchema,
   DateComponentSchema,


### PR DESCRIPTION
The goal here is to have a linter complain about type-only imports, requiring the 'type' keyword to be present.

Personally, I'd prefer to have imports statements that are only type imports have a single top-level type keyword, and imports that are a mix of runtime and type imports use the inline type keyword, but that doesn't seem possible with the available import rules (ts-eslint or import-eslint plugins), which brings us to separate import statements for types and runtime information. I can live with it.