### PR TITLE
Add form step help dialog + trigger button

### DIFF
--- a/src/components/FormStep/FormStepHelpDialog.mdx
+++ b/src/components/FormStep/FormStepHelpDialog.mdx
@@ -1,0 +1,57 @@
+import {Meta} from '@storybook/addon-docs/blocks';
+
+import * as FormStepHelpDialog from './FormStepHelpDialog.stories';
+
+<Meta of={FormStepHelpDialog} name="Docs & Design tokens" />
+
+# Form step help dialog
+
+The form step help dialog is an interactive help function for the end-user when they get stuck
+filling out a form. It is available on form steps that require form fields to be filled out (so not
+on the start page, overview/summary...).
+
+The content is configured on an individual form basis. When the (rich text) content is set up, a
+button will be displayed in the top right. Clicking this button will open the bottom sheet / dialog
+to display the content.
+
+## Available design tokens
+
+There are a number of design tokens available to customize the appearance of the bottom sheet /
+dialog. You may also be interested in the `FormHelpButton` component design tokens.
+
+```json
+{
+  "of": {
+    // the (content) of the dialog/bottom sheet itself
+    "step-help-dialog": {
+      "row-gap": {"value": "20px"}, // spacing between content and image
+      "image": {
+        "align-self": {"value": "start"},
+        // for images wider than the viewport, you want to limit this to prevent
+        // scrollbars
+        "max-inline-size": {"value": "100%"}
+      }
+    }
+  }
+}
+```
+
+## Suggested CSS overrides
+
+Not everything can be done in design tokens, most notably responsive overrides typically require
+some additional CSS to be added to your theme. For example:
+
+```css
+@media (max-width: 767px) {
+  .my-theme {
+    --of-modal-sheet-inline-size: 100dvw;
+    --of-step-help-dialog-image-align-self: center;
+  }
+}
+
+@media (min-width: 768px) {
+  .my-theme {
+    --of-modal-sheet-inline-size: 50dvw;
+  }
+}
+```

--- a/src/components/FormStep/FormStepHelpDialog.stories.ts
+++ b/src/components/FormStep/FormStepHelpDialog.stories.ts
@@ -1,0 +1,33 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {expect, userEvent, within} from 'storybook/test';
+
+import FormStepHelpDialog from './FormStepHelpDialog';
+
+export default {
+  title: 'Private API / FormStep / FormStepHelpDialog',
+  component: FormStepHelpDialog,
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const helpButton = canvas.getByRole('button', {name: 'Hulp'});
+    expect(helpButton).toBeVisible();
+
+    await userEvent.click(helpButton);
+  },
+} satisfies Meta<typeof FormStepHelpDialog>;
+
+type Story = StoryObj<typeof FormStepHelpDialog>;
+
+export const ContentOnly: Story = {
+  args: {
+    content: `<p>Rich <b>text</b> <em>content</em></p>`,
+    image: '',
+  },
+};
+
+export const ContentAndImage: Story = {
+  args: {
+    content: `<p>Rich <b>text</b> <em>content</em></p>`,
+    image: './eidas.png',
+  },
+};

--- a/src/components/FormStep/FormStepHelpDialog.tsx
+++ b/src/components/FormStep/FormStepHelpDialog.tsx
@@ -1,0 +1,47 @@
+import {Modal} from '@open-formulieren/formio-renderer';
+import {useState} from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import {FormHelpButton} from '@/components/FormHelpButton';
+import {FormHelpContent} from '@/components/FormHelpContent';
+import Image from '@/components/Image';
+
+export interface FormStepHelpDialogProps {
+  content: string;
+  image: string;
+}
+
+/**
+ * Button and dialog/model for the form step help function.
+ */
+const FormStepHelpDialog: React.FC<FormStepHelpDialogProps> = ({content, image}) => {
+  const [helpDialogOpen, setHelpDialogOpen] = useState(false);
+
+  if (!content) throw new Error('You must pass non-empty content when rendering this component');
+
+  return (
+    <>
+      <FormHelpButton onClick={() => setHelpDialogOpen(true)} />
+      <Modal
+        variant="sheet"
+        title={
+          <FormattedMessage
+            description="Help dialog title text"
+            defaultMessage="Do you need help?"
+          />
+        }
+        isOpen={helpDialogOpen}
+        closeModal={() => setHelpDialogOpen(false)}
+      >
+        <div className="openforms-step-help-dialog">
+          <FormHelpContent content={content} />
+          {image && (
+            <Image src={image} className="openforms-step-help-dialog__image" aria-hidden="true" />
+          )}
+        </div>
+      </Modal>
+    </>
+  );
+};
+
+export default FormStepHelpDialog;

--- a/src/components/FormStep/FormStepNewRenderer.stories.tsx
+++ b/src/components/FormStep/FormStepNewRenderer.stories.tsx
@@ -111,6 +111,10 @@ export default {
             url: `${BASE_URL}forms/mock/steps/98980oi8-e5a4-4abf-b64a-76j3j3ki897`,
           },
         ],
+        helpDialog: {
+          content: '',
+          image: 'https://example.com/ignore-me.png',
+        },
       }),
     },
     submissionContext: {
@@ -688,5 +692,72 @@ export const LocationDerivationInRepeatingGroup: Story = {
     await userEvent.tab();
 
     await userEvent.click(await canvas.findByRole('button', {name: 'Opslaan'}));
+  },
+};
+
+export const HelpDialogEnabled: Story = {
+  parameters: {
+    formContext: {
+      form: buildForm({
+        helpDialog: {
+          content: `
+            <p>
+              A paragraph, content will already be escaped (like &gt;).
+              It can contain <a href="#" target="_blank">links</a>.
+            </p>
+            <p>
+              It <strong>supports</strong> some <b>markup</b>, <em>like</em>
+              text that's <i>italic</i>.
+            </p>
+            <ul>
+              <li>And bullets</li>
+            </ul>
+            <ol>
+              <li>but also</li>
+              <li>ordered lists</li>
+            </ol>
+          `,
+          image: '',
+        },
+      }),
+    },
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const helpButton = canvas.getByRole('button', {name: 'Hulp'});
+    expect(helpButton).toBeVisible();
+
+    await userEvent.click(helpButton);
+
+    expect(await canvas.findByText(/A paragraph, content will already be escaped/)).toBeVisible();
+  },
+};
+
+export const HelpDialogEnabledWithImage: Story = {
+  parameters: {
+    formContext: {
+      form: buildForm({
+        helpDialog: {
+          content: `
+            <p>
+              A paragraph, content will already be escaped (like &gt;).
+              It can contain <a href="#" target="_blank">links</a>.
+            </p>
+          `,
+          image: './eidas.png',
+        },
+      }),
+    },
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const helpButton = canvas.getByRole('button', {name: 'Hulp'});
+    expect(helpButton).toBeVisible();
+
+    await userEvent.click(helpButton);
   },
 };

--- a/src/components/FormStep/FormStepNewRenderer.tsx
+++ b/src/components/FormStep/FormStepNewRenderer.tsx
@@ -20,6 +20,7 @@ import useFormContext from '@/hooks/useFormContext';
 import useTitle from '@/hooks/useTitle';
 
 import AddressAutoFillObservers from './AddressAutoFillObservers';
+import FormStepHelpDialog from './FormStepHelpDialog';
 import FormStepNavigation from './FormStepNavigation';
 import FormStepTopNav from './FormStepTopNav';
 import Progress from './Progress';
@@ -169,6 +170,12 @@ const FormStepNewRenderer: React.FC = () => {
       <FormContainer mobileHeaderHidden>
         <FormStepTopNav>
           <PreviousLink to={previousTo} position="start" />
+          {form.helpDialog?.content && (
+            <FormStepHelpDialog
+              content={form.helpDialog.content}
+              image={form.helpDialog.image ?? ''}
+            />
+          )}
         </FormStepTopNav>
 
         <Progress form={form} submission={submission} currentStep={sparseStep} />

--- a/src/data/forms.ts
+++ b/src/data/forms.ts
@@ -117,7 +117,30 @@ export interface Form {
   communicationPreferencesPortalUrl: string;
   helpCalloutPage: {
     display: 'before_start_page' | 'after_start_page' | 'never';
+    /**
+     * Rich text describing where to find help instructions.
+     *
+     * @note Only paragraphs, anchors, lists, bold and italic formatting are allowed.
+     */
     content: string;
     image: string | null;
+  };
+  /**
+   * Help dialog configuration.
+   *
+   * When the nested content field is not empty, the SDK should render help controls to
+   * assist the user filling out the form.
+   */
+  helpDialog?: {
+    /**
+     * Rich text describing help instructions for the end-user.
+     *
+     * @note Only paragraphs, anchors, lists, bold and italic formatting are allowed.
+     */
+    content: string;
+    /**
+     * Image URL to display below the content.
+     */
+    image?: string | null;
   };
 }

--- a/src/i18n/compiled/en.json
+++ b/src/i18n/compiled/en.json
@@ -1549,6 +1549,12 @@
       "value": "The payment has failed. If you aborted the payment, please complete payment from the confirmation email."
     }
   ],
+  "JCDVcG": [
+    {
+      "type": 0,
+      "value": "Do you need help?"
+    }
+  ],
   "Jrb2Iv": [
     {
       "type": 0,

--- a/src/i18n/compiled/nl.json
+++ b/src/i18n/compiled/nl.json
@@ -1543,6 +1543,12 @@
       "value": "De betaling is mislukt. Indien je de betaling afgebroken hebt, gebruik dan de betaallink in de bevestigingsmail om deze alsnog te voltooien."
     }
   ],
+  "JCDVcG": [
+    {
+      "type": 0,
+      "value": "Heb je hulp nodig?"
+    }
+  ],
   "Jrb2Iv": [
     {
       "type": 0,

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -359,6 +359,11 @@
     "description": "payment failed status",
     "originalDefault": "The payment has failed. If you aborted the payment, please complete payment from the confirmation email."
   },
+  "JCDVcG": {
+    "defaultMessage": "Do you need help?",
+    "description": "Help dialog title text",
+    "originalDefault": "Do you need help?"
+  },
   "Jrb2Iv": {
     "defaultMessage": "Your email address",
     "description": "Form save modal email field label",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -363,6 +363,11 @@
     "description": "payment failed status",
     "originalDefault": "The payment has failed. If you aborted the payment, please complete payment from the confirmation email."
   },
+  "JCDVcG": {
+    "defaultMessage": "Heb je hulp nodig?",
+    "description": "Help dialog title text",
+    "originalDefault": "Do you need help?"
+  },
   "Jrb2Iv": {
     "defaultMessage": "Je e-mailadres",
     "description": "Form save modal email field label",

--- a/src/scss/_responsive.scss
+++ b/src/scss/_responsive.scss
@@ -8,11 +8,28 @@
     --of-modal-padding-inline-start: 12px;
     --of-modal-padding-inline-end: 12px;
     --of-modal-header-margin-inline-end: 36px;
+    --of-modal-sheet-inline-size: 100dvw;
 
     --of-help-callout-page-dialog-flex-direction: column;
     --of-help-callout-page-dialog-padding-block-end: 2em;
     --of-help-callout-page-dialog-padding-block-start: 2em;
     --of-help-callout-page-dialog-padding-inline-end: 2em;
     --of-help-callout-page-dialog-padding-inline-start: 2em;
+
+    --of-step-help-dialog-image-align-self: center;
+
+    // don't full-width the help button on mobile (styles defined in renderer)
+    .openforms-step-topnav .utrecht-button.openforms-form-help-button {
+      display: inline-flex;
+      inline-size: var(--utrecht-button-inline-size, auto);
+      justify-content: var(--utrecht-button-justify-content, center);
+      text-align: unset;
+    }
+  }
+}
+
+@include tablet {
+  .openforms-theme {
+    --of-modal-sheet-inline-size: 50dvw;
   }
 }

--- a/src/scss/components/_form-help-button.scss
+++ b/src/scss/components/_form-help-button.scss
@@ -1,4 +1,4 @@
-@use 'microscope-sass/lib/bem';
+@use '@bbt/bem';
 
 // @import instead of @use because breakpoints are defined globally
 @import 'microscope-sass/lib/responsive';

--- a/src/scss/components/_step-help-dialog.scss
+++ b/src/scss/components/_step-help-dialog.scss
@@ -1,0 +1,15 @@
+@use '@bbt/bem';
+
+// @import instead of @use because breakpoints are defined globally
+@import 'microscope-sass/lib/responsive';
+
+.openforms-step-help-dialog {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--of-step-help-dialog-row-gap, 20px);
+
+  @include bem.element('image') {
+    --of-image-max-inline-size: var(--of-step-help-dialog-image-max-inline-size, 100%);
+    align-self: var(--of-step-help-dialog-image-align-self, start);
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -47,6 +47,7 @@ $fa-font-path: '../webfonts/' !default; // vite.config.mts overrides this
 @import './scss/components/progress-indicator';
 @import './scss/components/previous-link';
 @import './scss/components/form-help-button';
+@import './scss/components/step-help-dialog';
 @import './scss/components/step-topnav';
 @import './scss/components/summary-progress';
 @import './scss/components/columns';


### PR DESCRIPTION
Closes open-formulieren/open-forms#6318

**TODO**

- [x] Define our own design token values & set neutral defaults
- [x] Document available design tokens

## Screenshots

<img width="433" height="938" alt="image" src="https://github.com/user-attachments/assets/95e70a6b-6cd6-4da9-abd4-8bcc976db6f8" />

<img width="448" height="953" alt="image" src="https://github.com/user-attachments/assets/37c0501c-2a47-4db0-94c7-d61122afdf17" />

