### PR TITLE
[#5695] Add the extra information to contact details step

### DIFF
--- a/src/api-mocks/appointments.ts
+++ b/src/api-mocks/appointments.ts
@@ -71,7 +71,13 @@ interface LocationConfig {
 const LOCATIONS: LocationConfig[] = [
   {
     products: ['166a5c79', 'e8e045ab'],
-    location: {identifier: '1396f17c', name: 'Open Gem', city: '', address: '', postalcode: ''},
+    location: {
+      identifier: '1396f17c',
+      name: 'Open Gem',
+      city: 'Amsterdam',
+      address: '',
+      postalcode: '',
+    },
   },
   {
     products: ['e8e045ab', 'ea04db83'],

--- a/src/components/appointments/CreateAppointment/CreateAppointment.stories.tsx
+++ b/src/components/appointments/CreateAppointment/CreateAppointment.stories.tsx
@@ -121,6 +121,11 @@ export const HappyFlow: Story = {
 
     await step('Fill out the location and time', async () => {
       expect(await canvas.findByText('Datum en tijd')).toBeVisible();
+
+      // previous step summary section (products)
+      expect(await canvas.findByText('Jouw product(en)')).toBeVisible();
+      expect(await canvas.findByText('Paspoort aanvraag: 1x')).toBeVisible();
+
       await waitFor(async () => {
         expect(canvas.getByRole('link', {name: 'Terug naar producten'})).toBeVisible();
         expect(canvas.queryByRole('button', {name: 'Naar contactgegevens'})).not.toHaveAttribute(
@@ -128,7 +133,7 @@ export const HappyFlow: Story = {
           'true'
         );
         // location auto-filled
-        await canvas.findByText('Open Gem');
+        await canvas.findByText('Open Gem (Amsterdam)');
       });
 
       // this location has a date available tomorrow (see api-mocks/appointments)
@@ -164,7 +169,20 @@ export const HappyFlow: Story = {
     });
 
     await step('Fill out the contact details', async () => {
-      expect(await canvas.findByText('Je gegevens')).toBeVisible();
+      const tomorrow = format(addDays(new Date(), 1), 'P', {
+        locale: calendarLocale,
+      });
+
+      await waitFor(async () => {
+        expect(await canvas.findAllByText('Contactgegevens')).toHaveLength(2);
+      });
+
+      // previous steps summary section (products, location and time of the appointment)
+      expect(await canvas.findByText('Jouw product(en)')).toBeVisible();
+      expect(await canvas.findByText('Paspoort aanvraag: 1x')).toBeVisible();
+      expect(await canvas.findByText('Jouw afspraak')).toBeVisible();
+      expect(await canvas.findByText(`Open Gem, Amsterdam, ${tomorrow}, 07:00`)).toBeVisible();
+
       await waitFor(async () => {
         expect(canvas.getByRole('link', {name: 'Terug naar locatie en tijdstip'})).toBeVisible();
       });

--- a/src/components/appointments/fields/LocationSelect.stories.ts
+++ b/src/components/appointments/fields/LocationSelect.stories.ts
@@ -32,11 +32,11 @@ export const MultipleCandidates: Story = {
   play: async ({canvasElement}) => {
     // test that the options are fetched from the API endpoint
     const canvas = within(canvasElement);
-    expect(canvas.queryByText('Open Gem')).not.toBeInTheDocument();
+    expect(canvas.queryByText('Open Gem (Amsterdam)')).not.toBeInTheDocument();
     const dropdown = canvas.getByLabelText('Locatie');
     dropdown.focus();
     await userEvent.keyboard('[ArrowDown]');
-    expect(await canvas.findByRole('option', {name: 'Open Gem'})).toBeVisible();
+    expect(await canvas.findByRole('option', {name: 'Open Gem (Amsterdam)'})).toBeVisible();
     expect(
       await canvas.findByRole('option', {name: 'Bahamas (Winsome Dr, 1014 EG, Nassau)'})
     ).toBeVisible();
@@ -53,7 +53,7 @@ export const SingleCandidate: Story = {
   },
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
-    expect(canvas.queryByText('Open Gem')).not.toBeInTheDocument();
+    expect(canvas.queryByText('Open Gem (Amsterdam)')).not.toBeInTheDocument();
     expect(canvas.queryByText('Bahamas (Winsome Dr, 1014 EG, Nassau)')).not.toBeInTheDocument();
 
     const dropdown = canvas.getByLabelText('Locatie');
@@ -62,12 +62,12 @@ export const SingleCandidate: Story = {
 
     // wait for locations to be loaded
     await waitFor(async () => {
-      const textNodes = canvas.queryAllByText('Open Gem');
+      const textNodes = canvas.queryAllByText('Open Gem (Amsterdam)');
       expect(textNodes.length).toBeGreaterThan(0);
     });
 
     expect(canvas.queryByText('Bahamas (Winsome Dr, 1014 EG, Nassau)')).not.toBeInTheDocument();
     await userEvent.keyboard('[Escape]');
-    expect(await canvas.findByText('Open Gem')).toBeVisible();
+    expect(await canvas.findByText('Open Gem (Amsterdam)')).toBeVisible();
   },
 };

--- a/src/components/appointments/steps/ContactDetailsStep.stories.tsx
+++ b/src/components/appointments/steps/ContactDetailsStep.stories.tsx
@@ -3,7 +3,11 @@ import {expect, userEvent, within} from '@storybook/test';
 import {addDays, formatISO} from 'date-fns';
 import {withRouter} from 'storybook-addon-remix-react-router';
 
-import {mockAppointmentCustomerFieldsGet} from '@/api-mocks/appointments';
+import {
+  mockAppointmentCustomerFieldsGet,
+  mockAppointmentLocationsGet,
+  mockAppointmentProductsGet,
+} from '@/api-mocks/appointments';
 import {withCard, withPageWrapper} from '@/sb-decorators';
 
 import {withAppointmentState} from '../story-utils';
@@ -22,7 +26,10 @@ export default {
       currentStep: 'contactgegevens',
       appointmentData: {
         producten: {
-          products: [{productId: '166a5c79', amount: 1}],
+          products: [
+            {productId: '166a5c79', amount: 1},
+            {productId: 'e8e045ab', amount: 2},
+          ],
         },
         kalender: {
           location: '1396f17c',
@@ -32,7 +39,11 @@ export default {
       } satisfies Partial<AppointmentDataByStep>,
     },
     msw: {
-      handlers: [mockAppointmentCustomerFieldsGet],
+      handlers: [
+        mockAppointmentCustomerFieldsGet,
+        mockAppointmentProductsGet,
+        mockAppointmentLocationsGet,
+      ],
     },
   },
 } satisfies Meta<typeof ContactDetailsStep>;

--- a/src/components/appointments/steps/ContactDetailsStep.tsx
+++ b/src/components/appointments/steps/ContactDetailsStep.tsx
@@ -15,6 +15,8 @@ import useTitle from '@/hooks/useTitle';
 
 import {useCreateAppointmentContext} from '../CreateAppointment/CreateAppointmentState';
 import SubmitRow from '../SubmitRow';
+import {LocationAndDateTimeSummary} from '../summary/LocationAndDatetimeSummary';
+import {ProductSummary} from '../summary/ProductSummary';
 
 const CACHED_CONTACT_DETAILS_FIELDS_KEY = 'appointments|contactDetailsFields';
 const CACHED_CONTACT_DETAILS_FIELDS_MAX_AGE_MS = 15 * 60 * 1000; // 15 minutes
@@ -65,6 +67,9 @@ const ContactDetailsStep: React.FC<ContactDetailsStepProps> = ({navigateTo = ''}
   const products = appointmentData?.products || [];
   const productIds = products.map(p => p.productId).sort();
 
+  const locationIdentifier = appointmentData?.location || '';
+  const appointmentDatetime = appointmentData?.datetime || '';
+
   const {
     loading,
     value: components = [],
@@ -95,35 +100,45 @@ const ContactDetailsStep: React.FC<ContactDetailsStepProps> = ({navigateTo = ''}
 
       {loading && <Loader modifiers={['centered']} />}
       {!loading && (
-        <FormioForm
-          components={components}
-          values={stepData?.contactDetails}
-          // @ts-expect-error the Errors type in our renderer needs to support undefined
-          errors={initialErrors?.contactDetails}
-          onSubmit={async values => {
-            flushSync(() => {
-              clearStepErrors();
-              submitStep({contactDetails: values});
-            });
-            if (navigateTo) navigate(navigateTo);
-          }}
-          requiredFieldsWithAsterisk={requiredFieldsWithAsterisk}
-        >
-          {/* TODO: ensure we can pass an ID for the submit button so that we don't
-          need to rely on children anymore to submit the form */}
-          <SubmitRow
-            canSubmit={!loading}
-            nextText={intl.formatMessage({
-              description: 'Appointments contact details step: next step text',
-              defaultMessage: 'To overview',
-            })}
-            previousText={intl.formatMessage({
-              description: 'Appointments contact details step: previous step text',
-              defaultMessage: 'Back to location and time',
-            })}
-            navigateBackTo="kalender"
+        <>
+          {/* previous steps summary */}
+          <ProductSummary products={products} />
+          <LocationAndDateTimeSummary
+            products={products}
+            selectedLocationIdentifier={locationIdentifier}
+            selectedLocationDatetime={appointmentDatetime}
           />
-        </FormioForm>
+
+          <FormioForm
+            components={components}
+            values={stepData?.contactDetails}
+            // @ts-expect-error the Errors type in our renderer needs to support undefined
+            errors={initialErrors?.contactDetails}
+            onSubmit={async values => {
+              flushSync(() => {
+                clearStepErrors();
+                submitStep({contactDetails: values});
+              });
+              if (navigateTo) navigate(navigateTo);
+            }}
+            requiredFieldsWithAsterisk={requiredFieldsWithAsterisk}
+          >
+            {/* TODO: ensure we can pass an ID for the submit button so that we don't
+          need to rely on children anymore to submit the form */}
+            <SubmitRow
+              canSubmit={!loading}
+              nextText={intl.formatMessage({
+                description: 'Appointments contact details step: next step text',
+                defaultMessage: 'To overview',
+              })}
+              previousText={intl.formatMessage({
+                description: 'Appointments contact details step: previous step text',
+                defaultMessage: 'Back to location and time',
+              })}
+              navigateBackTo="kalender"
+            />
+          </FormioForm>
+        </>
       )}
     </>
   );

--- a/src/components/appointments/steps/LocationAndTimeStep.spec.tsx
+++ b/src/components/appointments/steps/LocationAndTimeStep.spec.tsx
@@ -89,7 +89,7 @@ describe('The location and time step', () => {
     });
     // No location should be selected, as there are multiple options
     await waitFor(() => {
-      expect(screen.queryByText('Open Gem')).not.toBeInTheDocument();
+      expect(screen.queryByText('Open Gem (Amsterdam)')).not.toBeInTheDocument();
     });
     expect(screen.queryByText('Bahamas (Winsome Dr, 1014 EG, Nassau)')).not.toBeInTheDocument();
 
@@ -165,7 +165,7 @@ describe('The location and time step', () => {
       datetime: '',
     });
 
-    expect(await screen.findByText('Open Gem')).toBeVisible();
+    expect(await screen.findByText('Open Gem (Amsterdam)')).toBeVisible();
     await waitFor(() => {
       expect(screen.getByLabelText('Date')).not.toBeDisabled();
     });

--- a/src/components/appointments/steps/LocationAndTimeStep.stories.tsx
+++ b/src/components/appointments/steps/LocationAndTimeStep.stories.tsx
@@ -109,7 +109,7 @@ export const DependentFieldsReset: Story = {
       const dropdown = canvas.getByLabelText('Locatie');
       await userEvent.click(dropdown);
       await userEvent.keyboard('[ArrowDown]');
-      await userEvent.click(await canvas.findByText('Open Gem'));
+      await userEvent.click(await canvas.findByText('Open Gem (Amsterdam)'));
     });
 
     expect(canvas.getByLabelText('Datum')).toHaveDisplayValue('');

--- a/src/components/appointments/steps/LocationAndTimeStep.tsx
+++ b/src/components/appointments/steps/LocationAndTimeStep.tsx
@@ -1,23 +1,18 @@
-import {Heading3, UnorderedList, UnorderedListItem} from '@utrecht/component-library-react';
 import {Form, Formik, useFormikContext} from 'formik';
-import {useContext} from 'react';
 import {flushSync} from 'react-dom';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {Navigate, useNavigate} from 'react-router';
-import {useAsync, useUpdateEffect} from 'react-use';
+import {useUpdateEffect} from 'react-use';
 import {z} from 'zod';
 import {toFormikValidationSchema} from 'zod-formik-adapter';
 
-import {ConfigContext} from '@/Context';
 import {CardTitle} from '@/components/Card';
-import Loader from '@/components/Loader';
-import type {AppointmentProduct} from '@/data/appointments';
 import useTitle from '@/hooks/useTitle';
 
 import {useCreateAppointmentContext} from '../CreateAppointment/CreateAppointmentState';
 import SubmitRow from '../SubmitRow';
 import {DateSelect, LocationSelect, TimeSelect} from '../fields';
-import {getAllProducts} from '../fields/ProductSelect';
+import {ProductSummary} from '../summary/ProductSummary';
 
 export interface LocationAndTimeStepValues {
   location: string;
@@ -139,51 +134,6 @@ const LocationAndTimeStep: React.FC<LocationAndTimeStepProps> = ({navigateTo = '
         }}
         component={LocationAndTimeStepFields}
       />
-    </>
-  );
-};
-
-export interface ProductSummaryProps {
-  products: AppointmentProduct[];
-}
-
-const ProductSummary: React.FC<ProductSummaryProps> = ({products}) => {
-  const {baseUrl} = useContext(ConfigContext);
-  const {
-    loading,
-    value: allProducts = [],
-    error,
-  } = useAsync(async () => await getAllProducts(baseUrl), [baseUrl]);
-
-  if (!products.length) return null;
-  if (error) throw error;
-  if (loading) {
-    return <Loader modifiers={['small']} />;
-  }
-
-  const productsById = Object.fromEntries(allProducts.map(p => [p.identifier, p.name]));
-  return (
-    <>
-      <Heading3 className="utrecht-heading-3--distanced">
-        <FormattedMessage
-          description="Product summary on appointments location and time step heading"
-          defaultMessage="Your products"
-        />
-      </Heading3>
-      <UnorderedList className="utrecht-unordered-list--distanced">
-        {products.map(({productId, amount}, index) => (
-          <UnorderedListItem key={`${productId}-${index}`}>
-            <FormattedMessage
-              description="Product summary on appointments location and time step"
-              defaultMessage="{name}: {amount}x"
-              values={{
-                amount,
-                name: productsById[productId],
-              }}
-            />
-          </UnorderedListItem>
-        ))}
-      </UnorderedList>
     </>
   );
 };

--- a/src/components/appointments/summary/LocationAndDatetimeSummary.tsx
+++ b/src/components/appointments/summary/LocationAndDatetimeSummary.tsx
@@ -1,0 +1,69 @@
+import {Heading3, UnorderedList, UnorderedListItem} from '@utrecht/component-library-react';
+import {useContext} from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+import {useAsync} from 'react-use';
+
+import {ConfigContext} from '@/Context';
+import Loader from '@/components/Loader';
+import type {AppointmentProduct} from '@/data/appointments';
+
+import {getLocations} from '../fields/LocationSelect';
+
+export interface LocationAndDateTimeSummaryProps {
+  products: AppointmentProduct[];
+  selectedLocationIdentifier: string;
+  selectedLocationDatetime: string;
+}
+
+export const LocationAndDateTimeSummary: React.FC<LocationAndDateTimeSummaryProps> = ({
+  products,
+  selectedLocationIdentifier,
+  selectedLocationDatetime,
+}) => {
+  const intl = useIntl();
+  const {baseUrl} = useContext(ConfigContext);
+  const productIds = products.map(prod => prod.productId).sort(); // sort to get a stable identity
+  const {
+    loading,
+    value: allLocations = [],
+    error,
+  } = useAsync(async () => await getLocations(baseUrl, productIds));
+
+  if (!products.length) return null;
+  if (error) throw error;
+  if (loading) {
+    return <Loader modifiers={['small']} />;
+  }
+
+  const selectedLocation = allLocations.find(l => l.identifier === selectedLocationIdentifier);
+
+  return (
+    <>
+      <Heading3 className="utrecht-heading-3--distanced">
+        <FormattedMessage
+          description="Location summary on appointments contact details step heading"
+          defaultMessage="Your appointment"
+        />
+      </Heading3>
+
+      {/* A list is not really needed here but we keep it consistent with the products */}
+      <UnorderedList className="utrecht-unordered-list--distanced">
+        <UnorderedListItem key={selectedLocationIdentifier}>
+          {[
+            selectedLocation?.name,
+            selectedLocation?.city,
+            intl.formatDate(selectedLocationDatetime, {
+              year: 'numeric',
+              month: 'numeric',
+              day: 'numeric',
+              hour: 'numeric',
+              minute: 'numeric',
+            }),
+          ]
+            .filter(Boolean)
+            .join(', ')}
+        </UnorderedListItem>
+      </UnorderedList>
+    </>
+  );
+};

--- a/src/components/appointments/summary/ProductSummary.tsx
+++ b/src/components/appointments/summary/ProductSummary.tsx
@@ -1,0 +1,56 @@
+import {Heading3, UnorderedList, UnorderedListItem} from '@utrecht/component-library-react';
+import {useContext} from 'react';
+import {FormattedMessage} from 'react-intl';
+import {useAsync} from 'react-use';
+
+import {ConfigContext} from '@/Context';
+import Loader from '@/components/Loader';
+import type {AppointmentProduct} from '@/data/appointments';
+
+import {getAllProducts} from '../fields/ProductSelect';
+
+export interface ProductSummaryProps {
+  products: AppointmentProduct[];
+}
+
+export const ProductSummary: React.FC<ProductSummaryProps> = ({products}) => {
+  const {baseUrl} = useContext(ConfigContext);
+  const {
+    loading,
+    value: allProducts = [],
+    error,
+  } = useAsync(async () => await getAllProducts(baseUrl), [baseUrl]);
+
+  if (!products.length) return null;
+  if (error) throw error;
+  if (loading) {
+    return <Loader modifiers={['small']} />;
+  }
+
+  const productsById = Object.fromEntries(allProducts.map(p => [p.identifier, p.name]));
+
+  return (
+    <>
+      <Heading3 className="utrecht-heading-3--distanced">
+        <FormattedMessage
+          description="Product summary on appointments contact details step heading"
+          defaultMessage="Your products"
+        />
+      </Heading3>
+      <UnorderedList className="utrecht-unordered-list--distanced">
+        {products.map(({productId, amount}, index) => (
+          <UnorderedListItem key={`${productId}-${index}`}>
+            <FormattedMessage
+              description="Product summary on appointments contact details step"
+              defaultMessage="{name}: {amount}x"
+              values={{
+                amount,
+                name: productsById[productId],
+              }}
+            />
+          </UnorderedListItem>
+        ))}
+      </UnorderedList>
+    </>
+  );
+};

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -293,6 +293,12 @@
       "value": "Red smiley (negative)"
     }
   ],
+  "4DfOmj": [
+    {
+      "type": 0,
+      "value": "Your products"
+    }
+  ],
   "4IX8hk": [
     {
       "type": 0,
@@ -395,24 +401,6 @@
     {
       "type": 0,
       "value": "Payment"
-    }
-  ],
-  "7Fk8NY": [
-    {
-      "type": 1,
-      "value": "name"
-    },
-    {
-      "type": 0,
-      "value": ": "
-    },
-    {
-      "type": 1,
-      "value": "amount"
-    },
-    {
-      "type": 0,
-      "value": "x"
     }
   ],
   "7kd6yw": [
@@ -709,6 +697,24 @@
     {
       "type": 0,
       "value": "Remove shapes"
+    }
+  ],
+  "BBWisr": [
+    {
+      "type": 1,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": ": "
+    },
+    {
+      "type": 1,
+      "value": "amount"
+    },
+    {
+      "type": 0,
+      "value": "x"
     }
   ],
   "BL1Ehr": [
@@ -2269,12 +2275,6 @@
       "value": "Your appointment has been cancelled"
     }
   ],
-  "jbireK": [
-    {
-      "type": 0,
-      "value": "Your products"
-    }
-  ],
   "jdzNwf": [
     {
       "type": 0,
@@ -3039,6 +3039,12 @@
     {
       "type": 0,
       "value": "Add partner details"
+    }
+  ],
+  "wl8Ucz": [
+    {
+      "type": 0,
+      "value": "Your appointment"
     }
   ],
   "wwsWUp": [

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -301,6 +301,12 @@
       "value": "Rode smiley (negatief)"
     }
   ],
+  "4DfOmj": [
+    {
+      "type": 0,
+      "value": "Jouw product(en)"
+    }
+  ],
   "4IX8hk": [
     {
       "type": 0,
@@ -403,24 +409,6 @@
     {
       "type": 0,
       "value": "Betalen"
-    }
-  ],
-  "7Fk8NY": [
-    {
-      "type": 1,
-      "value": "name"
-    },
-    {
-      "type": 0,
-      "value": ": "
-    },
-    {
-      "type": 1,
-      "value": "amount"
-    },
-    {
-      "type": 0,
-      "value": "x"
     }
   ],
   "7kd6yw": [
@@ -717,6 +705,24 @@
     {
       "type": 0,
       "value": "Verwijder vormen"
+    }
+  ],
+  "BBWisr": [
+    {
+      "type": 1,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": ": "
+    },
+    {
+      "type": 1,
+      "value": "amount"
+    },
+    {
+      "type": 0,
+      "value": "x"
     }
   ],
   "BL1Ehr": [
@@ -1930,7 +1936,7 @@
   "ay8sO5": [
     {
       "type": 0,
-      "value": "Je gegevens"
+      "value": "Contactgegevens"
     }
   ],
   "bKPaUj": [
@@ -2227,12 +2233,6 @@
     {
       "type": 0,
       "value": "Je afspraak is geannuleerd"
-    }
-  ],
-  "jbireK": [
-    {
-      "type": 0,
-      "value": "Jouw producten"
     }
   ],
   "jdzNwf": [
@@ -3003,6 +3003,12 @@
     {
       "type": 0,
       "value": "Partner toevoegen"
+    }
+  ],
+  "wl8Ucz": [
+    {
+      "type": 0,
+      "value": "Jouw afspraak"
     }
   ],
   "wwsWUp": [

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -84,6 +84,11 @@
     "description": "GovMetric red face alt text",
     "originalDefault": "Red smiley (negative)"
   },
+  "4DfOmj": {
+    "defaultMessage": "Your products",
+    "description": "Product summary on appointments contact details step heading",
+    "originalDefault": "Your products"
+  },
   "4ZOmtU": {
     "defaultMessage": "Save changes",
     "description": "Edit toolbar save tooltip.",
@@ -148,11 +153,6 @@
     "defaultMessage": "Payment",
     "description": "On succesful completion title but payment required",
     "originalDefault": "Betalen"
-  },
-  "7Fk8NY": {
-    "defaultMessage": "{name}: {amount}x",
-    "description": "Product summary on appointments location and time step",
-    "originalDefault": "{name}: {amount}x"
   },
   "7kd6yw": {
     "defaultMessage": "This form is currently in maintenance mode. As a staff user, you can continue filling out the form as usual.",
@@ -268,6 +268,11 @@
     "defaultMessage": "Remove shapes",
     "description": "Edit toolbar remove button tooltip.",
     "originalDefault": "Remove shapes"
+  },
+  "BBWisr": {
+    "defaultMessage": "{name}: {amount}x",
+    "description": "Product summary on appointments contact details step",
+    "originalDefault": "{name}: {amount}x"
   },
   "BL1Ehr": {
     "defaultMessage": "Invalid.",
@@ -959,11 +964,6 @@
     "description": "Appointment cancellated body",
     "originalDefault": "Your appointment has been cancelled"
   },
-  "jbireK": {
-    "defaultMessage": "Your products",
-    "description": "Product summary on appointments location and time step heading",
-    "originalDefault": "Your products"
-  },
   "jdzNwf": {
     "defaultMessage": "Current step in form {formName}: {activeStepTitle}",
     "description": "Active step accessible label in mobile progress indicator",
@@ -1213,6 +1213,11 @@
     "defaultMessage": "Click first point to finish shape",
     "description": "Draw handler polygon tooltip end.",
     "originalDefault": "Click first point to finish shape"
+  },
+  "wl8Ucz": {
+    "defaultMessage": "Your appointment",
+    "description": "Location summary on appointments contact details step heading",
+    "originalDefault": "Your appointment"
   },
   "wwsWUp": {
     "defaultMessage": "How do you rate this form?",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -85,6 +85,11 @@
     "description": "GovMetric red face alt text",
     "originalDefault": "Red smiley (negative)"
   },
+  "4DfOmj": {
+    "defaultMessage": "Jouw product(en)",
+    "description": "Product summary on appointments contact details step heading",
+    "originalDefault": "Your products"
+  },
   "4ZOmtU": {
     "defaultMessage": "Wijzigingen opslaan",
     "description": "Edit toolbar save tooltip.",
@@ -150,12 +155,6 @@
     "description": "On succesful completion title but payment required",
     "isTranslated": true,
     "originalDefault": "Betalen"
-  },
-  "7Fk8NY": {
-    "defaultMessage": "{name}: {amount}x",
-    "description": "Product summary on appointments location and time step",
-    "isTranslated": true,
-    "originalDefault": "{name}: {amount}x"
   },
   "7kd6yw": {
     "defaultMessage": "Dit formulier is momenteel in onderhoud. Als medewerker kun je dit formulier wel invullen.",
@@ -271,6 +270,11 @@
     "defaultMessage": "Verwijder vormen",
     "description": "Edit toolbar remove button tooltip.",
     "originalDefault": "Remove shapes"
+  },
+  "BBWisr": {
+    "defaultMessage": "{name}: {amount}x",
+    "description": "Product summary on appointments contact details step",
+    "originalDefault": "{name}: {amount}x"
   },
   "BL1Ehr": {
     "defaultMessage": "Ongeldig.",
@@ -798,7 +802,7 @@
     "originalDefault": "No"
   },
   "ay8sO5": {
-    "defaultMessage": "Je gegevens",
+    "defaultMessage": "Contactgegevens",
     "description": "Appointments: contact details step title",
     "originalDefault": "Contact details"
   },
@@ -966,11 +970,6 @@
     "defaultMessage": "Je afspraak is geannuleerd",
     "description": "Appointment cancellated body",
     "originalDefault": "Your appointment has been cancelled"
-  },
-  "jbireK": {
-    "defaultMessage": "Jouw producten",
-    "description": "Product summary on appointments location and time step heading",
-    "originalDefault": "Your products"
   },
   "jdzNwf": {
     "defaultMessage": "Huidige stap in formulier {formName}: {activeStepTitle}",
@@ -1225,6 +1224,11 @@
     "defaultMessage": "Klik op het eerste punt, om de veelhoek te voltooien",
     "description": "Draw handler polygon tooltip end.",
     "originalDefault": "Click first point to finish shape"
+  },
+  "wl8Ucz": {
+    "defaultMessage": "Jouw afspraak",
+    "description": "Location summary on appointments contact details step heading",
+    "originalDefault": "Your appointment"
   },
   "wwsWUp": {
     "defaultMessage": "Wat vind je van dit formulier?",


### PR DESCRIPTION
Closes open-formulieren/open-forms#5695 partly
(this covers only the first two tasks, see the ticket for more information)

- The selected products, location and datetime from the previous steps are added as extra information (summary) to the contact details step.