### PR TITLE
:green_heart: Fix CI

### DIFF
--- a/src/components/appointments/CreateAppointment/CreateAppointment.stories.tsx
+++ b/src/components/appointments/CreateAppointment/CreateAppointment.stories.tsx
@@ -169,9 +169,7 @@ export const HappyFlow: Story = {
     });
 
     await step('Fill out the contact details', async () => {
-      const tomorrow = format(addDays(new Date(), 1), 'P', {
-        locale: calendarLocale,
-      });
+      const tomorrow = format(addDays(new Date(), 1), 'd-M-yyyy', {locale: calendarLocale});
 
       await waitFor(async () => {
         expect(await canvas.findAllByText('Contactgegevens')).toHaveLength(2);


### PR DESCRIPTION
Using the 'P' format string will add leading zeroes to the day and month, which `useIntl().formatDate` from 
react-intl does not do, so we just hardcode the format for Dutch locale here.

This worked previously because it was merged on the 30th of October, which does not contain leading
zeroes :upside_down_face: