### PR TITLE
Update supported versions in dockerhub

### DIFF
--- a/docker/ci/config.json
+++ b/docker/ci/config.json
@@ -5,11 +5,11 @@
       "tag": "latest"
     },
     {
-      "gitRef": "stable/3.2.x",
+      "gitRef": "stable/3.3.x",
       "tag": null
     },
     {
-      "gitRef": "stable/3.1.x",
+      "gitRef": "stable/3.2.x",
       "tag": null
     }
   ]


### PR DESCRIPTION
Updates the supported versions now that `3.3.0` was released.