### PR TITLE
Ensure frontend logic is executed upon step loading when possible

### DIFF
--- a/src/api-mocks/submissions.ts
+++ b/src/api-mocks/submissions.ts
@@ -2,6 +2,7 @@ import type {AnyComponentSchema, JSONObject} from '@open-formulieren/types';
 import {HttpResponse, http} from 'msw';
 
 import type {FormioConfiguration} from '@/data/formio';
+import type {LogicRule} from '@/data/logic';
 import type {SubmissionStep} from '@/data/submission-steps';
 import type {Submission} from '@/data/submissions';
 import type {InvalidParam} from '@/errors';
@@ -94,6 +95,9 @@ interface BuildSubmissionStepOpts {
   components?: AnyComponentSchema[];
   data?: JSONObject | null;
   canSubmit?: boolean;
+  formStepUuid?: string;
+  requireBackendLogicEvaluation?: boolean;
+  logicRules?: LogicRule[];
 }
 
 /**
@@ -103,17 +107,20 @@ export const buildSubmissionStep = ({
   components = SUBMISSION_STEP_DETAILS.configuration.components,
   data = null,
   canSubmit = true,
+  formStepUuid = 'f31e0bbb-0ad9-4dde-bb2c-9360c606f980',
+  requireBackendLogicEvaluation = true,
+  logicRules = [],
 }: BuildSubmissionStepOpts): SubmissionStep => {
   const formioConfiguration: FormioConfiguration = {type: 'form', components};
   return {
     id: '6ca342af-86c7-451c-a19f-65050b2eee5c',
     slug: 'step-1',
-    formStepUuid: 'f31e0bbb-0ad9-4dde-bb2c-9360c606f980',
+    formStepUuid,
     configuration: formioConfiguration,
-    defaultConfiguration: null,
-    requireBackendLogicEvaluation: true,
-    logicRules: [],
-    data: data,
+    defaultConfiguration: requireBackendLogicEvaluation ? null : formioConfiguration,
+    requireBackendLogicEvaluation,
+    logicRules,
+    data,
     canSubmit,
   } satisfies SubmissionStep;
 };

--- a/src/components/FormStep/FormStepNewRenderer.stories.tsx
+++ b/src/components/FormStep/FormStepNewRenderer.stories.tsx
@@ -264,6 +264,85 @@ export const DisableStepSubmissionWithServerLogic: Story = {
   },
 };
 
+const FRONTEND_LOGIC_STEP_DETAIL_BODY = buildSubmissionStep({
+  formStepUuid: '9e6eb3c5-e5a4-4abf-b64a-73d3243f2bf5',
+  components: [
+    {
+      id: 'checkbox',
+      type: 'checkbox',
+      key: 'checkbox',
+      label: 'Checkbox',
+      defaultValue: true,
+    },
+  ],
+  requireBackendLogicEvaluation: false,
+  logicRules: [
+    {
+      jsonLogicTrigger: {'==': [{var: 'checkbox'}, true]},
+      actions: [
+        {formStepUuid: '9e6eb3c5-e5a4-4abf-b64a-73d3243f2bf5', action: {type: 'disable-next'}},
+      ],
+    },
+  ],
+  canSubmit: true,
+  data: {},
+});
+
+export const DisableStepSubmissionWithFrontendLogic: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        submissionStep: [
+          mockSubmissionStepGet(FRONTEND_LOGIC_STEP_DETAIL_BODY),
+          mockSubmissionStepPut(FRONTEND_LOGIC_STEP_DETAIL_BODY, 201),
+        ],
+        logicCheck: [
+          // @ts-expect-error Return nonsense data on purpose, to make sure a crash will occur if
+          // a backend logic check was scheduled anyway.
+          mockSubmissionCheckLogicPost('nonsense', 'data'),
+        ],
+      },
+    },
+    formContext: {
+      form: buildForm({
+        newLogicEvaluationEnabled: true,
+        steps: [
+          {
+            uuid: '9e6eb3c5-e5a4-4abf-b64a-73d3243f2bf5',
+            slug: 'step-1',
+            formDefinition: 'Step 1',
+            index: 0,
+            literals: {
+              previousText: {resolved: 'Previous', value: ''},
+              saveText: {resolved: 'Save', value: ''},
+              nextText: {resolved: 'Next', value: ''},
+            },
+            url: `${BASE_URL}forms/mock/steps/9e6eb3c5-e5a4-4abf-b64a-73d3243f2bf5`,
+          },
+        ],
+      }),
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    // Initial state of the checkbox must be checked.
+    const checkbox = await canvas.findByLabelText('Checkbox');
+    expect(checkbox).toBeChecked();
+
+    // This ensures (frontend) logic was invoked upon loading the step, because a step can be
+    // submitted by default, but the is checked by default causing the rule to be triggered.
+    const nextButton = await canvas.findByRole('button', {name: 'Next'});
+    waitFor(() => {
+      expect(nextButton).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    // Unchecking the checkbox should allow step submission again.
+    await userEvent.click(checkbox);
+    expect(nextButton).toHaveAttribute('aria-disabled', 'false');
+  },
+};
+
 export const NextButtonDisabledInitially: Story = {
   parameters: {
     msw: {

--- a/src/components/FormStep/FormStepNewRenderer.tsx
+++ b/src/components/FormStep/FormStepNewRenderer.tsx
@@ -121,13 +121,6 @@ const FormStepNewRenderer: React.FC = () => {
   if (state.error) throw state.error;
   const step = state.value;
 
-  // Schedule logic check when step is loaded
-  useEffect(() => {
-    if (step === undefined) return;
-    scheduleLogicCheck();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [step]);
-
   const isLoading = state.loading || navigationState !== 'idle';
 
   // check our current position in the form
@@ -145,6 +138,24 @@ const FormStepNewRenderer: React.FC = () => {
   const rules = step?.logicRules ?? [];
   const requireBackendEvaluation =
     !form.newLogicEvaluationEnabled || (step?.requireBackendLogicEvaluation ?? true);
+
+  // Schedule logic check when step is loaded
+  useEffect(() => {
+    if (step === undefined) return;
+    if (requireBackendEvaluation) {
+      scheduleLogicCheck();
+    } else {
+      evaluateBackendRules({
+        submission,
+        step: step,
+        rules,
+        inputData: valuesRef.current ?? {},
+        components: step.defaultConfiguration?.components ?? [],
+        onLogicCheckResult,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step]);
 
   return (
     <LiteralsProvider literals={formStep.literals}>

--- a/src/components/FormStep/logic.ts
+++ b/src/components/FormStep/logic.ts
@@ -115,21 +115,8 @@ export const evaluateBackendRules = ({
     }
   }
 
-  const {data: updatedData, errorsToClear, disableNext, stepsApplicableUpdates} = evaluationState;
+  const {errorsToClear, disableNext, stepsApplicableUpdates} = evaluationState;
   const canSubmit = !disableNext;
-
-  const hasDataChanged = updatedData !== inputData;
-  const hasComponentConfigurationChanged = !isEqual(components, updatedComponents);
-  const hasStepsApplicableUpdates = Object.keys(stepsApplicableUpdates).length > 0;
-
-  if (
-    !hasDataChanged &&
-    !hasComponentConfigurationChanged &&
-    !errorsToClear.length &&
-    !canSubmit &&
-    !hasStepsApplicableUpdates
-  )
-    return;
 
   let updatedStep: SubmissionStep = setIn(step, 'configuration.components', updatedComponents);
   updatedStep = setIn(updatedStep, 'data', dataUpdates);


### PR DESCRIPTION
Closes open-formulieren/open-forms#5962, open-formulieren/open-forms#6099

Changes:
- Ensured frontend logic is executed upon step loading when possible
- Fixed bug where state of next button wasn't updated properly with frontend logic
- Added regression test (for both the bug and frontend logic execution)