### PR TITLE
[#869] Fix children component's styling for mobile devices

### DIFF
--- a/src/formio/components/Children/ChildrenForm.tsx
+++ b/src/formio/components/Children/ChildrenForm.tsx
@@ -86,7 +86,7 @@ export const DisplayChildren: React.FC<DisplayChildrenProps> = ({
   }));
 
   return (
-    <div style={{padding: '1em'}}>
+    <div className="openforms-children">
       {childrenValues.length > 0 && (
         <Table>
           <TableHeader>
@@ -143,7 +143,7 @@ export const DisplayChildren: React.FC<DisplayChildrenProps> = ({
                   )}
                 </TableCell>
                 {child.__addedManually && (
-                  <TableCell>
+                  <TableCell className="openforms-children__actions">
                     <OFButton
                       onClick={() => onEditChild(child)}
                       appearance="subtle-button"

--- a/src/scss/components/_children.scss
+++ b/src/scss/components/_children.scss
@@ -1,0 +1,19 @@
+.openforms-children {
+  padding: var(--of-children-padding, 8px);
+
+  @media (max-width: $breakpoint-tablet) {
+    overflow: auto;
+    overflow-wrap: break-word;
+    -webkit-overflow-scrolling: touch;
+
+    &__actions {
+      display: inline-flex;
+    }
+
+    --utrecht-table-cell-padding-inline-end: 20px;
+
+    .utrecht-table__header-cell {
+      white-space: nowrap;
+    }
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -36,6 +36,7 @@ $fa-font-path: '../webfonts/' !default; // vite.config.mts overrides this
 @import './scss/components/button';
 @import './scss/components/button-group';
 @import './scss/components/card';
+@import './scss/components/children';
 @import './scss/components/content';
 @import './scss/components/data-list';
 @import './scss/components/errors';


### PR DESCRIPTION
Closes #869 

Haven't used any design-tokens for this solution. The table component that we use from https://nl-design-system.github.io/utrecht/storybook/?path=/story/react_react-table--design-tokens doesn't support the necessary properties for what we need. If there is a different opinion please let me know.


- [ ] Requires open-formulieren/design-tokens#60 to be merged