### PR TITLE
Wire up `fetchDigitalAddresses` API and portalUrl

### DIFF
--- a/src/Context.ts
+++ b/src/Context.ts
@@ -44,6 +44,7 @@ const FormContext = React.createContext<Form>({
     supportsMultipleProducts: null,
   },
   newRendererEnabled: false,
+  communicationPreferencesPortalUrl: '',
 });
 FormContext.displayName = 'FormContext';
 

--- a/src/api-mocks/forms.ts
+++ b/src/api-mocks/forms.ts
@@ -59,6 +59,7 @@ export const FORM_DEFAULTS = {
   paymentRequired: false,
   submissionReportDownloadLinkTitle: '',
   newRendererEnabled: false,
+  communicationPreferencesPortalUrl: '',
 } satisfies Form;
 
 /**

--- a/src/components/FormStep/hooks.ts
+++ b/src/components/FormStep/hooks.ts
@@ -15,6 +15,7 @@ import {get} from '@/api';
 import {getCosignStatus as getCosignStatus_} from '@/components/CoSign';
 import {getLoginUrl} from '@/components/LoginOptions/utils';
 import {assertSubmission, useSubmissionContext} from '@/components/SubmissionProvider';
+import {fetchCommunicationPreferences} from '@/data/customer-profile';
 import {createTemporaryFileUpload, destroyTemporaryFileUpload} from '@/data/file-uploads';
 import type {Form, MinimalFormStep} from '@/data/forms';
 import {autoCompleteAddress} from '@/data/geo';
@@ -191,6 +192,13 @@ export const useFormioFormConfigurationParameters = (): Pick<
     [form, submissionId]
   );
 
+  const fetchDigitalAddresses = useCallback(
+    async (componentKey: string): ReturnType<typeof fetchCommunicationPreferences> => {
+      return await fetchCommunicationPreferences(baseUrl, submissionId, componentKey);
+    },
+    [baseUrl, submissionId]
+  );
+
   const upload = useCallback(
     async (file: File): ReturnType<typeof createTemporaryFileUpload> => {
       return await createTemporaryFileUpload(baseUrl, submission, file);
@@ -216,6 +224,10 @@ export const useFormioFormConfigurationParameters = (): Pick<
     componentParameters: {
       addressNL: {addressAutoComplete},
       coSign: {getCosignStatus, getLoginOption},
+      customerProfile: {
+        fetchDigitalAddresses,
+        portalUrl: form.communicationPreferencesPortalUrl,
+      },
       email: {requestVerificationCode, verifyCode},
       file: {
         upload,

--- a/src/data/customer-profile.ts
+++ b/src/data/customer-profile.ts
@@ -1,0 +1,28 @@
+import type {DigitalAddressType} from '@open-formulieren/types';
+
+import {get} from '@/api';
+import {logError} from '@/components/Errors';
+
+export interface DigitalAddressGroup {
+  type: DigitalAddressType;
+  addresses: string[];
+  preferred?: string;
+}
+
+type FetchCommunicationPreferencesResult = DigitalAddressGroup[];
+
+export const fetchCommunicationPreferences = async (
+  baseUrl: string,
+  submissionId: string,
+  componentKey: string
+): Promise<FetchCommunicationPreferencesResult | null> => {
+  try {
+    const result = await get<FetchCommunicationPreferencesResult>(
+      `${baseUrl}prefill/plugins/customer-interactions/communication-preferences/${submissionId}/component/${componentKey}`
+    );
+    return result!;
+  } catch (error) {
+    logError(error);
+    return null;
+  }
+};

--- a/src/data/forms.ts
+++ b/src/data/forms.ts
@@ -92,4 +92,5 @@ export interface Form {
   submissionStatementsConfiguration: SubmissionStatementConfiguration[];
   submissionReportDownloadLinkTitle: string;
   newRendererEnabled: boolean;
+  communicationPreferencesPortalUrl: string;
 }


### PR DESCRIPTION
Partly closes open-formulieren/formio-renderer#178

Added component parameters for customerProfile component. The `fetchDigitalAddresses` allows fetching of the digital addresses of the authenticated user. The `portalUrl` is used to direct users to the online customer interactions portal, were they can update their user information.