### PR TITLE
Fix excessive address-autocomplete/latlng-search calls

### DIFF
--- a/src/components/FormStep/AddressAutoFillObservers.tsx
+++ b/src/components/FormStep/AddressAutoFillObservers.tsx
@@ -1,7 +1,7 @@
 import {getComponentsMap} from '@open-formulieren/formio-renderer/formio.js';
 import {useFormSettings} from '@open-formulieren/formio-renderer/hooks.js';
 import type {AnyComponentSchema} from '@open-formulieren/types';
-import {useFormikContext} from 'formik';
+import {getIn, useFormikContext} from 'formik';
 import {useEffect, useMemo, useRef} from 'react';
 
 import type {AutoCompleteResult} from '@/data/geo';
@@ -9,7 +9,7 @@ import type {AutoCompleteResult} from '@/data/geo';
 const POSTCODE_REGEX = /^[0-9]{4}\s?[a-zA-Z]{2}$/;
 const HOUSE_NUMBER_REGEX = /^\d+$/;
 
-export const LOCATION_AUTOCOMPLETE_DEBOUNCE = 200;
+export const LOCATION_AUTOCOMPLETE_DEBOUNCE = 300;
 
 interface AddressAutoCompleteGroup {
   postcodeKey: string;
@@ -123,18 +123,36 @@ const AddressAutoFillObserver: React.FC<AddressAutoFillObserverProps> = ({
   group,
   getAddressAutoComplete,
 }) => {
-  const timerRef = useRef<number | null>(null);
+  const {setFieldValue, values} = useFormikContext();
 
-  const {setFieldValue, getFieldMeta} = useFormikContext();
-  const postcode = getFieldMeta<string>(group.postcodeKey).value;
-  const houseNumber = String(getFieldMeta<number | string>(group.houseNumberKey).value);
+  const timerRef = useRef<number | null>(null);
+  const updateableTargetsRef = useRef<typeof group.targets>(group.targets);
+
+  const postcode: string = getIn(values, group.postcodeKey);
+  const houseNumber = String(getIn(values, group.houseNumberKey));
+
+  // derive the subset of targets that can be updated in a useEffect hook - this
+  // collection changes based on the form values (a value has been set) or the readOnly
+  // state, so it depends on the group & formik values.
+  // Uses a mutable ref that doesn't trigger re-renders when it changes, otherwise we
+  // end up in infinite loops because the autocomplete updates the formik values and
+  // changes this collection by definition :)
+  useEffect(() => {
+    updateableTargetsRef.current = group.targets.filter(({key, isReadOnly}) => {
+      const currentValue: string = getIn(values, key);
+      const canAssignValue = isReadOnly || !currentValue;
+      return canAssignValue;
+    });
+  }, [group, values]);
 
   useEffect(() => {
     let isMounted = true;
+    const updateableTargets = updateableTargetsRef.current;
 
     const isValidPostcode = POSTCODE_REGEX.test(postcode);
     const isValidHouseNumber = HOUSE_NUMBER_REGEX.test(houseNumber);
-    if (isValidHouseNumber && isValidPostcode) {
+
+    if (isValidHouseNumber && isValidPostcode && updateableTargets.length) {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
         timerRef.current = null;
@@ -152,10 +170,7 @@ const AddressAutoFillObserver: React.FC<AddressAutoFillObserverProps> = ({
         };
         const {streetName, city} = result;
         if (!isMounted) return;
-        for (const {key, type, isReadOnly} of group.targets) {
-          const currentValue = getFieldMeta<string>(key).value;
-          const canAssignValue = isReadOnly || !currentValue;
-          if (!canAssignValue) continue;
+        for (const {key, type} of updateableTargets) {
           const newValue = type === 'streetName' ? streetName : city;
           setFieldValue(key, newValue);
         }
@@ -170,7 +185,7 @@ const AddressAutoFillObserver: React.FC<AddressAutoFillObserverProps> = ({
       }
       isMounted = false;
     };
-  }, [getFieldMeta, setFieldValue, group.targets, getAddressAutoComplete, postcode, houseNumber]);
+  }, [setFieldValue, getAddressAutoComplete, postcode, houseNumber]);
 
   return null;
 };

--- a/src/data/geo.ts
+++ b/src/data/geo.ts
@@ -7,6 +7,7 @@ import type {
 import AbstractProvider from 'leaflet-geosearch/src/providers/provider.js';
 
 import {get} from '@/api';
+import {getCached, setCached} from '@/cache';
 import {logError} from '@/components/Errors';
 
 /**
@@ -18,18 +19,25 @@ export interface AutoCompleteResult {
   secretStreetCity: string;
 }
 
+const AUTOCOMPLETE_CACHE_TTL = 15 * 60 * 1000; // 15 minutes
+
 export const autoCompleteAddress = async (
   baseUrl: string,
   postcode: string,
   houseNumber: string
 ): Promise<AutoCompleteResult | null> => {
+  const cacheKey = `${postcode.replace(' ', '')}|${houseNumber}`;
+  const cacheResult = getCached<AutoCompleteResult>(cacheKey, AUTOCOMPLETE_CACHE_TTL);
+  if (cacheResult !== null) return cacheResult;
+
   const params: Record<string, string> = {
     postcode: postcode,
     house_number: houseNumber,
   };
   try {
-    const result = await get<AutoCompleteResult>(`${baseUrl}geo/address-autocomplete`, params);
-    return result!;
+    const result = (await get<AutoCompleteResult>(`${baseUrl}geo/address-autocomplete`, params))!;
+    setCached(cacheKey, result);
+    return result;
   } catch (error) {
     logError(error);
     return null;

--- a/src/data/geo.ts
+++ b/src/data/geo.ts
@@ -19,7 +19,7 @@ export interface AutoCompleteResult {
   secretStreetCity: string;
 }
 
-const AUTOCOMPLETE_CACHE_TTL = 15 * 60 * 1000; // 15 minutes
+const GEO_CACHE_TTL = 15 * 60 * 1000; // 15 minutes
 
 export const autoCompleteAddress = async (
   baseUrl: string,
@@ -27,7 +27,7 @@ export const autoCompleteAddress = async (
   houseNumber: string
 ): Promise<AutoCompleteResult | null> => {
   const cacheKey = `${postcode.replace(' ', '')}|${houseNumber}`;
-  const cacheResult = getCached<AutoCompleteResult>(cacheKey, AUTOCOMPLETE_CACHE_TTL);
+  const cacheResult = getCached<AutoCompleteResult>(cacheKey, GEO_CACHE_TTL);
   if (cacheResult !== null) return cacheResult;
 
   const params: Record<string, string> = {
@@ -50,6 +50,9 @@ export const getAddressLabel = async (
   lng: number
 ): Promise<NearestLookupBody | null> => {
   let data: NearestLookupBody | null = null;
+  const cacheKey = `${lat}|${lng}`;
+  const cacheResult = getCached<NearestLookupBody>(cacheKey, GEO_CACHE_TTL);
+  if (cacheResult !== null) return cacheResult;
 
   try {
     const result = await get<{label: string}>(`${baseUrl}geo/latlng-search`, {
@@ -58,6 +61,7 @@ export const getAddressLabel = async (
     });
 
     data = result ? {label: result.label} : null;
+    if (data) setCached(cacheKey, data);
   } catch (error) {
     logError(error);
   }


### PR DESCRIPTION
(Partly) closes open-formulieren/open-forms#6354 

---

~~Ideally this PR also includes https://github.com/open-formulieren/formio-renderer/pull/341~~ Included with the new renderer patch release via #989

---

The original implementation used getFieldMeta with the assumption that the identity was stable and would prevent unnecessary useEffect calls when the postcode/house number values don't change, however that's not the case. It depends on formik.values, formik.touched and formik.errors which change constantly when filling out the rest of the form.

The reworked implementation avoids this by using Formik's getIn directly on the values that we care about, and avoids using values (or other meta) in the useEffect dependency array. Additionally, we now bail early if there are no updates to be done at all because there are no candidates to be updated, avoiding some more network IO.

Finally, the debounce of 200ms was quite short and has been upped to 300ms, which should hopefully strike a better balance between snappy UI and giving users enough time to type their house number.