### PR TITLE
:sparkles: [open-formulieren/open-forms#5191] Remove last poly-shape vertex

### DIFF
--- a/src/components/Map/LeafletMap.tsx
+++ b/src/components/Map/LeafletMap.tsx
@@ -22,6 +22,7 @@ import SearchControl, {type GeoSearchShowLocationEvent} from './LeafletMapSearch
 import NearestAddress from './NearestAddress';
 import {DEFAULT_INTERACTIONS, DEFAULT_LAT_LNG, DEFAULT_ZOOM} from './constants';
 import {overloadLeafletDeleteControl} from './deleteControl';
+import {overloadLeafletDrawPolylineControl} from './drawPolylineControl';
 import {CRS_RD, TILE_LAYER_RD, initialize} from './init';
 import {
   applyLeafletTranslations,
@@ -86,6 +87,10 @@ const LeafletMap: React.FC<LeafletMapProps> = ({
   useEffect(() => {
     overloadLeafletDeleteControl(featureGroupRef, intl);
   }, [featureGroupRef, intl]);
+
+  useEffect(() => {
+    overloadLeafletDrawPolylineControl();
+  }, []);
 
   const onFeatureCreate = (event: DrawEvents.Created) => {
     updateGeoJsonGeometry(event.layer);

--- a/src/components/Map/drawPolylineControl.ts
+++ b/src/components/Map/drawPolylineControl.ts
@@ -1,0 +1,40 @@
+import * as Leaflet from 'leaflet';
+
+/**
+ * Overload the Leaflet-Draw Polyline control, to support "delete last vertex" feature.
+ *
+ * Update the "deleteLastVertex" functionality of the Leaflet-Draw Polyline control to
+ * remove the entire polyline when only one vertex is present. By default, the
+ * "deleteLastVertex" is canceled when only one vertex is drawn.
+ *
+ * Because the Polygon control is an extension of the Polyline control, this
+ * "delete last vertex" function will also work when drawing Polygons.
+ */
+const overloadLeafletDrawPolylineControl = () => {
+  // Save original method
+  const originalDeleteLastVertex = Leaflet.Draw.Polyline.prototype.deleteLastVertex;
+
+  Leaflet.Draw.Polyline.include({
+    deleteLastVertex: function () {
+      if (this._markers?.length <= 1) {
+        // Remove poly-shape from map
+        if (this._poly) {
+          this._map.removeLayer(this._poly);
+        }
+
+        // Also clear the markers
+        this._markers.forEach((marker: Leaflet.Marker) => this._map.removeLayer(marker));
+        this._markers = [];
+
+        // Cancel drawing session
+        this.disable();
+        return;
+      }
+
+      // Otherwise run default behavior
+      return originalDeleteLastVertex.call(this);
+    },
+  });
+};
+
+export {overloadLeafletDrawPolylineControl};


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#5191

Override the default Leaflet Draw Polyline functionality to allow removal of the last draw vertex.

Normal Leaflet Draw behaviour is to "return" when only one vertex remains, but this functionality caused confusion for users. https://github.com/Leaflet/Leaflet.draw/blob/d5dd11781c2e07f9e719308e504fe579000edf54/src/draw/handler/Draw.Polyline.js#L156

By overriding the `deleteLastVertex` of Leaflet Draw Polyline, we can support "last vertex removal".

Because the Leaflet Draw Polygon control is an extension of the Leaflet Draw Polyline, the `overloadLeafletDrawPolylineControl` also effects the Polygon. Meaning, by updating the Polyline `deleteLastVertex` function, both Polyline and Polygon support the "delete last vertex" functionality.

## Testing
Leaflet **really** likes being difficult, so I've not managed to place a polygon/polyline vertex programmatically in a storybook test. From what I understand, they require actual manual user clicks, in an actual proper DOM, to place the vertexes. The storybook DOM doesn't have to right information, to translate pixels to coordinates, or something like that? I can see the click events, but the Leaflet map ignores it for some reason. As a last ditch I've tried to initialize the Leaflet.Draw.Polyline control directly, but that also doesn't work.
Long story short; it feels like a waste to spend more time trying to get this to work. If the need to cover this functionality with tests is really great, I can take another look.