### PR TITLE
Fix default styling `ul` bullets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "@utrecht/heading-1-css": "^2.0.2",
         "@utrecht/heading-3-css": "^2.0.2",
         "@utrecht/img-css": "^2.0.1",
-        "@utrecht/link-button-css": "^2.0.1",
+        "@utrecht/link-button-css": "^3.0.1",
         "@utrecht/link-css": "^2.0.1",
         "@vitejs/plugin-react": "^5.1.0",
         "@vitest/browser-playwright": "^4.1.8",
@@ -6816,12 +6816,6 @@
       "integrity": "sha512-8RBjO+fHCoeugzFHubx4Az79fHX0FNhsXjIBJ3TzA3hnmZwk4VSPUfCFL/3v1b9q6OlbhEBCwM9KoiNYN6KLng==",
       "license": "EUPL-1.2"
     },
-    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/link-button-css": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/link-button-css/-/link-button-css-3.0.1.tgz",
-      "integrity": "sha512-nwTadzdHiI7O6ca653afWlZXqKQOdR2nk96UnhMi2GWHd6W8x5aw+ORdX+INe8M56WHI3iO7jHAYyxsCMe1RpQ==",
-      "license": "EUPL-1.2"
-    },
     "node_modules/@utrecht/currency-data-css": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/currency-data-css/-/currency-data-css-3.0.1.tgz",
@@ -7131,10 +7125,9 @@
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/link-button-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/link-button-css/-/link-button-css-2.0.1.tgz",
-      "integrity": "sha512-7HxgKyp7IkV0PAZb90ASvr9Iz+BPMw4yqpiN3IiD5HdPzTwQY8CjW7k4/hFZXrh/MMwnRUwcrDLJsbCLSfyKrw==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@utrecht/link-button-css/-/link-button-css-3.0.1.tgz",
+      "integrity": "sha512-nwTadzdHiI7O6ca653afWlZXqKQOdR2nk96UnhMi2GWHd6W8x5aw+ORdX+INe8M56WHI3iO7jHAYyxsCMe1RpQ==",
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/link-css": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@date-fns/tz": "^1.4.1",
         "@floating-ui/react": "^0.27.5",
         "@fortawesome/fontawesome-free": "^6.4.0",
-        "@open-formulieren/design-tokens": "^0.66.0",
+        "@open-formulieren/design-tokens": "^0.67.0",
         "@open-formulieren/formio-renderer": "^1.7.0",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@sentry/react": "^8.50.0",
@@ -137,7 +137,7 @@
     },
     "design-tokens": {
       "name": "@open-formulieren/design-tokens",
-      "version": "0.66.0",
+      "version": "0.67.0",
       "license": "EUPL-1.2",
       "devDependencies": {
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@date-fns/tz": "^1.4.1",
     "@floating-ui/react": "^0.27.5",
     "@fortawesome/fontawesome-free": "^6.4.0",
-    "@open-formulieren/design-tokens": "^0.66.0",
+    "@open-formulieren/design-tokens": "^0.67.0",
     "@open-formulieren/formio-renderer": "^1.7.0",
     "@open-formulieren/leaflet-tools": "^1.0.0",
     "@sentry/react": "^8.50.0",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@utrecht/heading-1-css": "^2.0.2",
     "@utrecht/heading-3-css": "^2.0.2",
     "@utrecht/img-css": "^2.0.1",
-    "@utrecht/link-button-css": "^2.0.1",
+    "@utrecht/link-button-css": "^3.0.1",
     "@utrecht/link-css": "^2.0.1",
     "@vitejs/plugin-react": "^5.1.0",
     "@vitest/browser-playwright": "^4.1.8",

--- a/src/components/ComponentValueDisplay.tsx
+++ b/src/components/ComponentValueDisplay.tsx
@@ -226,7 +226,7 @@ const CustomerProfileDisplay: React.FC<
       className="utrecht-unordered-list--level-1"
       style={{
         // backportable fix without needing to upgrade our design tokens now
-        '--utrecht-unordered-list-level-1-list-style-type': '"-"',
+        '--utrecht-unordered-list-level-1-list-style-type': '"-  "',
       }}
     >
       {addresses.map(address => (

--- a/src/components/FormStart/FormStart.stories.ts
+++ b/src/components/FormStart/FormStart.stories.ts
@@ -29,6 +29,9 @@ export const ExplanationTemplate: Story = {
         explanationTemplate: `
           <h2>Important!</h2>
           <p>A WYSIWYG explanation text set by form builders</p>
+          <ul>
+            <li>It can have unordered lists too</li>
+          </ul>
         `,
       }),
     },

--- a/src/scss/_fixes.scss
+++ b/src/scss/_fixes.scss
@@ -1,0 +1,9 @@
+// Patches for upstream bugs
+
+// utrecht-link-button uses the wrong design token compared to the button component:
+// https://github.com/nl-design-system/utrecht/issues/3188
+.utrecht-link-button {
+  // use the *wrong* token first, in case this is defined in a custom theme so that we
+  // don't break other content on the same page when the SDK is embedded
+  gap: var(--utrecht-button-icon-gap, var(--utrecht-button-column-gap));
+}

--- a/src/scss/components/_anchor.scss
+++ b/src/scss/components/_anchor.scss
@@ -8,7 +8,6 @@
  * :active states for some variants.
  */
 @use 'microscope-sass/lib/bem';
-@use '@utrecht/link-button-css';
 // FIXME: this should be removable, but the styles are distributed via the formio-render
 // and removing this line breaks the @extend below.
 @use '@utrecht/link-css'; // emits the .utrecht-link {...} styles

--- a/src/scss/nl-design-system-community.scss
+++ b/src/scss/nl-design-system-community.scss
@@ -2,3 +2,4 @@
 @use '@utrecht/img-css';
 @use '@utrecht/heading-1-css';
 @use '@utrecht/heading-3-css';
+@use '@utrecht/link-button-css';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -20,6 +20,7 @@ $fa-font-path: '../webfonts/' !default; // vite.config.mts overrides this
 
 @use './scss/nl-design-system-community.scss';
 
+@import './scss/fixes';
 @import './scss/settings';
 @import './scss/responsive';
 


### PR DESCRIPTION
Closes open-formulieren/open-forms#6410

- [x] Upgrade to the renderer bugfix
- [x] Upgrade to the latest design tokens (no backport needed for this)
- [x] Fix the level-1 styling for the customer profile summary that uses dashes