### PR TITLE
Prepare release 3.4.3

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "3.4.2"
+current_version = "3.4.3"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,25 @@
 SDK Changelog
 =============
 
+3.4.3 (2026-04-28)
+==================
+
+Regular bugfix release.
+
+* Upgraded ``@open-formulieren/formio-renderer`` to 1.1.2 bugfix release, which fixes:
+
+  - [#6185] Fixed soft-required file component inside a conditionally visible editgrid
+    causing a form crash.
+  - [#6190] Fixed the anchor ``target`` attribute being stripped out by DOMPurify.
+  - [#6192] Fixed missing textfield ``autocomplete`` attribute support.
+  - [#6181] Fixed empty-ish comparison against file components not working as expected.
+  - [#6163] Fixed UX of date(time) validation not applying consistently.
+  - [#6125] Fixed a crash in ``addressNL`` when conditionally displaying it.
+
+* [#5944] Fixed checkbox input not being clickable on iOS 18.
+* Backported fix for test failure due to daylight savings time.
+* Fixed NPM tag derivation during package publishing.
+
 3.4.2 (2026-03-09)
 ==================
 

--- a/README.NL.rst
+++ b/README.NL.rst
@@ -2,7 +2,7 @@
 Open Formulieren SDK
 ====================
 
-:Version: 3.4.2
+:Version: 3.4.3
 :Source: https://github.com/open-formulieren/open-forms-sdk
 :Keywords: e-Formulieren, Common Ground, FormIO, API
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Open Forms SDK
 ==============
 
-:Version: 3.4.2
+:Version: 3.4.3
 :Source: https://github.com/open-formulieren/open-forms-sdk
 :Keywords: e-Formulieren, Common Ground, FormIO, API
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-formulieren/sdk",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-formulieren/sdk",
-      "version": "3.4.2",
+      "version": "3.4.3",
       "license": "EUPL-1.2",
       "workspaces": [
         "design-tokens"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-formulieren/sdk",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "private": true,
   "main": "dist/open-forms-sdk.js",
   "exports": {

--- a/publiccode.yaml
+++ b/publiccode.yaml
@@ -7,7 +7,7 @@ publiccodeYmlVersion: '0.2'
 name: Open Forms SDK
 url: 'http://github.com/open-formulieren/open-forms-sdk.git'
 softwareType: standalone/frontend
-softwareVersion: 3.4.2
+softwareVersion: 3.4.3
 releaseDate: 't.b.d.'
 logo: 'https://github.com/open-formulieren/open-forms/blob/master/docs/logo.svg'
 platforms:


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#6222

This should be the complete set of fixes for this patch release.