### PR TITLE
:fire: Remove explicit validate call before submitting a step

### DIFF
--- a/src/api-mocks/submissions.ts
+++ b/src/api-mocks/submissions.ts
@@ -178,36 +178,30 @@ export const mockSubmissionStepGet = (
     }
   );
 
-export const mockSubmissionStepValidatePost = (
-  errors: Record<string, string> | undefined = undefined
-) =>
-  http.post(`${BASE_URL}submissions/:uuid/steps/:stepUuid/validate`, () => {
-    if (!errors) {
-      return new HttpResponse(null, {status: 204});
-    }
-
-    const invalidParams: InvalidParam[] = Object.entries(errors).map(([name, error]) => ({
-      name: `data.${name}`,
-      code: 'invalid',
-      reason: error,
-    }));
-    const body = {
-      type: 'http://localhost:8000/fouten/ValidationError/',
-      code: 'invalid',
-      title: 'Invalid input.',
-      status: 400,
-      detail: '',
-      instance: 'urn:uuid:a3a9701b-3fa6-444b-a777-bcb43960440a',
-      invalidParams: invalidParams,
-    };
-    return HttpResponse.json(body, {status: 400});
-  });
-
 export const mockSubmissionStepPut = (
   stepDetails: SubmissionStep = SUBMISSION_STEP_DETAILS,
+  errors: Record<string, string> | undefined = undefined,
   status: 200 | 201 = 200
 ) =>
   http.put(`${BASE_URL}submissions/:uuid/steps/:stepUuid`, () => {
+    if (errors) {
+      const invalidParams: InvalidParam[] = Object.entries(errors).map(([name, error]) => ({
+        name: `data.${name}`,
+        code: 'invalid',
+        reason: error,
+      }));
+      const body = {
+        type: 'http://localhost:8000/fouten/ValidationError/',
+        code: 'invalid',
+        title: 'Invalid input.',
+        status: 400,
+        detail: '',
+        instance: 'urn:uuid:a3a9701b-3fa6-444b-a777-bcb43960440a',
+        invalidParams: invalidParams,
+      };
+      return HttpResponse.json(body, {status: 400});
+    }
+
     return HttpResponse.json(stepDetails, {status: status});
   });
 

--- a/src/components/FormStep/FormStepNewRenderer.stories.tsx
+++ b/src/components/FormStep/FormStepNewRenderer.stories.tsx
@@ -9,7 +9,6 @@ import {
   mockSubmissionGet,
   mockSubmissionStepGet,
   mockSubmissionStepPut,
-  mockSubmissionStepValidatePost,
 } from '@/api-mocks/submissions';
 import {
   mockEmailVerificationPost,
@@ -72,7 +71,7 @@ export default {
         submission: [mockSubmissionGet(DEFAULT_SUBMISSION)],
         submissionStep: [
           mockSubmissionStepGet(DEFAULT_SUBMISSION_STEP_DETAIL_BODY),
-          mockSubmissionStepPut(DEFAULT_SUBMISSION_STEP_DETAIL_BODY, 201),
+          mockSubmissionStepPut(DEFAULT_SUBMISSION_STEP_DETAIL_BODY, undefined, 201),
         ],
         logicCheck: [
           mockSubmissionCheckLogicPost(
@@ -81,8 +80,6 @@ export default {
             400
           ),
         ],
-        // no validation errors by default
-        validate: [mockSubmissionStepValidatePost(undefined)],
         emailVerification: [mockEmailVerificationPost, mockEmailVerificationVerifyCodePost],
       },
     },
@@ -163,7 +160,7 @@ export const PerformServerLogicCheck: Story = {
       handlers: {
         submissionStep: [
           mockSubmissionStepGet(LOGIC_CHECK_STEP_DETAIL_BODY),
-          mockSubmissionStepPut(LOGIC_CHECK_STEP_DETAIL_BODY, 201),
+          mockSubmissionStepPut(LOGIC_CHECK_STEP_DETAIL_BODY, undefined, 201),
         ],
         logicCheck: [
           mockSubmissionCheckLogicPost(
@@ -221,7 +218,7 @@ export const DisableStepSubmissionWithServerLogic: Story = {
       handlers: {
         submissionStep: [
           mockSubmissionStepGet(LOGIC_CHECK_STEP_DETAIL_BODY),
-          mockSubmissionStepPut(LOGIC_CHECK_STEP_DETAIL_BODY, 201),
+          mockSubmissionStepPut(LOGIC_CHECK_STEP_DETAIL_BODY, undefined, 201),
         ],
         logicCheck: [
           mockSubmissionCheckLogicPost(
@@ -297,7 +294,7 @@ export const DisableStepSubmissionWithFrontendLogic: Story = {
       handlers: {
         submissionStep: [
           mockSubmissionStepGet(FRONTEND_LOGIC_STEP_DETAIL_BODY),
-          mockSubmissionStepPut(FRONTEND_LOGIC_STEP_DETAIL_BODY, 201),
+          mockSubmissionStepPut(FRONTEND_LOGIC_STEP_DETAIL_BODY, undefined, 201),
         ],
         logicCheck: [
           // @ts-expect-error Return nonsense data on purpose, to make sure a crash will occur if
@@ -397,7 +394,7 @@ export const DisplayDataLoadedFromBackend: Story = {
       handlers: {
         submissionStep: [
           mockSubmissionStepGet(SUBMISSION_STEP_WITH_DATA_DETAIL_BODY),
-          mockSubmissionStepPut(SUBMISSION_STEP_WITH_DATA_DETAIL_BODY, 201),
+          mockSubmissionStepPut(SUBMISSION_STEP_WITH_DATA_DETAIL_BODY, undefined, 201),
         ],
         logicCheck: [
           mockSubmissionCheckLogicPost(
@@ -434,15 +431,14 @@ export const BackendValidationError: Story = {
       handlers: {
         submissionStep: [
           mockSubmissionStepGet(VALIDATION_ERRORS_STEP_DETAIL_BODY),
-          mockSubmissionStepPut(VALIDATION_ERRORS_STEP_DETAIL_BODY, 201),
+          mockSubmissionStepPut(
+            VALIDATION_ERRORS_STEP_DETAIL_BODY,
+            {text1: 'Server side validation error'},
+            201
+          ),
         ],
         logicCheck: [
           mockSubmissionCheckLogicPost(DEFAULT_SUBMISSION, VALIDATION_ERRORS_STEP_DETAIL_BODY, 200),
-        ],
-        validate: [
-          mockSubmissionStepValidatePost({
-            text1: 'Server side validation error',
-          }),
         ],
       },
     },
@@ -582,7 +578,7 @@ export const LocationDerivation: Story = {
       handlers: {
         submissionStep: [
           mockSubmissionStepGet(LOCATION_DERIVATION_SUBMISSION_STEP_DETAIL_BODY),
-          mockSubmissionStepPut(LOCATION_DERIVATION_SUBMISSION_STEP_DETAIL_BODY, 201),
+          mockSubmissionStepPut(LOCATION_DERIVATION_SUBMISSION_STEP_DETAIL_BODY, undefined, 201),
         ],
         logicCheck: [
           mockSubmissionCheckLogicPost(
@@ -618,7 +614,7 @@ export const LocationDerivationDoesNotOverwriteValues: Story = {
       handlers: {
         submissionStep: [
           mockSubmissionStepGet(LOCATION_DERIVATION_SUBMISSION_STEP_DETAIL_BODY),
-          mockSubmissionStepPut(LOCATION_DERIVATION_SUBMISSION_STEP_DETAIL_BODY, 201),
+          mockSubmissionStepPut(LOCATION_DERIVATION_SUBMISSION_STEP_DETAIL_BODY, undefined, 201),
         ],
         logicCheck: [
           mockSubmissionCheckLogicPost(
@@ -665,7 +661,7 @@ export const LocationDerivationInRepeatingGroup: Story = {
       handlers: {
         submissionStep: [
           mockSubmissionStepGet(LOCATION_DERIVATION_SUBMISSION_STEP_DETAIL_BODY),
-          mockSubmissionStepPut(LOCATION_DERIVATION_SUBMISSION_STEP_DETAIL_BODY, 201),
+          mockSubmissionStepPut(LOCATION_DERIVATION_SUBMISSION_STEP_DETAIL_BODY, undefined, 201),
         ],
         logicCheck: [
           mockSubmissionCheckLogicPost(

--- a/src/components/FormStep/FormStepNewRenderer.tsx
+++ b/src/components/FormStep/FormStepNewRenderer.tsx
@@ -193,9 +193,7 @@ const FormStepNewRenderer: React.FC = () => {
             }}
             onSubmit={async values => {
               try {
-                // XXX: do we still need the validate endpoint? Perhaps this could use
-                // a header for the PUT endpoint instead?
-                await saveStepData(sparseStep.url, values, {skipValidation: false});
+                await saveStepData(sparseStep.url, values);
               } catch (error: unknown) {
                 // rethrow what we can't handle
                 if (!(error instanceof ValidationError)) {
@@ -247,7 +245,7 @@ const FormStepNewRenderer: React.FC = () => {
           const values = valuesRef.current;
           if (values === null) throw new Error('Cannot save non-existent values');
           // XXX: check what happens if invalidly shaped data is submitted during save!
-          await saveStepData(sparseStep.url, values, {skipValidation: true});
+          await saveStepData(sparseStep.url, values);
         }}
         onSessionDestroyed={onDestroySession}
         suspendFormUrl={`${submission.url}/_suspend`}

--- a/src/components/FormStep/SingleFormStepNewRenderer.stories.tsx
+++ b/src/components/FormStep/SingleFormStepNewRenderer.stories.tsx
@@ -14,7 +14,6 @@ import {
   mockSubmissionProcessingStatusGet,
   mockSubmissionStepGet,
   mockSubmissionStepPut,
-  mockSubmissionStepValidatePost,
 } from '@/api-mocks/submissions';
 import routes, {FUTURE_FLAGS} from '@/routes';
 import {withForm, withNuqs} from '@/sb-decorators';
@@ -57,9 +56,8 @@ export default {
         ],
         submissionStep: [
           mockSubmissionStepGet(SINGLE_STEP_SUBMISSION_STEP_DETAILS),
-          mockSubmissionStepPut(SINGLE_STEP_SUBMISSION_STEP_DETAILS, 201),
+          mockSubmissionStepPut(SINGLE_STEP_SUBMISSION_STEP_DETAILS, undefined, 201),
         ],
-        validate: [mockSubmissionStepValidatePost(undefined)],
         formStep: [mockFormStepGet()],
       },
     },

--- a/src/components/FormStep/SingleFormStepNewRenderer.tsx
+++ b/src/components/FormStep/SingleFormStepNewRenderer.tsx
@@ -119,7 +119,7 @@ const SingleFormStepNewRenderer: React.FC = () => {
     // the submission exists, move to the next steps
     // create the submission step
     try {
-      await saveStepData(currentSubmission.steps[0].url, values, {skipValidation: true});
+      await saveStepData(currentSubmission.steps[0].url, values);
     } catch (error: unknown) {
       // rethrow what we can't handle
       if (!(error instanceof ValidationError)) {

--- a/src/components/FormStep/tests.spec.tsx
+++ b/src/components/FormStep/tests.spec.tsx
@@ -70,7 +70,7 @@ test('Single step form happy flow', async () => {
     mockAnalyticsToolConfigGet(),
     mockFormStepGet(),
     mockSubmissionPost(buildSubmission(SINGLE_STEP_SUBMISSION_DETAILS)),
-    mockSubmissionStepPut(SINGLE_STEP_SUBMISSION_STEP_DETAILS, 201),
+    mockSubmissionStepPut(SINGLE_STEP_SUBMISSION_STEP_DETAILS, undefined, 201),
     mockSubmissionCompletePost(SINGLE_STEP_SUBMISSION_DETAILS.id),
     mockSubmissionProcessingStatusGet
   );

--- a/src/data/submission-steps.ts
+++ b/src/data/submission-steps.ts
@@ -98,18 +98,6 @@ export const checkStepLogic = async (
 
 type SubmissionStepCreateOrUpdateBody = Pick<SubmissionStep, 'data'>;
 
-interface SaveStepDataOptions {
-  /**
-   * Optionally skip calling the validate endpoint.
-   *
-   * In certain situations, the (potentially) invalid data can be submitted to continue
-   * at a later time. This does not affect the validation of the submission at the end
-   * of the process. If not skipped, the step validate endpoint will be called and any
-   * validation errors will be thrown in a `ValidationError` instance.
-   */
-  skipValidation?: boolean;
-}
-
 export const saveStepData = async (
   /**
    * API endpoint pointing to the step within its submission.
@@ -122,32 +110,28 @@ export const saveStepData = async (
    * Nesting can occur here, if a key like `foo.bar` is set, it creates a parent object
    * for the key `foo` with a child property `bar`.
    */
-  data: SubmissionStep['data'],
-  options?: SaveStepDataOptions
+  data: SubmissionStep['data']
 ): Promise<void> => {
-  if (!options?.skipValidation) {
-    // if data is not valid, this throws a `ValidationError` with the `asFormikProps`
-    // method, which contains the errors in the suitable format for the formio-renderer.
-    try {
-      await post<null, SubmissionStepCreateOrUpdateBody>(`${resourceUrl}/validate`, {data});
-    } catch (error: unknown) {
-      // strip out the `data` prefix, the API details are encapsulated from the caller
-      if (error instanceof ValidationError) {
-        const processedInvalidParams: InvalidParam[] = [];
-        error.invalidParams.forEach(param => {
-          if (!param.name.startsWith('data.')) return;
-          processedInvalidParams.push({
-            ...param,
-            name: param.name.replace('data.', ''),
-          } satisfies InvalidParam);
-        });
-        error.invalidParams = processedInvalidParams;
-        throw error;
-      } else {
-        // otherwise simply rethrow
-        throw error;
-      }
+  // if data is not valid, this throws a `ValidationError` with the `asFormikProps`
+  // method, which contains the errors in the suitable format for the formio-renderer.
+  try {
+    await put<SubmissionStep, SubmissionStepCreateOrUpdateBody>(resourceUrl, {data});
+  } catch (error: unknown) {
+    // strip out the `data` prefix, the API details are encapsulated from the caller
+    if (error instanceof ValidationError) {
+      const processedInvalidParams: InvalidParam[] = [];
+      error.invalidParams.forEach(param => {
+        if (!param.name.startsWith('data.')) return;
+        processedInvalidParams.push({
+          ...param,
+          name: param.name.replace('data.', ''),
+        } satisfies InvalidParam);
+      });
+      error.invalidParams = processedInvalidParams;
+      throw error;
+    } else {
+      // otherwise simply rethrow
+      throw error;
     }
   }
-  await put<SubmissionStep, SubmissionStepCreateOrUpdateBody>(resourceUrl, {data});
 };


### PR DESCRIPTION
This is no longer necessary - the main API endpoint returns the same validation errors as the explicit validate endpoint. This code was a workaround to be able to run server side validation with formio.js *and* being able to process the validation errors + set them on the client. Because our own renderer is async-first, this is possible out of the box and the workaround is no longer necessary.