### PR TITLE
Drop UMD bundle support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build Javascript
         run: |
           echo "Building version $VITE_VERSION"
-          VITE_VERSION=${VITE_VERSION} npm run build
+          npm run build
         env:
           VITE_VERSION: ${{ needs.setup.outputs.version }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,7 @@ RUN npm run build:design-tokens \
 # set up symlinks to mimick the old dist/ layout
 WORKDIR /app/dist
 RUN \
-  ln -s "./bundles/open-forms-sdk.js" "./open-forms-sdk.js" \
-  && ln -s "./bundles/open-forms-sdk.js.map" "./open-forms-sdk.js.map" \
-  && ln -s "./bundles/open-forms-sdk.mjs" "./open-forms-sdk.mjs" \
+  ln -s "./bundles/open-forms-sdk.mjs" "./open-forms-sdk.mjs" \
   && ln -s "./bundles/open-forms-sdk.mjs.map" "./open-forms-sdk.mjs.map" \
   && ln -s "./bundles/assets" "./assets" \
   && ln -s "./bundles/open-forms-sdk.css" "./open-forms-sdk.css" \

--- a/README.npm.md
+++ b/README.npm.md
@@ -21,7 +21,7 @@ and visual regression testing.
 The package exports two ways to use the library:
 
 1. Importing and composing the invididual modules (ESM, recommended)
-2. Importing the library as a whole (ESM or UMD bundle)
+2. Importing the library as a whole (ESM bundle)
 
 The former approach allows more fine-grained control and should exclude code/dependencies that
 aren't used and result in smaller builds, while the latter gives you the public API as it would be

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,6 @@
         "@maykinmedia/eslint-config": "^3.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
         "@open-formulieren/types": "^1.0.1",
-        "@rollup/plugin-replace": "^6.0.2",
         "@sentry/vite-plugin": "^4.6.0",
         "@storybook/addon-docs": "10.3.5",
         "@storybook/addon-links": "10.3.5",
@@ -3257,28 +3256,6 @@
       "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rollup/plugin-replace": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
-      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "magic-string": "^0.30.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "@open-formulieren/sdk",
   "version": "3.5.0",
   "private": true,
-  "main": "dist/open-forms-sdk.js",
+  "main": "dist/open-forms-sdk.mjs",
+  "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/bundles/open-forms-sdk.js",
+      "import": "./dist/bundles/open-forms-sdk.mjs",
       "types": "./dist/bundles/index.d.ts"
     },
     "./open-forms-sdk.mjs": "./dist/bundles/open-forms-sdk.mjs",
@@ -72,9 +73,8 @@
   },
   "scripts": {
     "start": "npm run build:design-tokens && vite",
-    "build": "npm run build:esm && npm run build:umd && npm run build:esm-bundle && python ./bin/extract_i18n_source_messages.py",
+    "build": "npm run build:esm && npm run build:esm-bundle && python ./bin/extract_i18n_source_messages.py",
     "build:typecheck": "tsc --noEmit",
-    "build:umd": "BUILD_TARGET=umd vite build",
     "build:esm": "BUILD_TARGET=esm vite build",
     "build:esm-bundle": "BUILD_TARGET=esm-bundle vite build",
     "test": "TZ=Europe/Amsterdam vitest --project=unit",
@@ -105,7 +105,6 @@
     "@maykinmedia/eslint-config": "^3.0.0",
     "@open-formulieren/monaco-json-editor": "^0.2.0",
     "@open-formulieren/types": "^1.0.1",
-    "@rollup/plugin-replace": "^6.0.2",
     "@sentry/vite-plugin": "^4.6.0",
     "@storybook/addon-docs": "10.3.5",
     "@storybook/addon-links": "10.3.5",

--- a/src/index.mdx
+++ b/src/index.mdx
@@ -218,9 +218,8 @@ This implies:
 The source code is built to multiple targets for different audiences:
 
 - ESM bundle with multiple modules, for optimized loading patterns when embedding.
-- UMD bundle with single JS/CSS files, for drop-in embedding and plain JS usage.
-- NPM package containing the UMD bundle **and** ES-modules of the main components.
+- NPM package containing ES-modules of the main components.
 - Storybook static build (you're reading this now!)
-- Docker image containing the ESM and UMD build for easy deployment, embedded in the backend build.
+- Docker image containing the ESM build for easy deployment, embedded in the backend build.
 
 [contributing]: https://github.com/open-formulieren/open-forms-sdk/blob/main/CONTRIBUTING.md

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,9 @@
 import {clsx} from 'clsx';
 import type {IntlShape} from 'react-intl';
 
-import {getEnv} from './env';
-
 export {DEBUG} from './env';
 
-const VERSION = getEnv('VERSION');
+const VERSION = import.meta.env.VITE_VERSION;
 
 export const PREFIX = 'openforms';
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference types="vitest/config" />
 import {codecovVitePlugin} from '@codecov/vite-plugin';
-import replace from '@rollup/plugin-replace';
 import {sentryVitePlugin} from '@sentry/vite-plugin';
 import {storybookTest} from '@storybook/addon-vitest/vitest-plugin';
 import react from '@vitejs/plugin-react';
@@ -24,42 +23,21 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace NodeJS {
     interface ProcessEnv {
-      BUILD_TARGET: 'umd' | 'esm' | 'esm-bundle' | undefined;
+      BUILD_TARGET: 'esm' | 'esm-bundle' | undefined;
     }
   }
 }
 
 const _OF_INTERNAL_dirname = dirname(fileURLToPath(import.meta.url));
 
-const buildTarget = process.env.BUILD_TARGET || 'umd';
-const buildTargetDefined = process.env.BUILD_TARGET !== undefined;
+const buildTarget = process.env.BUILD_TARGET || 'esm-bundle';
 
 const getOutput = (buildTarget: typeof process.env.BUILD_TARGET): OutputOptions => {
   switch (buildTarget) {
-    case 'esm-bundle': {
-      return {
-        dir: `dist/bundles/`,
-        format: 'esm',
-        preserveModules: false,
-        entryFileNames: 'open-forms-sdk.mjs',
-        assetFileNames: ({name}) => {
-          if (name === 'style.css') {
-            return 'open-forms-sdk.css';
-          }
-          return 'static/media/[name].[hash:8].[ext]';
-        },
-        inlineDynamicImports: false,
-      } satisfies OutputOptions;
-    }
     case 'esm': {
       /**
        * Rollup output options for ESM build, which is what we package in the NPM package
        * under the 'esm' subdirectory.
-       *
-       * The ESM package is experimental. Known issues:
-       * @fixme
-       *
-       * - the react-intl translations are not distributed yet (also broken in CRA/babel build!)
        */
       return {
         dir: 'dist/',
@@ -75,28 +53,21 @@ const getOutput = (buildTarget: typeof process.env.BUILD_TARGET): OutputOptions 
         },
       } satisfies OutputOptions;
     }
-    case 'umd':
+    // esm-bundle is the default, and it's what gets emitted into the docker image
+    case 'esm-bundle':
     default: {
-      /**
-       * Rollup output options for UMD bundle, included in the NPM package but
-       * the primary distribution mechanism is in a Docker image.
-       *
-       * @deprecated - it's better to use the ESM bundle which has separate chunks.
-       */
       return {
         dir: `dist/bundles/`,
-        format: 'umd',
-        exports: 'named',
-        name: 'OpenForms',
-        generatedCode: 'es2015',
-        entryFileNames: 'open-forms-sdk.js',
+        format: 'esm',
+        preserveModules: false,
+        entryFileNames: 'open-forms-sdk.mjs',
         assetFileNames: ({name}) => {
           if (name === 'style.css') {
             return 'open-forms-sdk.css';
           }
           return 'static/media/[name].[hash:8].[ext]';
         },
-        inlineDynamicImports: true,
+        inlineDynamicImports: false,
       } satisfies OutputOptions;
     }
   }
@@ -110,11 +81,11 @@ export default defineConfig(({mode}) => {
       port: 3000,
     },
     plugins: [
-      // BIG DISCLAIMER - Vite only processes files with the .jsx or .tsx extension with
+      // BIG DISCLAIMER - Vite only processes files with the .tsx extension with
       // babel, and changing this configuration is... cumbersome and comes with a performance
-      // penalty. This manifests if you're using react-intl in .js/.mjs/.ts files etc., as
+      // penalty. This manifests if you're using react-intl in .(m)ts files etc., as
       // they don't get transformed to inject the message ID. The solution is to rename the
-      // file extension to .jsx/.tsx
+      // file extension to .tsx
       react({babel: {babelrc: true}}),
       tsconfigPaths(),
       eslint({
@@ -134,22 +105,6 @@ export default defineConfig(({mode}) => {
             rollupTypes: true,
             outDir: `dist/bundles`,
           }),
-      /**
-       * Plugin to ignore (S)CSS when bundling to UMD bundle target, since we use the ESM
-       * bundle to generate these.
-       *
-       * @todo Remove this when we drop the UMD bundle entirely (in 4.0?)
-       */
-      {
-        name: 'ignore-styles-esm-bundle',
-        transform(code, id) {
-          if (!buildTargetDefined) return;
-          if (buildTarget === 'umd' && (id.endsWith('.css') || id.endsWith('scss'))) {
-            // skip processing
-            return {code: '', map: null};
-          }
-        },
-      },
       sentryVitePlugin({
         silent: mode === 'development',
         release: {
@@ -196,7 +151,7 @@ export default defineConfig(({mode}) => {
       emptyOutDir: buildTarget !== 'esm-bundle',
       rollupOptions: {
         input: 'src/sdk.tsx',
-        // do not externalize anything in UMD build - bundle everything
+        // do not externalize anything in bundle build - bundle everything
         external: buildTarget === 'esm' ? packageRegexes : undefined,
         output: getOutput(buildTarget),
         preserveEntrySignatures: 'strict',


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#6164

This removes the fat UMD bundle from our build pipeline and artifacts. It has been deprecated a while ago. We are now ESM-only, and offer a "source" build and bundle variant for inclusion in the backend.