### PR TITLE
Fix remove buttons being shown despite `disableAddingRemovingRows` being set to `true`

### DIFF
--- a/src/formio/components/EditGrid.stories.jsx
+++ b/src/formio/components/EditGrid.stories.jsx
@@ -118,6 +118,25 @@ export const WithData = {
   },
 };
 
+export const DisableAddingRemovingRows = {
+  render,
+  args: {
+    key: 'editgrid',
+    label: "Auto's",
+    groupLabel: 'Auto',
+    extraComponentProperties: {
+      disableAddingRemovingRows: true,
+      components: defaultNested,
+    },
+    data: [
+      {
+        kleur: 'Red',
+        bedrag: '15000000',
+      },
+    ],
+  },
+};
+
 export const AddressNLWithData = {
   render: SingleFormioComponent,
   parameters: {

--- a/src/formio/templates/editGrid.ejs
+++ b/src/formio/templates/editGrid.ejs
@@ -24,7 +24,7 @@
                 {{ctx.t(ctx.component.saveRow || 'Save', { _userInput: true })}}
               </button>
 
-              {% if (ctx.component.removeRow) { %}
+              {% if (ctx.component.removeRow && !ctx.component.disableAddingRemovingRows) { %}
                 <button class="utrecht-button utrecht-button--primary-action utrecht-button--danger" ref="{{ctx.ref.cancelRow}}">
                   {{ctx.t(ctx.component.removeRow || 'Cancel', { _userInput: true })}}
                 </button>

--- a/src/formio/templates/editGridRow.ejs
+++ b/src/formio/templates/editGridRow.ejs
@@ -16,8 +16,10 @@
     <button class="utrecht-button utrecht-button--secondary-action editRow">
       <i class="{{ ctx.iconClass('edit') }}"></i>
     </button>
+    {% if (!ctx.component.disableAddingRemovingRows) { %}
     <button class="utrecht-button utrecht-button--primary-action utrecht-button--danger removeRow">
       <i class="{{ ctx.iconClass('trash-can') }}"></i>
     </button>
+    {% } %}
   </p>
 {% } %}


### PR DESCRIPTION
Closes open-formulieren/open-forms#5728