### PR TITLE
[OF#5548] Update add-button to secondary action

### DIFF
--- a/src/formio/components/Children/ChildrenForm.tsx
+++ b/src/formio/components/Children/ChildrenForm.tsx
@@ -52,7 +52,7 @@ export const ChildrenComponent: React.FC<ChildrenComponentProps> = ({
       toggleChildSelection={toggleChildSelection}
     />
     {enableCreation && (
-      <OFButton onClick={onAddChild} variant="primary" appearance="primary-action-button">
+      <OFButton onClick={onAddChild} variant="secondary" appearance="primary-action-button">
         <FormattedMessage
           description="Add child: add child button text"
           defaultMessage="Add Child"

--- a/src/formio/components/Partners/PartnersForm.tsx
+++ b/src/formio/components/Partners/PartnersForm.tsx
@@ -31,7 +31,7 @@ export const PartnersComponent: React.FC<PartnersComponentProps> = ({
   <>
     <DisplayPartners partners={partners} />
     {hasNoPartners && (
-      <OFButton onClick={onAddPartner} variant="primary" appearance="primary-action-button">
+      <OFButton onClick={onAddPartner} variant="secondary" appearance="primary-action-button">
         <FormattedMessage
           description="Add partner: add partner button text"
           defaultMessage="Add partner"
@@ -39,7 +39,7 @@ export const PartnersComponent: React.FC<PartnersComponentProps> = ({
       </OFButton>
     )}
     {!hasNoPartners && manuallyAddedPartner && (
-      <OFButton onClick={onEditPartner} variant="primary" appearance="primary-action-button">
+      <OFButton onClick={onEditPartner} variant="secondary" appearance="primary-action-button">
         <FormattedMessage
           description="Edit partner: edit partner button text"
           defaultMessage="Edit partner"

--- a/src/formio/templates/editGrid.ejs
+++ b/src/formio/templates/editGrid.ejs
@@ -46,7 +46,7 @@
 
   {% if (!ctx.readOnly && ctx.hasAddButton) { %}
     <p class="utrecht-button-group">
-      <button class="utrecht-button utrecht-button--primary-action" ref="{{ctx.ref.addRow}}">
+      <button class="utrecht-button utrecht-button--secondary-action" ref="{{ctx.ref.addRow}}">
         <i class="{{ctx.iconClass('plus')}}"></i>
         {{ctx.t(ctx.component.addAnother || 'Add Another', { _userInput: true })}}
       </button>

--- a/src/formio/templates/multiValueTable.ejs
+++ b/src/formio/templates/multiValueTable.ejs
@@ -4,7 +4,7 @@
   {% if (!ctx.disabled) {%}
     <tr>
       <td colspan="2">
-        <button class="utrecht-button utrecht-button--primary-action" ref="addButton">
+        <button class="utrecht-button utrecht-button--secondary-action" ref="addButton">
           <i class="{{ctx.iconClass('plus')}}"></i>
           <div class="{{ctx.ofPrefix}}multi-value-table__button-label">{{ctx.t(ctx.addAnother, {_userInput: true})}}</div>
         </button>


### PR DESCRIPTION
Close open-formulieren/open-forms#5548 partly

This PR handles only the following in the SDK. Some other changes are needed in the new formio renderer (for example in the edit grid component, which is used in the appointments). Discussed the email verification and concluded that the button will stay as is because the secondary would make it hard to find in some themes.

- EditGrid
- Partners
- Children
- Formio's multiple True